### PR TITLE
Windows: Use CRLF instead of LF when writing files out.

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -20,8 +20,16 @@ package build
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"strings"
 )
+
+var breakLine = func() string {
+	if runtime.GOOS == "windows" {
+		return "\r\n"
+	}
+	return "\n"
+}()
 
 // Format returns the formatted form of the given BUILD file.
 func Format(f *File) []byte {
@@ -76,7 +84,7 @@ func (p *printer) newline() {
 		for i, com := range p.comment {
 			if i > 0 {
 				p.trim()
-				p.printf("\n%*s", p.margin, "")
+				p.printf("%s%*s", breakLine, p.margin, "")
 			}
 			p.printf("%s", strings.TrimSpace(com.Token))
 		}
@@ -84,7 +92,7 @@ func (p *printer) newline() {
 	}
 
 	p.trim()
-	p.printf("\n%*s", p.margin, "")
+	p.printf("%s%*s", breakLine, p.margin, "")
 }
 
 // breakline breaks the current line, inserting a continuation \ if needed.


### PR DESCRIPTION
Honestly, I'm not sure if this is the right thing but just for background:

- Git installations on Windows are typically configured to replace LF with CRLF (See [`core.autocrlf`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration))
- Thus runs of `buildifier` on Windows without this change produce spurious differences

I suspect using `bazel`/`buildifier` on Windows is typically done in git repositories, but that may not be always true and it is still possible to configure `git` differently. Hence I'm a bit unsure of this myself.

An alternative would be to introduce a flag to switch between LF and CRLF.