### PR TITLE
Fixed bug where buildifier swallowed up some comments.

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -725,9 +725,10 @@ func (in *input) assignComments() {
 		// Do not assign suffix comments to call, list, end-of-list,
 		// whole file, or conditional expression.
 		// Instead assign them to the last argument, element, or rule.
+		// IfClause and ForClause because in single line mode, [a for b in c]
+		// the suffix comments assigned to these are swallowed up.
 		switch x.(type) {
-		case *CallExpr, *ListExpr, *End, *File, 
-			*ConditionalExpr, *IfClause, *ForClause:
+		case *CallExpr, *ListExpr, *End, *File, *ConditionalExpr, *IfClause, *ForClause:
 			continue
 		}
 

--- a/build/lex.go
+++ b/build/lex.go
@@ -726,7 +726,8 @@ func (in *input) assignComments() {
 		// whole file, or conditional expression.
 		// Instead assign them to the last argument, element, or rule.
 		switch x.(type) {
-		case *CallExpr, *ListExpr, *End, *File, *ConditionalExpr:
+		case *CallExpr, *ListExpr, *End, *File, 
+			*ConditionalExpr, *IfClause, *ForClause:
 			continue
 		}
 

--- a/build/print.go
+++ b/build/print.go
@@ -121,7 +121,16 @@ func (p *printer) file(f *File) {
 	for i, stmt := range f.Stmt {
 		switch stmt := stmt.(type) {
 		case *CommentBlock:
-			// comments already handled
+			// This is necessary so that CommentBlock
+			// doesn't swallow up suffix comments of
+			// the expression after it.
+			for _, scom := range stmt.Suffix {
+				scom.Suffix = false
+				stmt.After = append(stmt.After, scom)
+				suffix := stmt.Suffix
+				stmt.Suffix = suffix[:len(suffix) - 1]
+			}
+
 
 		case *PythonBlock:
 			for _, com := range stmt.Before {

--- a/build/print.go
+++ b/build/print.go
@@ -121,9 +121,8 @@ func (p *printer) file(f *File) {
 	for i, stmt := range f.Stmt {
 		switch stmt := stmt.(type) {
 		case *CommentBlock:
-			// This is necessary so that CommentBlock
-			// doesn't swallow up suffix comments of
-			// the expression after it.
+			// This is necessary so that CommentBlock doesn't swallow 
+			// up suffix comments of the expression after it.
 			for _, scom := range stmt.Suffix {
 				scom.Suffix = false
 				stmt.After = append(stmt.After, scom)

--- a/build/testdata/046.golden
+++ b/build/testdata/046.golden
@@ -1,0 +1,22 @@
+[cc_binary(
+    name = "translator_for_%s" % lang,
+) for lang in li]  # Bug if this comment get eaten by buildifier
+
+[
+    # This line should be fine
+    cc_binary(
+        name = "translate_%s_benchmark" % lang,
+    )
+    for lang in li
+]
+
+# Start of a comment block
+# end of a comment block
+# Comment block should not swallow this up
+
+[
+    cc_binary(
+        name = "%s_binary" % lang,
+    )
+    for lang in li
+]

--- a/build/testdata/046.in
+++ b/build/testdata/046.in
@@ -1,0 +1,22 @@
+[cc_binary(
+    name = "translator_for_%s" % lang,
+) for lang in li]
+
+[   # Bug if this comment get eaten by buildifier
+    # This line should be fine
+    cc_binary(
+        name = "translate_%s_benchmark" % lang,
+    )
+    for lang in li]
+
+
+# Start of a comment block
+# end of a comment block
+
+[   # Comment block should not swallow this up
+    cc_binary(
+        name = "%s_binary" % lang,
+    )
+    for lang in li]
+
+


### PR DESCRIPTION
Fixes #68 on github
```
[cc_binary(
    name = "translator_for_%s" % lang,
) for lang in li]

[   # This line will be eaten by buildifier
    # but not this line.
    cc_binary(
        name = "translate_%s_benchmark" % lang,
    )
    for lang in li]
```
This is due to the comment line `# This line will be eaten by buildifier` being assigned to the expression `cc_binary() for lang in li` and then never printed.

@laurentlb @pmbethe09 I thought the comment assignment a bit strange in buildifier. For example, given the input

```
[func1() for j in list2]

[  #This comment gets associated with the list above
func3()
]
```
This is due to the code [here](https://github.com/bazelbuild/buildifier/blob/master/build/lex.go#L733-L743). Thoughts and reviews?