### PR TITLE
Update WORKSPACE to reflect the new repo name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "com_github_bazelbuild_builditools")
+workspace(name = "com_github_bazelbuild_buildtools")
 
 http_archive(
     name = "io_bazel_rules_go",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "com_github_bazelbuild_buildifier")
+workspace(name = "com_github_bazelbuild_builditools")
 
 http_archive(
     name = "io_bazel_rules_go",


### PR DESCRIPTION
For now, downstream users have the following warning message:

```
(@com_github_bazelbuild_buildifier) does not match the name given in the repository's definition (@com_github_bazelbuild_buildtools); this will cause a build error in future versions.
```