### PR TITLE
modify LabelsEqual for unused_deps and some tests

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -74,11 +74,11 @@ func ShortenLabel(label string, pkg string) string {
 }
 
 // LabelsEqual returns true if label1 and label2 are equal. The function
-// takes care of the optional ":" prefix, "@" references and differences
-// between long-form labels and local labels.
+// takes care of the optional ":" prefix and differences between long-form
+// labels and local labels.
 func LabelsEqual(label1, label2, pkg string) bool {
-	str1 := strings.Trim(ShortenLabel(label1, pkg), ":@")
-	str2 := strings.Trim(ShortenLabel(label2, pkg), ":@")
+	str1 := strings.TrimPrefix(ShortenLabel(label1, pkg), ":")
+	str2 := strings.TrimPrefix(ShortenLabel(label2, pkg), ":")
 	return str1 == str2
 }
 

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -74,11 +74,11 @@ func ShortenLabel(label string, pkg string) string {
 }
 
 // LabelsEqual returns true if label1 and label2 are equal. The function
-// takes care of the optional ":" prefix and differences between long-form
-// labels and local labels.
+// takes care of the optional ":" prefix, "@" references and differences
+// between long-form labels and local labels.
 func LabelsEqual(label1, label2, pkg string) bool {
-	str1 := strings.TrimPrefix(ShortenLabel(label1, pkg), ":")
-	str2 := strings.TrimPrefix(ShortenLabel(label2, pkg), ":")
+	str1 := strings.Trim(ShortenLabel(label1, pkg), ":@")
+	str2 := strings.Trim(ShortenLabel(label2, pkg), ":@")
 	return str1 == str2
 }
 

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -75,7 +75,6 @@ var labelsEqualTests = []struct {
 }{
 	{"//devtools/buildozer:rule", "rule", "devtools/buildozer", true},
 	{"//devtools/buildozer:rule", "rule:jar","devtools", false},
-	{"@@io_bazel", "@io_bazel","devtools", true},
 }
 
 func TestLabelsEqual(t *testing.T) {

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -68,10 +68,10 @@ func TestShortenLabel(t *testing.T) {
 }
 
 var labelsEqualTests = []struct {
-	label1 string
-	label2 string
-	pkg    string
-	result bool
+	label1   string
+	label2   string
+	pkg      string
+	expected bool
 }{
 	{"//devtools/buildozer:rule", "rule", "devtools/buildozer", true},
 	{"//devtools/buildozer:rule", "rule:jar","devtools", false},
@@ -79,10 +79,10 @@ var labelsEqualTests = []struct {
 
 func TestLabelsEqual(t *testing.T) {
 	for i, tt := range labelsEqualTests {
-		result := LabelsEqual(tt.label1, tt.label2, tt.pkg)
-		if result != tt.result {
+		got := LabelsEqual(tt.label1, tt.label2, tt.pkg)
+		if got != tt.expected {
 			t.Errorf("%d. LabelsEqual(%q, %q, %q) => %q, want %q",
-				i, tt.label1, tt.label2, tt.pkg, result, tt.result)
+				i, tt.label1, tt.label2, tt.pkg, got, tt.expected)
 		}
 	}
 }

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -67,6 +67,27 @@ func TestShortenLabel(t *testing.T) {
 	}
 }
 
+var labelsEqualTests = []struct {
+	label1 string
+	label2 string
+	pkg    string
+	result bool
+}{
+	{"//devtools/buildozer:rule", "rule", "devtools/buildozer", true},
+	{"//devtools/buildozer:rule", "rule:jar","devtools", false},
+	{"@@io_bazel", "@io_bazel","devtools", true},
+}
+
+func TestLabelsEqual(t *testing.T) {
+	for i, tt := range labelsEqualTests {
+		result := LabelsEqual(tt.label1, tt.label2, tt.pkg)
+		if result != tt.result {
+			t.Errorf("%d. LabelsEqual(%q, %q, %q) => %q, want %q",
+				i, tt.label1, tt.label2, tt.pkg, result, tt.result)
+		}
+	}
+}
+
 var splitOnSpacesTests = []struct {
 	in  string
 	out []string

--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -221,11 +221,11 @@ func printCommands(label string, deps map[string]bool) (anyCommandPrinted bool) 
 		for _, elem := range li.List {
 			for dep := range deps {
 				str, ok := elem.(*build.StringExpr)
-				if ok && edit.ShortenLabel(str.Value, pkg) == edit.ShortenLabel(dep, pkg) {
+				if ok && edit.LabelsEqual(str.Value, dep, pkg) {
 					if hasRuntimeComment(str) {
-						fmt.Printf("buildozer 'move deps runtime_deps %s' %s\n", dep, label)
+						fmt.Printf("buildozer 'move deps runtime_deps %s' %s\n", str.Value, label)
 					} else {
-						fmt.Printf("buildozer 'remove deps %s' %s\n", dep, label)
+						fmt.Printf("buildozer 'remove deps %s' %s\n", str.Value, label)
 					}
 					anyCommandPrinted = true
 				}


### PR DESCRIPTION
@pmbethe09, I modified a bit LabelsEqual in order to deal with `.jar-2.params` files notation.

Assuming, that I have a `maven_jar` defined in a WORKSPACE like:
```
maven_jar(
    name = "org_apache_commons_commons_lang3",
    artifact = "org.apache.commons:commons-lang3:3.1",
    sha1 = "905075e6c80f206bbe6cf1e809d2caa69f420c76",
)
```
for every direct dep on it in BUILD file I got in params file following string: `@@org_apache_commons_commons_lang3//jar:jar`

I have two problems with this
1) leading `@@`, that I think should be trimmed (and that's the reason of modifying LabelEquals)
2) `:jar` suffix, that is usually omit in BUILD files. Here, I am not sure about what to do and lean to force administratively demand writing full label name with :jar extension.

WDYT?