### PR TITLE
Handle glob arguments in buildozer.

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -440,11 +440,14 @@ func getAttrValueExpr(attr string, args []string) build.Expr {
 		}
 		return &build.ListExpr{List: list}
 	case IsList(attr):
-		var list []build.Expr
-		for _, i := range args {
-			list = append(list, &build.StringExpr{Value: i})
+		if !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")) {
+			var list []build.Expr
+			for _, i := range args {
+				list = append(list, &build.StringExpr{Value: i})
+			}
+			return &build.ListExpr{List: list}
 		}
-		return &build.ListExpr{List: list}
+		fallthrough // `args` is a glob; fallthrough to string case.
 	case IsString(attr):
 		return &build.StringExpr{Value: args[0]}
 	default:

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -439,15 +439,12 @@ func getAttrValueExpr(attr string, args []string) build.Expr {
 			list = append(list, &build.LiteralExpr{Token: i})
 		}
 		return &build.ListExpr{List: list}
-	case IsList(attr):
-		if !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")) {
-			var list []build.Expr
-			for _, i := range args {
-				list = append(list, &build.StringExpr{Value: i})
-			}
-			return &build.ListExpr{List: list}
+	case IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")):
+		var list []build.Expr
+		for _, i := range args {
+			list = append(list, &build.StringExpr{Value: i})
 		}
-		fallthrough // `args` is a glob; fallthrough to string case.
+		return &build.ListExpr{List: list}
 	case IsString(attr):
 		return &build.StringExpr{Value: args[0]}
 	default:


### PR DESCRIPTION
If a list attribute has a single glob argument, it will now be treated as a literal argument instead.

For example,
`> buildozer 'set srcs glob(["*.go"])' $target`
produces `srcs = glob(["*.go"])` instead of `srcs = ["glob([\"*.go\"])"]`.

To fix https://github.com/bazelbuild/buildtools/issues/99.