### PR TITLE
Allowing overriding named argument priority via `tables.json`

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -305,11 +305,11 @@ func sortCallArgs(f *File, info *RewriteInfo) {
 // It could use the auto-generated per-rule tables but for now it just
 // falls back to the original list.
 func ruleNamePriority(rule, arg string) int {
-	return namePriority[arg]
+	return tables.NamePriority[arg]
 	/*
 		list := ruleArgOrder[rule]
 		if len(list) == 0 {
-			return namePriority[arg]
+			return tables.NamePriority[arg]
 		}
 		for i, x := range list {
 			if x == arg {
@@ -318,39 +318,6 @@ func ruleNamePriority(rule, arg string) int {
 		}
 		return len(list)
 	*/
-}
-
-// namePriority maps an argument name to its sorting priority.
-//
-// NOTE(bazel-team): These are the old buildifier rules. It is likely that this table
-// will change, perhaps swapping in a separate table for each call,
-// derived from the order used in the Build Encyclopedia.
-var namePriority = map[string]int{
-	"name":              -99,
-	"gwt_name":          -98,
-	"package_name":      -97,
-	"visible_node_name": -96, // for boq_initial_css_modules and boq_jswire_test_suite
-	"size":              -95,
-	"timeout":           -94,
-	"testonly":          -93,
-	"src":               -92,
-	"srcdir":            -91,
-	"srcs":              -90,
-	"out":               -89,
-	"outs":              -88,
-	"hdrs":              -87,
-	"has_services":      -86, // before api versions, for proto
-	"include":           -85, // before exclude, for glob
-	"of":                -84, // for check_dependencies
-	"baseline":          -83, // for searchbox_library
-	// All others sort here, at 0.
-	"destdir":        1,
-	"exports":        2,
-	"runtime_deps":   3,
-	"deps":           4,
-	"implementation": 5,
-	"implements":     6,
-	"alwayslink":     7,
 }
 
 // If x is of the form key=value, argName returns the string key.

--- a/tables/jsonparser.go
+++ b/tables/jsonparser.go
@@ -27,6 +27,7 @@ type Definitions struct {
 	IsSortableListArg map[string]bool
 	SortableBlacklist map[string]bool
 	SortableWhitelist map[string]bool
+	NamePriority      map[string]int
 }
 
 func ParseJsonDefinitions(file string) (Definitions, error) {
@@ -47,6 +48,6 @@ func ParseAndUpdateJsonDefinitions(file string) error {
 		return err
 	}
 
-	OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist)
+	OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority)
 	return nil
 }

--- a/tables/jsonparser_test.go
+++ b/tables/jsonparser_test.go
@@ -35,6 +35,7 @@ func TestParseJsonDefinitions(t *testing.T) {
 		IsSortableListArg: map[string]bool{"srcs": true, "visibility": true},
 		SortableBlacklist: map[string]bool{"genrule.srcs": true},
 		SortableWhitelist: map[string]bool{},
+		NamePriority:      map[string]int{"name": -1},
 	}
 	if !reflect.DeepEqual(expected, definitions) {
 		t.Errorf("ParseJsonDefinitions() = %v; want %v", definitions, expected)

--- a/tables/tables.go
+++ b/tables/tables.go
@@ -163,11 +163,45 @@ var SortableWhitelist = map[string]bool{
 	"java_import.constraints":  true,
 }
 
+// NamePriority maps an argument name to its sorting priority.
+//
+// NOTE(bazel-team): These are the old buildifier rules. It is likely that this table
+// will change, perhaps swapping in a separate table for each call,
+// derived from the order used in the Build Encyclopedia.
+var NamePriority = map[string]int{
+	"name":              -99,
+	"gwt_name":          -98,
+	"package_name":      -97,
+	"visible_node_name": -96, // for boq_initial_css_modules and boq_jswire_test_suite
+	"size":              -95,
+	"timeout":           -94,
+	"testonly":          -93,
+	"src":               -92,
+	"srcdir":            -91,
+	"srcs":              -90,
+	"out":               -89,
+	"outs":              -88,
+	"hdrs":              -87,
+	"has_services":      -86, // before api versions, for proto
+	"include":           -85, // before exclude, for glob
+	"of":                -84, // for check_dependencies
+	"baseline":          -83, // for searchbox_library
+	// All others sort here, at 0.
+	"destdir":        1,
+	"exports":        2,
+	"runtime_deps":   3,
+	"deps":           4,
+	"implementation": 5,
+	"implements":     6,
+	"alwayslink":     7,
+}
+
 // OverrideTables allows a user of the build package to override the special-case rules.
-func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool) {
+func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int) {
 	IsLabelArg = labelArg
 	LabelBlacklist = blacklist
 	IsSortableListArg = sortableListArg
 	SortableBlacklist = sortBlacklist
 	SortableWhitelist = sortWhitelist
+	NamePriority = namePriority
 }

--- a/tables/testdata/simple_tables.json
+++ b/tables/testdata/simple_tables.json
@@ -15,5 +15,8 @@
   },
   "SortableWhitelist": {
 
+  },
+  "NamePriority": {
+    "name": -1
   }
 }


### PR DESCRIPTION
Currently, the priority used to sort named arguments is hard-coded in `build/rewrite`.  This moves and exposes it via `tables.json` to make it customizable.