### PR TITLE
Support table merging

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -305,6 +305,10 @@ func sortCallArgs(f *File, info *RewriteInfo) {
 // It could use the auto-generated per-rule tables but for now it just
 // falls back to the original list.
 func ruleNamePriority(rule, arg string) int {
+	rule_arg := rule + "." + arg
+	if val, ok := tables.NamePriority[rule_arg]; ok {
+		return val
+	}
 	return tables.NamePriority[arg]
 	/*
 		list := ruleArgOrder[rule]

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -39,12 +39,13 @@ var (
 	// Undocumented; for debugging.
 	showlog = flag.Bool("showlog", false, "show log in check mode")
 
-	vflag      = flag.Bool("v", false, "print verbose information on standard error")
-	dflag      = flag.Bool("d", false, "alias for -mode=diff")
-	mode       = flag.String("mode", "", "formatting mode: check, diff, or fix (default fix)")
-	path       = flag.String("path", "", "assume BUILD file has this path relative to the workspace directory")
-	tablesPath = flag.String("tables", "", "path to JSON file with custom table definitions")
-	version    = flag.Bool("version", false, "Print the version of buildifier")
+	vflag         = flag.Bool("v", false, "print verbose information on standard error")
+	dflag         = flag.Bool("d", false, "alias for -mode=diff")
+	mode          = flag.String("mode", "", "formatting mode: check, diff, or fix (default fix)")
+	path          = flag.String("path", "", "assume BUILD file has this path relative to the workspace directory")
+	tablesPath    = flag.String("tables", "", "path to JSON file with custom table definitions which will replace the built-in tables")
+	addTablesPath = flag.String("add_tables", "", "path to JSON file with custom table definitions which will be merged with the built-in tables")
+	version       = flag.Bool("version", false, "Print the version of buildifier")
 	// Debug flags passed through to rewrite.go
 	allowSort = stringList("allowsort", "additional sort contexts to treat as safe")
 	disable   = stringList("buildifier_disable", "list of buildifier rewrites to disable")
@@ -128,8 +129,15 @@ func main() {
 	}
 
 	if *tablesPath != "" {
-		if err := tables.ParseAndUpdateJsonDefinitions(*tablesPath); err != nil {
+		if err := tables.ParseAndUpdateJsonDefinitions(*tablesPath, false); err != nil {
 			fmt.Fprintf(os.Stderr, "buildifier: failed to parse %s for -tables: %s\n", *tablesPath, err)
+			os.Exit(2)
+		}
+	}
+
+	if *addTablesPath != "" {
+		if err := tables.ParseAndUpdateJsonDefinitions(*addTablesPath, true); err != nil {
+			fmt.Fprintf(os.Stderr, "buildifier: failed to parse %s for -add_tables: %s\n", *addTablesPath, err)
 			os.Exit(2)
 		}
 	}

--- a/tables/jsonparser.go
+++ b/tables/jsonparser.go
@@ -42,12 +42,16 @@ func ParseJsonDefinitions(file string) (Definitions, error) {
 	return definitions, err
 }
 
-func ParseAndUpdateJsonDefinitions(file string) error {
+func ParseAndUpdateJsonDefinitions(file string, merge bool) error {
 	definitions, err := ParseJsonDefinitions(file)
 	if err != nil {
 		return err
 	}
 
-	OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority)
+	if merge {
+		MergeTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority)
+	} else {
+		OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority)
+	}
 	return nil
 }

--- a/tables/tables.go
+++ b/tables/tables.go
@@ -196,7 +196,7 @@ var NamePriority = map[string]int{
 	"alwayslink":     7,
 }
 
-// OverrideTables allows a user of the build package to override the special-case rules.
+// OverrideTables allows a user of the build package to override the special-case rules. The user-provided tables replace the built-in tables.
 func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int) {
 	IsLabelArg = labelArg
 	LabelBlacklist = blacklist
@@ -204,4 +204,26 @@ func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhi
 	SortableBlacklist = sortBlacklist
 	SortableWhitelist = sortWhitelist
 	NamePriority = namePriority
+}
+
+// MergeTables allows a user of the build package to override the special-case rules. The user-provided tables are merged into the built-in tables.
+func MergeTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int) {
+	for k, v := range labelArg {
+		IsLabelArg[k] = v
+	}
+	for k, v := range blacklist {
+		LabelBlacklist[k] = v
+	}
+	for k, v := range sortableListArg {
+		IsSortableListArg[k] = v
+	}
+	for k, v := range sortBlacklist {
+		SortableBlacklist[k] = v
+	}
+	for k, v := range sortWhitelist {
+		SortableWhitelist[k] = v
+	}
+	for k, v := range namePriority {
+		NamePriority[k] = v
+	}
 }


### PR DESCRIPTION
Add `-add_tables` option to buildifier which will merge the user provided tables into the built-in tables, rather than replacing them wholesale. Add ability to override `NamePriority` per rule.

Fixes #112.