### PR TITLE
Return non zero code, if check mode failed

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -224,6 +224,7 @@ func processFiles(files []string) {
 // 1: syntax errors in input
 // 2: usage errors: invoked incorrectly
 // 3: unexpected runtime errors: file I/O problems or internal bugs
+// 4: check mode failed (reformat is needed) 
 var exitCode = 0
 
 // toRemove is a list of files to remove before exiting.
@@ -286,6 +287,7 @@ func processFile(filename string, data []byte) {
 				log = " " + strings.Join(uniq, " ")
 			}
 			fmt.Printf("%s #%s %s%s\n", filename, reformat, &info, log)
+                        exitCode = 4
 		}
 		return
 


### PR DESCRIPTION
Fixes: #110.

The point of check mode is to be able to verify the formatting of BUILD
files from the CI:

```
  $ buildifier -mode=check $(find . -name BUILD)
```

Choose the next free return value 4, and return it in case, reformat is
needed.