### PR TITLE
ParseLabel(): handle labels without colons

### DIFF
--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -30,6 +30,8 @@ var parseLabelTests = []struct {
 	{"//devtools/buildozer", "devtools/buildozer", "buildozer"},
 	{"//base", "base", "base"},
 	{"//base:", "base", "base"},
+	{":label", "", "label"},
+	{"label", "", "label"},
 }
 
 func TestParseLabel(t *testing.T) {


### PR DESCRIPTION
Before: "label" was interpreted as "label:label", but it actually refers
to ":label".

https://docs.bazel.build/versions/master/build-ref.html#labels