### PR TITLE
Parse WORKSPACE for BUILD files of external repos

### DIFF
--- a/wspace/BUILD.bazel
+++ b/wspace/BUILD.bazel
@@ -4,6 +4,10 @@ go_library(
     name = "go_default_library",
     srcs = ["workspace.go"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//build:go_default_library",
+        "//file:go_default_library",
+    ],
 )
 
 go_test(


### PR DESCRIPTION
This can then be used by buildozer to locate such BUILD files. It won't
work for repos defined with Skylark - for example, for [Tensorflow][1]
it could locate models.BUILD but not the BUILD files in third_party.

[1]: https://github.com/tensorflow/tensorflow/blob/master/WORKSPACE