### PR TITLE
Load BUILD files for external (new_*) repos

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -17,6 +17,7 @@ package edit
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -715,6 +716,10 @@ func rewrite(commandsForFile commandsForFile) *rewriteResult {
 			name = strings.TrimSuffix(name, suffix)
 		}
 		if err != nil {
+			data, fi, err = file.ReadFile(name)
+		}
+		if err != nil {
+			err = errors.New("file not found or not readable")
 			return &rewriteResult{file: origName, errs: []error{err}}
 		}
 	}
@@ -734,7 +739,7 @@ func rewrite(commandsForFile commandsForFile) *rewriteResult {
 		target := commands.target
 		commands := commands.commands
 		_, absPkg, rule := InterpretLabelForWorkspaceLocation(Opts.RootDir, target)
-		pkg, _ := ParseLabel(target)
+		_, pkg, _ := ParseLabel(target)
 		if pkg == stdinPackageName { // Special-case: This is already absolute
 			absPkg = stdinPackageName
 		}
@@ -884,7 +889,7 @@ func appendCommands(commandMap map[string][]commandsForTarget, args []string) {
 			target = strings.TrimSuffix(target, "/BUILD") + ":__pkg__"
 		}
 		var buildFiles []string
-		pkg, _ := ParseLabel(target)
+		_, pkg, _ := ParseLabel(target)
 		if pkg == stdinPackageName {
 			buildFiles = []string{stdinPackageName}
 		} else {

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -22,24 +22,30 @@ import (
 
 var parseLabelTests = []struct {
 	in   string
+	repo string
 	pkg  string
 	rule string
 }{
-	{"//devtools/buildozer:rule", "devtools/buildozer", "rule"},
-	{"devtools/buildozer:rule", "devtools/buildozer", "rule"},
-	{"//devtools/buildozer", "devtools/buildozer", "buildozer"},
-	{"//base", "base", "base"},
-	{"//base:", "base", "base"},
-	{":label", "", "label"},
-	{"label", "", "label"},
+	{"//devtools/buildozer:rule", "", "devtools/buildozer", "rule"},
+	{"devtools/buildozer:rule", "", "devtools/buildozer", "rule"},
+	{"//devtools/buildozer", "", "devtools/buildozer", "buildozer"},
+	{"//base", "", "base", "base"},
+	{"//base:", "", "base", "base"},
+	{"@r//devtools/buildozer:rule", "r", "devtools/buildozer", "rule"},
+	{"@r//devtools/buildozer", "r", "devtools/buildozer", "buildozer"},
+	{"@r//base", "r", "base", "base"},
+	{"@r//base:", "r", "base", "base"},
+	{"@foo", "foo", "", "foo"},
+	{":label", "", "", "label"},
+	{"label", "", "", "label"},
 }
 
 func TestParseLabel(t *testing.T) {
 	for i, tt := range parseLabelTests {
-		pkg, rule := ParseLabel(tt.in)
-		if pkg != tt.pkg || rule != tt.rule {
-			t.Errorf("%d. ParseLabel(%q) => (%q, %q), want (%q, %q)",
-				i, tt.in, pkg, rule, tt.pkg, tt.rule)
+		repo, pkg, rule := ParseLabel(tt.in)
+		if repo != tt.repo || pkg != tt.pkg || rule != tt.rule {
+			t.Errorf("%d. ParseLabel(%q) => (%q, %q, %q), want (%q, %q, %q)",
+				i, tt.in, repo, pkg, rule, tt.repo, tt.pkg, tt.rule)
 		}
 	}
 }


### PR DESCRIPTION
This adds an extra output variable to `ParseLabel()` for the repository,
to support labels of the form `@repo//pkg:rule`. Users of `ParseLabel()`
that don't want to support external repos need to change to:

`_, pkg, rule = ParseLabel(label)`