### PR TITLE
Lint and warning fixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,10 +10,17 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_rules_dependencies",
+    "go_register_toolchains",
+    "go_repository",
+)
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
 
-go_repositories()
+go_rules_dependencies()
+
+go_register_toolchains()
 
 go_proto_repositories()
 
@@ -28,7 +35,7 @@ http_archive(
     ],
 )
 
-new_go_repository(
+go_repository(
     name = "org_golang_x_tools",
     commit = "3d92dd60033c312e3ae7cac319c792271cf67e37",
     importpath = "golang.org/x/tools",

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -305,8 +305,8 @@ func sortCallArgs(f *File, info *RewriteInfo) {
 // It could use the auto-generated per-rule tables but for now it just
 // falls back to the original list.
 func ruleNamePriority(rule, arg string) int {
-	rule_arg := rule + "." + arg
-	if val, ok := tables.NamePriority[rule_arg]; ok {
+	ruleArg := rule + "." + arg
+	if val, ok := tables.NamePriority[ruleArg]; ok {
 		return val
 	}
 	return tables.NamePriority[arg]

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -129,14 +129,14 @@ func main() {
 	}
 
 	if *tablesPath != "" {
-		if err := tables.ParseAndUpdateJsonDefinitions(*tablesPath, false); err != nil {
+		if err := tables.ParseAndUpdateJSONDefinitions(*tablesPath, false); err != nil {
 			fmt.Fprintf(os.Stderr, "buildifier: failed to parse %s for -tables: %s\n", *tablesPath, err)
 			os.Exit(2)
 		}
 	}
 
 	if *addTablesPath != "" {
-		if err := tables.ParseAndUpdateJsonDefinitions(*addTablesPath, true); err != nil {
+		if err := tables.ParseAndUpdateJSONDefinitions(*addTablesPath, true); err != nil {
 			fmt.Fprintf(os.Stderr, "buildifier: failed to parse %s for -add_tables: %s\n", *addTablesPath, err)
 			os.Exit(2)
 		}
@@ -224,7 +224,7 @@ func processFiles(files []string) {
 // 1: syntax errors in input
 // 2: usage errors: invoked incorrectly
 // 3: unexpected runtime errors: file I/O problems or internal bugs
-// 4: check mode failed (reformat is needed) 
+// 4: check mode failed (reformat is needed)
 var exitCode = 0
 
 // toRemove is a list of files to remove before exiting.
@@ -287,7 +287,7 @@ func processFile(filename string, data []byte) {
 				log = " " + strings.Join(uniq, " ")
 			}
 			fmt.Printf("%s #%s %s%s\n", filename, reformat, &info, log)
-                        exitCode = 4
+			exitCode = 4
 		}
 		return
 

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -56,10 +56,9 @@ func ParseLabel(target string) (string, string, string) {
 		if strings.HasPrefix(target, "//") {
 			// "//absolute/pkg" -> "absolute/pkg", "pkg"
 			return repo, parts[0], path.Base(parts[0])
-		} else {
-			// "relative/label" -> "", "relative/label"
-			return repo, "", parts[0]
 		}
+		// "relative/label" -> "", "relative/label"
+		return repo, "", parts[0]
 	}
 	return repo, parts[0], parts[1]
 }

--- a/tables/jsonparser.go
+++ b/tables/jsonparser.go
@@ -30,7 +30,8 @@ type Definitions struct {
 	NamePriority      map[string]int
 }
 
-func ParseJsonDefinitions(file string) (Definitions, error) {
+// ParseJSONDefinitions reads and parses JSON table definitions from file.
+func ParseJSONDefinitions(file string) (Definitions, error) {
 	var definitions Definitions
 
 	data, err := ioutil.ReadFile(file)
@@ -42,8 +43,10 @@ func ParseJsonDefinitions(file string) (Definitions, error) {
 	return definitions, err
 }
 
-func ParseAndUpdateJsonDefinitions(file string, merge bool) error {
-	definitions, err := ParseJsonDefinitions(file)
+// ParseAndUpdateJSONDefinitions reads definitions from file and merges or
+// overrides the values in memory.
+func ParseAndUpdateJSONDefinitions(file string, merge bool) error {
+	definitions, err := ParseJSONDefinitions(file)
 	if err != nil {
 		return err
 	}

--- a/tables/jsonparser_test.go
+++ b/tables/jsonparser_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 )
 
-func TestParseJsonDefinitions(t *testing.T) {
+func TestParseJSONDefinitions(t *testing.T) {
 	testdata := os.Getenv("TEST_SRCDIR") + "/" + os.Getenv("TEST_WORKSPACE") + "/tables/testdata"
-	definitions, err := ParseJsonDefinitions(testdata + "/simple_tables.json")
+	definitions, err := ParseJSONDefinitions(testdata + "/simple_tables.json")
 	if err != nil {
 		t.Error(err)
 	}
@@ -38,6 +38,6 @@ func TestParseJsonDefinitions(t *testing.T) {
 		NamePriority:      map[string]int{"name": -1},
 	}
 	if !reflect.DeepEqual(expected, definitions) {
-		t.Errorf("ParseJsonDefinitions() = %v; want %v", definitions, expected)
+		t.Errorf("ParseJSONDefinitions() = %v; want %v", definitions, expected)
 	}
 }


### PR DESCRIPTION
I haven't been able to test this as I get the following error with bazel 0.5.3:

```
ERROR: error loading package 'bazel-buildtools/external/bazel_tools/tools/jdk': Extension file not found. Unable to load package for '//tools/jdk:alias_rules.bzl': BUILD file not found on package path
```

Any idea why that is?