### PR TITLE
Command 'replace' works on expressions containing lists

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -402,13 +402,12 @@ func cmdReplace(env CmdEnvironment) (*build.File, error) {
 	oldV := env.Args[1]
 	newV := env.Args[2]
 	for _, key := range attrKeysForPattern(env.Rule, env.Args[0]) {
-		switch e := env.Rule.Attr(key).(type) {
-		case *build.ListExpr:
-			ListReplace(e, oldV, newV, env.Pkg)
-		case *build.StringExpr:
+		if e, ok := env.Rule.Attr(key).(*build.StringExpr); ok {
 			if LabelsEqual(e.Value, oldV, env.Pkg) {
 				env.Rule.SetAttr(key, getAttrValueExpr(key, []string{newV}))
 			}
+		} else {
+			ListReplace(e, oldV, newV, env.Pkg)
 		}
 	}
 	return env.File, nil


### PR DESCRIPTION
e.g., 'deps = [foo] + CONSTANT'.