### PR TITLE
update the WORKSPACE to point to rules_go 0.5.5 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,12 @@
 workspace(name = "com_github_bazelbuild_buildtools")
 
+# 0.5.5
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "1e8e662ab93eca94beb6c690b8fd41347835e8ce0f3c4f71708af4b6673dd171",
-    strip_prefix = "rules_go-2e319588571f20fdaaf83058b690abd32f596e89",
+    strip_prefix = "rules_go-e1c4b58c05e4a6ab67392daf28f3d57e4902f581",
     urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/2e319588571f20fdaaf83058b690abd32f596e89.tar.gz",
-        "https://github.com/bazelbuild/rules_go/archive/2e319588571f20fdaaf83058b690abd32f596e89.tar.gz",
+        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/e1c4b58c05e4a6ab67392daf28f3d57e4902f581.tar.gz",
+        "https://github.com/bazelbuild/rules_go/archive/e1c4b58c05e4a6ab67392daf28f3d57e4902f581.tar.gz",
     ],
 )
 
@@ -16,18 +16,14 @@ load(
     "go_register_toolchains",
     "go_repository",
 )
-load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
 
 go_rules_dependencies()
 
 go_register_toolchains()
 
-go_proto_repositories()
-
 # used for build.proto
 http_archive(
     name = "io_bazel",
-    sha256 = "71e8b433b5d210867322336a2afcc8d11e832cb5db9e04100e3ac8bba2c9af96",
     strip_prefix = "bazel-0.5.4",
     urls = [
         "http://mirror.bazel.build/github.com/bazelbuild/bazel/archive/0.5.4.tar.gz",


### PR DESCRIPTION
also removed the sha26 which is breaking from GitHub.

Fixes https://github.com/bazelbuild/buildtools/issues/139