### PR TITLE
Accept either WORKSPACE or .buckconfig as indicating repo root.

### DIFF
--- a/wspace/workspace.go
+++ b/wspace/workspace.go
@@ -27,6 +27,8 @@ import (
 
 const workspaceFile = "WORKSPACE"
 
+var repoRootFiles = [...]string{workspaceFile, ".buckconfig"}
+
 // findContextPath finds the context path inside of a WORKSPACE-rooted source tree.
 func findContextPath(rootDir string) (string, error) {
 	if rootDir == "" {
@@ -58,10 +60,12 @@ func Find(dir string) (string, error) {
 	if dir == "" || dir == "/" || dir == "." {
 		return "", os.ErrNotExist
 	}
-	if _, err := os.Stat(filepath.Join(dir, workspaceFile)); err == nil {
-		return dir, nil
-	} else if !os.IsNotExist(err) {
-		return "", err
+	for _, repoRootFile := range repoRootFiles {
+		if _, err := os.Stat(filepath.Join(dir, repoRootFile)); err == nil {
+			return dir, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
 	}
 	return Find(filepath.Dir(dir))
 }

--- a/wspace/workspace_test.go
+++ b/wspace/workspace_test.go
@@ -28,7 +28,7 @@ type testCase struct {
 	expectedRoot, expectedRest string
 }
 
-func TestBasic(t *testing.T) {
+func runBasicTestWithRepoRootFile(t *testing.T, repoRootFile string) {
 	tmp, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)
@@ -37,10 +37,10 @@ func TestBasic(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "b", "c"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, workspaceFile), nil, 0755); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(tmp, repoRootFile), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "a", "b", workspaceFile), nil, 0755); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(tmp, "a", "b", repoRootFile), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,6 +56,11 @@ func TestBasic(t *testing.T) {
 			t.Errorf("FindWorkspaceRoot(%q) = %q, %q; want %q, %q", tc.input, root, rest, tc.expectedRoot, tc.expectedRest)
 		}
 	}
+}
+
+func TestBasic(t *testing.T) {
+	runBasicTestWithRepoRootFile(t, ".buckconfig")
+	runBasicTestWithRepoRootFile(t, workspaceFile)
 }
 
 func TestFindRepoBuildfiles(t *testing.T) {


### PR DESCRIPTION
Fixes #93.