### PR TITLE
Fix the ci.bazel.io status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ This repository contains developer tools for working with Google's `bazel` build
 [java_library](https://docs.bazel.build/versions/master/be/java.html#java_library) rules.
 
 
-linux-x86_64 | ubuntu_15.10-x86_64 | darwin-x86_64
-:---: | :---: | :---:
-[![Build Status](http://ci.bazel.io/buildStatus/icon?job=buildtools/BAZEL_VERSION=latest,PLATFORM_NAME=linux-x86_64)](http://ci.bazel.io/job/buildtools/BAZEL_VERSION=latest,PLATFORM_NAME=linux-x86_64) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=buildtools/BAZEL_VERSION=latest,PLATFORM_NAME=ubuntu_15.10-x86_64)](http://ci.bazel.io/job/buildtools/BAZEL_VERSION=latest,PLATFORM_NAME=ubuntu_15.10-x86_64) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=buildtools/BAZEL_VERSION=latest,PLATFORM_NAME=darwin-x86_64)](http://ci.bazel.io/job/buildtools/BAZEL_VERSION=latest,PLATFORM_NAME=darwin-x86_64)
+[![Build Status](https://ci.bazel.io/buildStatus/icon?job=buildtools)](https://ci.bazel.io/job/buildtools)
 
 ## Setup
 


### PR DESCRIPTION
The current config on ci.bazel.io rolls all configs into a single (pipeline) job. Which, AIUI, means there's only one badge. This change replaces the three non-working badges with one working one.