### PR TITLE
Add Implicit Name Recognition

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -212,7 +212,7 @@ func cmdNew(env CmdEnvironment) (*build.File, error) {
 		return nil, err
 	}
 
-	if FindRuleByName(env.File, "", name) != nil {
+	if FindRuleByName(env.File, name) != nil {
 		return nil, fmt.Errorf("rule '%s' already exists", name)
 	}
 
@@ -479,7 +479,7 @@ func cmdCopyNoOverwrite(env CmdEnvironment) (*build.File, error) {
 }
 
 func copyAttributeBetweenRules(env CmdEnvironment, attrName string, from string) (*build.File, error) {
-	fromRule := FindRuleByName(env.File, "", from)
+	fromRule := FindRuleByName(env.File, from)
 	if fromRule == nil {
 		return nil, fmt.Errorf("could not find rule '%s'", from)
 	}
@@ -537,8 +537,8 @@ var AllCommands = map[string]CommandInfo{
 	"copy_no_overwrite":  {cmdCopyNoOverwrite, 2, 2, "<attr> <from_rule>"},
 }
 
-func expandTargets(f *build.File, pkg string, rule string) ([]*build.Rule, error) {
-	if r := FindRuleByName(f, pkg, rule); r != nil {
+func expandTargets(f *build.File, rule string) ([]*build.Rule, error) {
+	if r := FindRuleByName(f, rule); r != nil {
 		return []*build.Rule{r}, nil
 	} else if r := FindExportedFile(f, rule); r != nil {
 		return []*build.Rule{r}, nil
@@ -751,7 +751,7 @@ func rewrite(commandsForFile commandsForFile) *rewriteResult {
 			absPkg = stdinPackageName
 		}
 
-		targets, err := expandTargets(f, pkg, rule)
+		targets, err := expandTargets(f, rule)
 		if err != nil {
 			cerr := commandError(commands, target, err)
 			errs = append(errs, cerr)

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -212,7 +212,7 @@ func cmdNew(env CmdEnvironment) (*build.File, error) {
 		return nil, err
 	}
 
-	if FindRuleByName(env.File, name) != nil {
+	if FindRuleByName(env.File, "", name) != nil {
 		return nil, fmt.Errorf("rule '%s' already exists", name)
 	}
 
@@ -479,7 +479,7 @@ func cmdCopyNoOverwrite(env CmdEnvironment) (*build.File, error) {
 }
 
 func copyAttributeBetweenRules(env CmdEnvironment, attrName string, from string) (*build.File, error) {
-	fromRule := FindRuleByName(env.File, from)
+	fromRule := FindRuleByName(env.File, "", from)
 	if fromRule == nil {
 		return nil, fmt.Errorf("could not find rule '%s'", from)
 	}
@@ -537,8 +537,8 @@ var AllCommands = map[string]CommandInfo{
 	"copy_no_overwrite":  {cmdCopyNoOverwrite, 2, 2, "<attr> <from_rule>"},
 }
 
-func expandTargets(f *build.File, rule string) ([]*build.Rule, error) {
-	if r := FindRuleByName(f, rule); r != nil {
+func expandTargets(f *build.File, pkg string, rule string) ([]*build.Rule, error) {
+	if r := FindRuleByName(f, pkg, rule); r != nil {
 		return []*build.Rule{r}, nil
 	} else if r := FindExportedFile(f, rule); r != nil {
 		return []*build.Rule{r}, nil
@@ -751,7 +751,7 @@ func rewrite(commandsForFile commandsForFile) *rewriteResult {
 			absPkg = stdinPackageName
 		}
 
-		targets, err := expandTargets(f, rule)
+		targets, err := expandTargets(f, pkg, rule)
 		if err != nil {
 			cerr := commandError(commands, target, err)
 			errs = append(errs, cerr)

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -262,10 +262,10 @@ func FindRuleByName(f *build.File, name string) *build.Rule {
 
 // UseImplicitName returns the rule in the file if it meets these conditions:
 // - It is the only unnamed rule in the file.
-// - The ending directory in the file path and passed rule name match.
+// - The file path's ending directory name and the passed rule name match.
 func UseImplicitName(f *build.File, rule string) *build.Rule {
 	// We disallow empty names
-  if f.Path == "BUILD" {
+	if f.Path == "BUILD" {
 		return nil
 	}
 	ruleCount := 0

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -261,10 +261,11 @@ func FindRuleByName(f *build.File, name string) *build.Rule {
 }
 
 // UseImplicitName returns the rule in the file if it meets these conditions:
-// - It is the only rule in the file.
-// - The passed package and rule names match.
+// - It is the only unnamed rule in the file.
+// - The ending directory in the file path and passed rule name match.
 func UseImplicitName(f *build.File, rule string) *build.Rule {
-	if f.Path == "BUILD" {
+	// We disallow empty names
+  if f.Path == "BUILD" {
 		return nil
 	}
 	ruleCount := 0

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -260,7 +260,9 @@ func FindRuleByName(f *build.File, name string) *build.Rule {
 	return UseImplicitName(f, name)
 }
 
-// UseImplicitName returns the rule in the file if it meets these conditions:
+// In the Pants Build System, by pantsbuild, the use of an implicit name makes
+// creating targets easier. Therefore, for the smoother integration of Buildozer into
+// Pants, UseImplicitName returns the rule in the file if it meets these conditions:
 // - It is the only unnamed rule in the file.
 // - The file path's ending directory name and the passed rule name match.
 func UseImplicitName(f *build.File, rule string) *build.Rule {

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -174,18 +174,20 @@ func TestAddValueToListAttribute(t *testing.T) {
 }
 
 func TestUseImplicitName(t *testing.T) {
+  // TODO: add the description
 	tests := []struct {
+    description      string
 		input            string
 		expectedRuleLine int
 		wantErr          bool
 		wantRootErr      bool
 	}{
-		{`rule()`, 1, false, false},
-		{`rule(name="a")
+		{``, `rule()`, 1, false, false},
+		{``, `rule(name="a")
 		  rule(name="b")
 		  rule()`, 3, false, false},
-		{`rule() rule() rule()`, 1, true, false},
-		{`rule()`, 1, true, true},
+		{``, `rule() rule() rule()`, 1, true, false},
+		{``, `rule()`, 1, true, true},
 	}
 
 	for _, tst := range tests {
@@ -195,7 +197,9 @@ func TestUseImplicitName(t *testing.T) {
 		}
 		bld, err := build.Parse(path, []byte(tst.input))
 		if err != nil {
-			t.Error(err)
+			t.Error("TODO: some sort of description", err)
+      // TODO: what about combining this error down below? No that doesn't make
+      // sens
 			continue
 		}
 		got := UseImplicitName(bld, "foo")
@@ -207,7 +211,10 @@ func TestUseImplicitName(t *testing.T) {
 			}
 		} else {
 			if got != nil {
-				t.Errorf("UseImplicitName(%s): got %s, expected nil", tst.input, got)
+      // render tst.description in the formatted string as well
+      // TODO: new line ugly?
+      // TODO: fix to tabs in VS Code
+				t.Errorf("%s \n UseImplicitName(%s): got %s, expected nil", tst.description, tst.input, got)
 			}
 		}
 	}

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -174,20 +174,19 @@ func TestAddValueToListAttribute(t *testing.T) {
 }
 
 func TestUseImplicitName(t *testing.T) {
-  // TODO: add the description
 	tests := []struct {
-    description      string
 		input            string
 		expectedRuleLine int
 		wantErr          bool
 		wantRootErr      bool
+		description      string
 	}{
-		{``, `rule()`, 1, false, false},
-		{``, `rule(name="a")
+		{`rule()`, 1, false, false, `Use an implicit name for one rule.`},
+		{`rule(name="a")
 		  rule(name="b")
-		  rule()`, 3, false, false},
-		{``, `rule() rule() rule()`, 1, true, false},
-		{``, `rule()`, 1, true, true},
+		  rule()`, 3, false, false, `Use an implicit name for the one unnamed rule`},
+		{`rule() rule() rule()`, 1, true, false, `Error for multiple unnamed rules`},
+		{`rule()`, 1, true, true, `Error for the root package`},
 	}
 
 	for _, tst := range tests {
@@ -197,9 +196,7 @@ func TestUseImplicitName(t *testing.T) {
 		}
 		bld, err := build.Parse(path, []byte(tst.input))
 		if err != nil {
-			t.Error("TODO: some sort of description", err)
-      // TODO: what about combining this error down below? No that doesn't make
-      // sens
+			t.Error(tst.description, err)
 			continue
 		}
 		got := UseImplicitName(bld, "foo")
@@ -207,14 +204,11 @@ func TestUseImplicitName(t *testing.T) {
 		if !tst.wantErr {
 			want := bld.RuleAt(tst.expectedRuleLine)
 			if got.Kind() != want.Kind() || got.Name() != want.Name() {
-				t.Errorf("UseImplicitName(%s): got %s, expected %s", tst.input, got, want)
+				t.Errorf("UseImplicitName(%s): got %s, expected %s. %s", tst.input, got, want, tst.description)
 			}
 		} else {
 			if got != nil {
-      // render tst.description in the formatted string as well
-      // TODO: new line ugly?
-      // TODO: fix to tabs in VS Code
-				t.Errorf("%s \n UseImplicitName(%s): got %s, expected nil", tst.description, tst.input, got)
+				t.Errorf("UseImplicitName(%s): got %s, expected nil. %s", tst.input, got, tst.description)
 			}
 		}
 	}


### PR DESCRIPTION
It would be nice to have implicit name recognition to support the smooth integration of buildozer into Pants at Twitter. This allows for target granularity by making targets easier to create. With a [1:1:1 rule](https://www.pantsbuild.org/build_files.html#target-granularity), for one target per directory, the target can implicitly use the directory name.

This code change supports this behavior:

```
When trying to find target //foo/bar/baz:baz
if foo/bar/baz/BUILD does not contain any target with attribute name="baz":
  if foo/bar/baz/BUILD contains exactly one target with no name attribute:
    treat that target as //foo/bar/baz:baz
```

Original proposal: https://github.com/bazelbuild/buildtools/issues/148

**To verify**
Setup a `tmp` directory with a BUILD file that has only one nameless target. Try and confirm:
`./buildozer 'add dependencies a/b' tmp:tmp`

@illicitonion @wisechengyi