### PR TITLE
Allow tables.json to configure label default behaviour to strip leading //

### DIFF
--- a/build/testdata/049.golden
+++ b/build/testdata/049.golden
@@ -1,0 +1,9 @@
+cc_library(
+    name = "foo",
+    deps = [
+        "yet/another:dep",
+        ":bar",
+        "//some:dep",
+        "//some/other/dep",
+    ],
+)

--- a/build/testdata/049.in
+++ b/build/testdata/049.in
@@ -1,0 +1,9 @@
+cc_library(
+    name = "foo",
+    deps = [
+        "yet/another:dep",
+        "//some/other/dep",
+        ":bar",
+        "//some:dep",
+    ],
+)

--- a/build/testdata/049.stripslashes.golden
+++ b/build/testdata/049.stripslashes.golden
@@ -1,0 +1,9 @@
+cc_library(
+    name = "foo",
+    deps = [
+        ":bar",
+        "some:dep",
+        "some/other/dep",
+        "yet/another:dep",
+    ],
+)

--- a/tables/jsonparser.go
+++ b/tables/jsonparser.go
@@ -28,6 +28,7 @@ type Definitions struct {
 	SortableBlacklist map[string]bool
 	SortableWhitelist map[string]bool
 	NamePriority      map[string]int
+	StripLabelLeadingSlashes bool
 }
 
 // ParseJSONDefinitions reads and parses JSON table definitions from file.
@@ -52,9 +53,9 @@ func ParseAndUpdateJSONDefinitions(file string, merge bool) error {
 	}
 
 	if merge {
-		MergeTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority)
+		MergeTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority, definitions.StripLabelLeadingSlashes)
 	} else {
-		OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority)
+		OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority, definitions.StripLabelLeadingSlashes)
 	}
 	return nil
 }

--- a/tables/jsonparser_test.go
+++ b/tables/jsonparser_test.go
@@ -36,6 +36,7 @@ func TestParseJSONDefinitions(t *testing.T) {
 		SortableBlacklist: map[string]bool{"genrule.srcs": true},
 		SortableWhitelist: map[string]bool{},
 		NamePriority:      map[string]int{"name": -1},
+		StripLabelLeadingSlashes: true,
 	}
 	if !reflect.DeepEqual(expected, definitions) {
 		t.Errorf("ParseJSONDefinitions() = %v; want %v", definitions, expected)

--- a/tables/tables.go
+++ b/tables/tables.go
@@ -196,18 +196,21 @@ var NamePriority = map[string]int{
 	"alwayslink":     7,
 }
 
+var StripLabelLeadingSlashes = false
+
 // OverrideTables allows a user of the build package to override the special-case rules. The user-provided tables replace the built-in tables.
-func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int) {
+func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes bool) {
 	IsLabelArg = labelArg
 	LabelBlacklist = blacklist
 	IsSortableListArg = sortableListArg
 	SortableBlacklist = sortBlacklist
 	SortableWhitelist = sortWhitelist
 	NamePriority = namePriority
+	StripLabelLeadingSlashes = stripLabelLeadingSlashes
 }
 
 // MergeTables allows a user of the build package to override the special-case rules. The user-provided tables are merged into the built-in tables.
-func MergeTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int) {
+func MergeTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes bool) {
 	for k, v := range labelArg {
 		IsLabelArg[k] = v
 	}
@@ -226,4 +229,5 @@ func MergeTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitel
 	for k, v := range namePriority {
 		NamePriority[k] = v
 	}
+	StripLabelLeadingSlashes = stripLabelLeadingSlashes || StripLabelLeadingSlashes;
 }

--- a/tables/testdata/simple_tables.json
+++ b/tables/testdata/simple_tables.json
@@ -18,5 +18,6 @@
   },
   "NamePriority": {
     "name": -1
-  }
+  },
+  "StripLabelLeadingSlashes": true
 }


### PR DESCRIPTION
Pants has this behaviour. This is completely configurable through tables.json, so shouldn't affect anyone who doesn't want this behaviour.

Also, treat //foo:bar to be equivalent to :bar in foo/BUILD

The three commits should be usefully independently reviewable.