### PR TITLE
Allow buildozer to edit arbitrary files

### DIFF
--- a/build/syntax.go
+++ b/build/syntax.go
@@ -234,14 +234,14 @@ func (x *IfClause) Span() (start, end Position) {
 // if expressions: for ... in ... [if ... if ...]
 type ForClauseWithIfClausesOpt struct {
 	Comments
-	For  *ForClause
-	Ifs  []*IfClause
+	For *ForClause
+	Ifs []*IfClause
 }
 
 func (x *ForClauseWithIfClausesOpt) Span() (start, end Position) {
 	start, end = x.For.Span()
 	if len(x.Ifs) > 0 {
-		_, end = x.Ifs[len(x.Ifs) - 1].Span()
+		_, end = x.Ifs[len(x.Ifs)-1].Span()
 	}
 
 	return start, end

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -281,11 +281,11 @@ func FindRuleByName(f *build.File, name string) *build.Rule {
 	return UseImplicitName(f, name)
 }
 
-// In the Pants Build System, by pantsbuild, the use of an implicit name makes
-// creating targets easier. Therefore, for the smoother integration of Buildozer into
-// Pants, UseImplicitName returns the rule in the file if it meets these conditions:
+// UseImplicitName returns the rule in the file if it meets these conditions:
 // - It is the only unnamed rule in the file.
 // - The file path's ending directory name and the passed rule name match.
+// In the Pants Build System, by pantsbuild, the use of an implicit name makes
+// creating targets easier. This function implements such names.
 func UseImplicitName(f *build.File, rule string) *build.Rule {
 	// We disallow empty names
 	if f.Path == "BUILD" {

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -38,6 +38,7 @@ var parseLabelTests = []struct {
 	{"@foo", "foo", "", "foo"},
 	{":label", "", "", "label"},
 	{"label", "", "", "label"},
+	{"/abs/path/to/WORKSPACE:rule", "", "/abs/path/to/WORKSPACE", "rule"},
 }
 
 func TestParseLabel(t *testing.T) {


### PR DESCRIPTION
This is useful for WORKSPACE files in particular, eg:

`buildozer 'print name' WORKSPACE:%http_archive`

Make sure that ParseLabel doesn't interfere with absolute paths to
support this overloading.