### PR TITLE
Fix differ and make buildifier build on Windows.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("github.com/bazelbuild/buildtools")
 
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
 test_suite(
     name = "tests",
     tests = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,8 +31,3 @@ http_archive(
     ],
 )
 
-go_repository(
-    name = "org_golang_x_tools",
-    commit = "3d92dd60033c312e3ae7cac319c792271cf67e37",
-    importpath = "golang.org/x/tools",
-)

--- a/differ/BUILD.bazel
+++ b/differ/BUILD.bazel
@@ -4,9 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = [
         "diff.go",
-        "isatty_other.go",
-        # When go_library() supports build constraints, add isatty_windows.go
-        # here.
-    ],
+    ] + select({
+        "//:windows": ["isatty_windows.go"],
+        "//conditions:default": ["isatty_other.go"],
+    }),
     visibility = ["//visibility:public"],
 )

--- a/differ/diff.go
+++ b/differ/diff.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -41,7 +42,12 @@ func (d *Differ) run(command string, args ...string) {
 	}
 
 	// Pass args to bash and reference with $@ to avoid shell injection in args.
-	cmd := exec.Command("/bin/bash", "-c", command+` "$@"`, "--")
+	var cmd *exec.Cmd
+	if command == "FC" {
+		cmd = exec.Command(command, "/T")
+	} else {
+		cmd = exec.Command("/bin/bash", "-c", command+` "$@"`, "--")
+	}
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -111,7 +117,11 @@ func Find() *Differ {
 		if d.MultiDiff {
 			d.Cmd = "tkdiff"
 		} else {
-			d.Cmd = "diff"
+			if runtime.GOOS == "windows" {
+				d.Cmd = "FC"
+			} else {
+				d.Cmd = "diff"
+			}
 		}
 	}
 	return d


### PR DESCRIPTION
- Uses `FC` to diff on Windows by default.
- Adds `config_setting` to use `isatty_windows.go` on Windows
- Removes `go_repository` rule that fails on Windows

Fixes: #137
Test: Built and ran `buildifier <file>` and `buildifier -d <file>` on both Windows and Linux