### PR TITLE
Don't consider load() as an implicit rule

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -270,6 +270,8 @@ func InsertAtEnd(stmt []build.Expr, expr build.Expr) []build.Expr {
 
 // FindRuleByName returns the rule in the file that has the given name.
 // If the name is "__pkg__", it returns the global package declaration.
+// If the name is that of the package and the file contains a single unnamed
+// rule, the unnamed rule is returned. (Implicit Naming)
 func FindRuleByName(f *build.File, name string) *build.Rule {
 	if name == "__pkg__" {
 		return PackageDeclaration(f)
@@ -294,6 +296,10 @@ func UseImplicitName(f *build.File, rule string) *build.Rule {
 	ruleCount := 0
 	var temp, found *build.Rule
 	pkg := filepath.Base(filepath.Dir(f.Path))
+	invalidKinds := map[string]bool{
+		"":     true,
+		"load": true,
+	}
 
 	for _, stmt := range f.Stmt {
 		call, ok := stmt.(*build.CallExpr)
@@ -301,7 +307,7 @@ func UseImplicitName(f *build.File, rule string) *build.Rule {
 			continue
 		}
 		temp = &build.Rule{Call: call}
-		if temp.Kind() != "" && temp.Name() == "" {
+		if !invalidKinds[temp.Kind()] && temp.Name() == "" {
 			ruleCount++
 			found = temp
 		}

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -188,6 +188,7 @@ func TestUseImplicitName(t *testing.T) {
 		  rule()`, 3, false, false, `Use an implicit name for the one unnamed rule`},
 		{`rule() rule() rule()`, 1, true, false, `Error for multiple unnamed rules`},
 		{`rule()`, 1, true, true, `Error for the root package`},
+		{`load()`, 1, true, false, `Error for load statement`},
 	}
 
 	for _, tst := range tests {


### PR DESCRIPTION
Fixes #165.

Also amend the documentation of FindRuleByName to explain its behaviour
in the presence of implicitly-named rules.