### PR TITLE
buildozer: add `-tables` flag to load tables.json from file

### DIFF
--- a/buildozer/main.go
+++ b/buildozer/main.go
@@ -16,10 +16,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/bazelbuild/buildtools/edit"
+	"github.com/bazelbuild/buildtools/tables"
 )
 
 var (
@@ -35,6 +37,7 @@ var (
 	quiet             = flag.Bool("quiet", false, "suppress informational messages")
 	editVariables     = flag.Bool("edit-variables", false, "For attributes that simply assign a variable (e.g. hdrs = LIB_HDRS), edit the build variable instead of appending to the attribute.")
 	isPrintingProto   = flag.Bool("output_proto", false, "output serialized devtools.buildozer.Output protos instead of human-readable strings.")
+	tablesPath        = flag.String("tables", "", "path to JSON file with custom table definitions which will replace the built-in tables")
 
 	shortenLabelsFlag  = flag.Bool("shorten_labels", true, "convert added labels to short form, e.g. //foo:bar => :bar")
 	deleteWithComments = flag.Bool("delete_with_comments", true, "If a list attribute should be deleted even if there is a comment attached to it")
@@ -56,6 +59,13 @@ func stringList(name, help string) func() []string {
 
 func main() {
 	flag.Parse()
+
+	if *tablesPath != "" {
+		if err := tables.ParseAndUpdateJSONDefinitions(*tablesPath, false); err != nil {
+			fmt.Fprintf(os.Stderr, "buildifier: failed to parse %s for -tables: %s\n", *tablesPath, err)
+			os.Exit(2)
+		}
+	}
 
 	edit.ShortenLabelsFlag = *shortenLabelsFlag
 	edit.DeleteWithComments = *deleteWithComments


### PR DESCRIPTION
This adds an equivalent flag from buildifier to buildozer to load the tables from a custom JSON-encoded path.