### PR TITLE
buildozer: add command line flag to override build file names

### DIFF
--- a/buildozer/main.go
+++ b/buildozer/main.go
@@ -38,6 +38,7 @@ var (
 
 	shortenLabelsFlag  = flag.Bool("shorten_labels", true, "convert added labels to short form, e.g. //foo:bar => :bar")
 	deleteWithComments = flag.Bool("delete_with_comments", true, "If a list attribute should be deleted even if there is a comment attached to it")
+	buildFiles         = stringList("build-files", "comma-separated list of build file names")
 )
 
 func stringList(name, help string) func() []string {
@@ -72,6 +73,7 @@ func main() {
 		Quiet:             *quiet,
 		EditVariables:     *editVariables,
 		IsPrintingProto:   *isPrintingProto,
+		BuildFileNames:    buildFiles(),
 	}
 	os.Exit(edit.Buildozer(flag.Args()))
 }


### PR DESCRIPTION
Lots of places in the code still assume BUILD is the build file name, as such
this is mainly useful to add additional build file names.