### PR TITLE
Fix paths for build files inside packages

### DIFF
--- a/wspace/workspace.go
+++ b/wspace/workspace.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
 )
@@ -91,10 +92,12 @@ func FindRepoBuildFiles(root string) (map[string]string, error) {
 	files := make(map[string]string)
 	for _, kind := range kinds {
 		for _, r := range ast.Rules(kind) {
-			if r.AttrString("build_file") == "" {
+			buildFile := r.AttrString("build_file")
+			if buildFile == "" {
 				continue
 			}
-			files[r.Name()] = filepath.Join(root, r.AttrString("build_file"))
+			buildFile = strings.Replace(buildFile, ":", "/", -1)
+			files[r.Name()] = filepath.Join(root, buildFile)
 		}
 	}
 	return files, nil

--- a/wspace/workspace_test.go
+++ b/wspace/workspace_test.go
@@ -90,6 +90,10 @@ new_git_repository(
     name = "e",
     build_file_content = "n/a",
 )
+new_http_archive(
+    name = "f",
+    build_file = "//third_party:f.BUILD",
+)
 `)
 	if err := ioutil.WriteFile(filepath.Join(tmp, workspaceFile), workspace, 0755); err != nil {
 		t.Fatal(err)
@@ -102,6 +106,7 @@ new_git_repository(
 		"a": filepath.Join(tmp, "a.BUILD"),
 		"b": filepath.Join(tmp, "b.BUILD"),
 		"c": filepath.Join(tmp, "c.BUILD"),
+		"f": filepath.Join(tmp, "third_party/f.BUILD"),
 	}
 	if !reflect.DeepEqual(files, expected) {
 		t.Errorf("FileRepoBuildFiles(`%s`) = %q; want %q", workspace, files, expected)


### PR DESCRIPTION
Before, this would break with:
  File not found: /path/to/workspace/third_party:repo.BUILD