### PR TITLE
Don't strip // prefix for targets in the root BUILD file

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -212,8 +212,10 @@ func fixLabels(f *File, info *RewriteInfo) {
 		editPerformed := false
 
 		if tables.StripLabelLeadingSlashes && strings.HasPrefix(str.Value, "//") {
-			editPerformed = true
-			str.Value = str.Value[2:]
+			if path.Dir(f.Path) == "." || !strings.HasPrefix(str.Value, "//:") {
+				editPerformed = true
+				str.Value = str.Value[2:]
+			}
 		}
 
 		if tables.ShortenAbsoluteLabelsToRelative {

--- a/build/testdata/050.golden
+++ b/build/testdata/050.golden
@@ -3,5 +3,6 @@ cc_library(
     deps = [
         "testdata",
         ":testdata",
+        "//:root",
     ],
 )

--- a/build/testdata/050.in
+++ b/build/testdata/050.in
@@ -5,5 +5,6 @@ cc_library(
         "testdata",
         "//testdata",
         "//testdata:testdata",
+	"//:root",
     ],
 )

--- a/build/testdata/050.stripslashes.golden
+++ b/build/testdata/050.stripslashes.golden
@@ -1,4 +1,7 @@
 cc_library(
     name = "foo",
-    deps = [":testdata"],
+    deps = [
+        ":testdata",
+        "//:root",
+    ],
 )


### PR DESCRIPTION
Unless the current BUILD file is in the root directory.