### PR TITLE
Rollback change related to --stdout

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -723,8 +723,7 @@ func rewrite(commandsForFile commandsForFile) *rewriteResult {
 			}
 		}
 	}
-	stdout := Opts.Stdout || name == stdinPackageName // True if we write to stdout instead of a file.
-	if !changed && !stdout {
+	if !changed {
 		return &rewriteResult{file: name, errs: errs, records: records}
 	}
 	f = RemoveEmptyPackage(f)
@@ -733,7 +732,7 @@ func rewrite(commandsForFile commandsForFile) *rewriteResult {
 		return &rewriteResult{file: name, errs: []error{fmt.Errorf("running buildifier: %v", err)}, records: records}
 	}
 
-	if stdout { // print, even if the AST hasn't changed
+	if Opts.Stdout || name == stdinPackageName {
 		os.Stdout.Write(ndata)
 		return &rewriteResult{file: name, errs: errs, records: records}
 	}


### PR DESCRIPTION
This was breaking some workflow: when using the print command, you
expect this is the only thing on stdout (with the change, the whole file
was printed as well).