### PR TITLE
Disable the UseImplicitName feature.

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -278,7 +278,7 @@ func FindRuleByName(f *build.File, name string) *build.Rule {
 	if i != -1 {
 		return &build.Rule{Call: f.Stmt[i].(*build.CallExpr)}
 	}
-	return UseImplicitName(f, name)
+	return nil
 }
 
 // UseImplicitName returns the rule in the file if it meets these conditions:


### PR DESCRIPTION
This modifies the behavior of Buildozer and breaks existing users. Once
the depot is in a more stable state, we can try to reintroduce this
feature (maybe with a special syntax?).