### PR TITLE
Add merge and copy_merge functionality

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -109,6 +109,9 @@ Buildozer supports the following commands(`'command args'`):
     exists in the `to_rule`, it will be overwritten.
   * `copy_no_overwrite <attr> <from_rule>`:  Copies the value of `attr` between
     rules. If it exists in the `to_rule`, no action is taken.
+  * `copy_merge <attr> <from_rule>`:  Copies the value of `attr` between
+    rules. If it exists in the `to_rule`, values from both rules are merged.
+  * `merge <from_rule>`:  Merges all attributes between rules.
 
 Here, `<attr>` represents an attribute (being `add`ed/`rename`d/`delete`d etc.),
 e.g.: `srcs`, `<value(s)>` represents values of the attribute and so on.
@@ -155,6 +158,12 @@ buildozer 'new cc_binary new_bin before tests' //:__pkg__
 
 # Copy an attribute from `protolib` to `py_protolib`.
 buildozer 'copy testonly protolib' //pkg:py_protolib
+
+# Merge an attribute from `protolib` to `py_protolib`.
+buildozer 'copy_merge testonly protolib' //pkg:py_protolib
+
+# Merge rule `protolib` to `py_protolib`.
+buildozer 'merge protolib' //pkg:py_protolib
 
 # Set two attributes in the same rule
 buildozer 'set compile 1' 'set srcmap 1' //pkg:rule

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -438,6 +438,39 @@ func copyAttributeBetweenRules(env CmdEnvironment, attrName string, from string)
 	return env.File, nil
 }
 
+func cmdCopyMerge(env CmdEnvironment) (*build.File, error) {
+	attrName := env.Args[0]
+	from := env.Args[1]
+
+     fromRule := FindRuleByName(env.File, from)
+	if fromRule == nil {
+		return nil, fmt.Errorf("could not find rule '%s'", from)
+	}
+	attr := fromRule.Attr(attrName)
+	if attr == nil {
+		return nil, fmt.Errorf("rule '%s' does not have attribute '%s'", from, attrName)
+	}
+
+     MergeAllListAttributeValues(fromRule, env.Rule, attrName, env.Pkg, &env.Vars)
+
+	return env.File, nil
+}
+
+func cmdMerge(env CmdEnvironment) (*build.File, error) {
+	from := env.Args[0]
+
+     fromRule := FindRuleByName(env.File, from)
+	if fromRule == nil {
+		return nil, fmt.Errorf("could not find rule '%s'", from)
+	}
+
+     for _, attrName := range attrKeysForPattern(fromRule, "*") {
+          MergeAllListAttributeValues(fromRule, env.Rule, attrName, env.Pkg, &env.Vars)
+	}
+
+	return env.File, nil
+}
+
 func cmdFix(env CmdEnvironment) (*build.File, error) {
 	// Fix the whole file
 	if env.Rule.Kind() == "package" {
@@ -472,6 +505,8 @@ var AllCommands = map[string]CommandInfo{
 	"replace":           {cmdReplace, 3, 3, "<attr> <old_value> <new_value>"},
 	"set":               {cmdSet, 2, -1, "<attr> <value(s)>"},
 	"set_if_absent":     {cmdSetIfAbsent, 2, -1, "<attr> <value(s)>"},
+	"copy":              {cmdCopy, 2, 2, "<attr> <from_rule>"},
+	"copy_no_overwrite": {cmdCopyNoOverwrite, 2, 2, "<attr> <from_rule>"},
 	"copy":              {cmdCopy, 2, 2, "<attr> <from_rule>"},
 	"copy_no_overwrite": {cmdCopyNoOverwrite, 2, 2, "<attr> <from_rule>"},
 }

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -652,6 +652,21 @@ func MoveAllListAttributeValues(rule *build.Rule, oldAttr, newAttr, pkg string, 
 	return fmt.Errorf("%s already exists and %s is not a simple list", newAttr, oldAttr)
 }
 
+// MergeAllListAttributeValues merges all values from one rule's list attribute attr to another rule's list attribute attr,
+// and keeps original rule's attr.
+func MergeAllListAttributeValues(origRule *build.Rule, destRule *build.Rule, attr, pkg string, vars *map[string]*build.BinaryExpr) error {
+	if origRule.Attr(attr) == nil {
+		return fmt.Errorf("no attribute %s found in %s", attr, origRule.Name())
+	}
+	if listExpr, ok := origRule.Attr(attr).(*build.ListExpr); ok {
+		for _, val := range listExpr.List {
+			AddValueToListAttribute(destRule, attr, pkg, val, vars)
+		}
+		return nil
+	}
+	return fmt.Errorf("%s already exists and %s is not a simple list", attr, attr)
+}
+
 // DictionarySet looks for the key in the dictionary expression. If value is not nil,
 // it replaces the current value with it. In all cases, it returns the current value.
 func DictionarySet(dict *build.DictExpr, key string, value build.Expr) build.Expr {


### PR DESCRIPTION
Added the following functionality:

- copy_merge: Works similar to copy, but the attribute values are merged together instead of being replaced.
- merge: Merges all attributes between two rules.
