### PR TITLE
Allow overriding IsList via -tables

### DIFF
--- a/edit/BUILD.bazel
+++ b/edit/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//build_proto:go_default_library",
         "//file:go_default_library",
         "//lang:go_default_library",
+        "//tables:go_default_library",
         "//wspace:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],

--- a/edit/types.go
+++ b/edit/types.go
@@ -17,12 +17,22 @@ package edit
 import (
 	buildpb "github.com/bazelbuild/buildtools/build_proto"
 	"github.com/bazelbuild/buildtools/lang"
+	"github.com/bazelbuild/buildtools/tables"
 )
 
 var typeOf = lang.TypeOf
 
 // IsList returns true for all attributes whose type is a list.
 func IsList(attr string) bool {
+	overrideValue, isOverridden := tables.IsListArg[attr]
+	if (isOverridden) {
+		return overrideValue
+	}
+	// It stands to reason that a sortable list must be a list.
+	isSortableList := tables.IsSortableListArg[attr]
+	if (isSortableList) {
+		return true
+	}
 	ty := typeOf[attr]
 	return ty == buildpb.Attribute_STRING_LIST ||
 		ty == buildpb.Attribute_LABEL_LIST ||

--- a/tables/jsonparser.go
+++ b/tables/jsonparser.go
@@ -24,6 +24,7 @@ import (
 type Definitions struct {
 	IsLabelArg                      map[string]bool
 	LabelBlacklist                  map[string]bool
+	IsListArg                       map[string]bool
 	IsSortableListArg               map[string]bool
 	SortableBlacklist               map[string]bool
 	SortableWhitelist               map[string]bool
@@ -54,9 +55,9 @@ func ParseAndUpdateJSONDefinitions(file string, merge bool) error {
 	}
 
 	if merge {
-		MergeTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority, definitions.StripLabelLeadingSlashes, definitions.ShortenAbsoluteLabelsToRelative)
+		MergeTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsListArg, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority, definitions.StripLabelLeadingSlashes, definitions.ShortenAbsoluteLabelsToRelative)
 	} else {
-		OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority, definitions.StripLabelLeadingSlashes, definitions.ShortenAbsoluteLabelsToRelative)
+		OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsListArg, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist, definitions.NamePriority, definitions.StripLabelLeadingSlashes, definitions.ShortenAbsoluteLabelsToRelative)
 	}
 	return nil
 }

--- a/tables/tables.go
+++ b/tables/tables.go
@@ -97,6 +97,12 @@ var LabelBlacklist = map[string]bool{
 	"package_group.includes": true,
 }
 
+// By default, edit.types.IsList consults lang.TypeOf to determine if an arg is a list.
+// You may override this using IsListArg. Specifying a name here overrides any value
+// in lang.TypeOf.
+var IsListArg = map[string]bool{
+}
+
 // IsSortableListArg: a named argument to a rule call is considered to be a sortable list
 // if the name is one of these names. There is a separate blacklist for
 // rule-specific exceptions.
@@ -201,9 +207,10 @@ var StripLabelLeadingSlashes = false
 var ShortenAbsoluteLabelsToRelative = false
 
 // OverrideTables allows a user of the build package to override the special-case rules. The user-provided tables replace the built-in tables.
-func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes, shortenAbsoluteLabelsToRelative bool) {
+func OverrideTables(labelArg, blacklist, listArg, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes, shortenAbsoluteLabelsToRelative bool) {
 	IsLabelArg = labelArg
 	LabelBlacklist = blacklist
+	IsListArg = listArg
 	IsSortableListArg = sortableListArg
 	SortableBlacklist = sortBlacklist
 	SortableWhitelist = sortWhitelist
@@ -213,12 +220,15 @@ func OverrideTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhi
 }
 
 // MergeTables allows a user of the build package to override the special-case rules. The user-provided tables are merged into the built-in tables.
-func MergeTables(labelArg, blacklist, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes, shortenAbsoluteLabelsToRelative bool) {
+func MergeTables(labelArg, blacklist, listArg, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes, shortenAbsoluteLabelsToRelative bool) {
 	for k, v := range labelArg {
 		IsLabelArg[k] = v
 	}
 	for k, v := range blacklist {
 		LabelBlacklist[k] = v
+	}
+	for k, v := range listArg {
+		IsListArg[k] = v
 	}
 	for k, v := range sortableListArg {
 		IsSortableListArg[k] = v


### PR DESCRIPTION
The default implementation of `edit.types.IsList` consults `lang.tables.TypeOf`. This means that the definition of whether a given label represents a list argument is essentially hardcoded into buildifier and buildozer.

Some consumers may wish to customize this value for certain labels. Introduce a feature that allows you to override the default value using the tables feature.