### PR TITLE
Fix end statement tracking

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -60,6 +60,11 @@ type input struct {
 }
 
 func newInput(filename string, data []byte) *input {
+	// The syntax requires that each simple statement ends with '\n', however it's optional at EOF.
+	// If `data` doesn't end with '\n' we add it here to keep parser simple.
+	// It shouldn't affect neither the parsed tree nor its formatting.
+	data = append(data, '\n')
+
 	return &input{
 		filename:  filename,
 		complete:  data,
@@ -67,6 +72,7 @@ func newInput(filename string, data []byte) *input {
 		pos:       Position{Line: 1, LineRune: 1, Byte: 0},
 		cleanLine: true,
 		indents:   []int{0},
+		endStmt:   -1, // -1 denotes it's not inside a statement
 	}
 }
 
@@ -190,24 +196,13 @@ func (in *input) Lex(val *yySymType) int {
 		//  # Actual indentation is from 0 to 2 spaces here
 		//  return x
 		//
-		// If the --format_bzl flag is set to false, for legacy reason we track the end of each
-		// code block defined at the top level instead the end of the current statement.
+		// To handle this case, when we reach the beginning of a statement  we scan forward to see where
+		// it should end and record the number of input bytes remaining at that endpoint.
 		//
-		// To handle these cases, when we reach the beginning of a statement (or
-		// top-level code block), we scan forward to see where
-		// it should end and record the number of input bytes remaining
-		// at that endpoint. When we reach that point in the input, we
-		// insert an implicit semicolon to force the two expressions
-		// to stay separate (only if --format_bzl is set to false, for legacy reasons).
-		// We also set in.endStmt = 0 as a signal that we nee to track indentation levels.
-		//
-		if in.endStmt != 0 && len(in.remaining) == in.endStmt {
-			in.endStmt = 0
-			if !tables.FormatBzlFiles {
-				in.lastToken = "implicit ;"
-				val.tok = ";"
-				return ';'
-			}
+		// If --format_bzl is set to false, top level blocks (e.g. an entire function definition)
+		// is considered as a single statement.
+		if in.endStmt != -1 && len(in.remaining) == in.endStmt {
+			in.endStmt = -1
 		}
 
 		// Skip over spaces. Count newlines so we can give the parser
@@ -218,7 +213,7 @@ func (in *input) Lex(val *yySymType) int {
 			if c == '\n' {
 				in.indent = 0
 				in.cleanLine = true
-				if in.endStmt == 0 {
+				if in.endStmt == -1 {
 					// Not in a statememt. Tell parser about top-level blank line.
 					in.startToken(val)
 					in.readRune()
@@ -256,10 +251,12 @@ func (in *input) Lex(val *yySymType) int {
 				isSuffix = false
 			}
 
-			// Consume comment.
+			// Consume comment without the \n it ends with.
 			in.startToken(val)
-			for len(in.remaining) > 0 && in.readRune() != '\n' {
+			for len(in.remaining) > 0 && in.peekRune() != '\n' {
+				in.readRune()
 			}
+
 			in.endToken(val)
 
 			val.tok = strings.TrimRight(val.tok, "\n")
@@ -268,7 +265,7 @@ func (in *input) Lex(val *yySymType) int {
 			// If we are at top level (not in a rule), hand the comment to
 			// the parser as a _COMMENT token. The grammar is written
 			// to handle top-level comments itself.
-			if in.endStmt == 0 {
+			if in.endStmt == -1 {
 				// Not in a statement. Tell parser about top-level comment.
 				return _COMMENT
 			}
@@ -278,12 +275,13 @@ func (in *input) Lex(val *yySymType) int {
 				in.comments = append(in.comments, Comment{val.pos, "", false})
 			}
 			in.comments = append(in.comments, Comment{val.pos, val.tok, isSuffix})
-			countNL = 1
+			countNL = 0
 			continue
 		}
 
 		if c == '\\' && len(in.remaining) >= 2 && in.remaining[1] == '\n' {
-			// We can ignore a trailing \ at end of line.
+			// We can ignore a trailing \ at end of line together with the \n.
+			in.readRune()
 			in.readRune()
 			continue
 		}
@@ -295,7 +293,7 @@ func (in *input) Lex(val *yySymType) int {
 	// Check for changes in indentation
 	// Skip if --format_bzl is set to false, if we're inside a statement, or if there were non-space
 	// characters before in the current line.
-	if tables.FormatBzlFiles && in.endStmt == 0 && in.cleanLine {
+	if tables.FormatBzlFiles && in.endStmt == -1 && in.cleanLine {
 		if in.indent > in.currentIndent() {
 			// A new indentation block starts
 			in.indents = append(in.indents, in.indent)
@@ -340,13 +338,8 @@ func (in *input) Lex(val *yySymType) int {
 	// If endStmt is 0, we need to recompute where the end
 	// of the next statement is, so that we can
 	// generate a virtual end-of-rule semicolon (see above).
-	if in.endStmt == 0 {
+	if in.endStmt == -1 {
 		in.endStmt = len(in.skipStmt(in.remaining))
-		if in.endStmt == 0 {
-			// skipStmt got confused.
-			// No more virtual semicolons.
-			in.endStmt = -1
-		}
 	}
 
 	// Punctuation tokens.
@@ -557,13 +550,26 @@ func hasPrefixSpace(p []byte, pre string) bool {
 	return true
 }
 
-func isBlankOrComment(b []byte) bool {
+// A utility function for the legacy formatter.
+// Returns whether a given code starts with a top-level statement (maybe with some preceeding
+// comments and blank lines)
+func isOutsideBlock(b []byte) bool {
+	isBlankLine := true
+	isComment := false
 	for _, c := range b {
-		if c == '#' || c == '\n' {
-			return true
-		}
-		if c != ' ' && c != '\t' && c != '\r' {
-			return false
+		switch {
+		case c == ' ' || c == '\t' || c == '\r':
+			isBlankLine = false
+		case c == '#':
+			isBlankLine = false
+			isComment = true
+		case c == '\n':
+			isBlankLine = true
+			isComment = false
+		default:
+			if !isComment {
+				return isBlankLine
+			}
 		}
 	}
 	return true
@@ -633,7 +639,7 @@ func (in *input) skipStmt(p []byte) []byte {
 			continue
 		}
 
-		if depth == 0 && i > 0 && p[i-1] == '\n' && (i < 2 || p[i-2] != '\\') {
+		if depth == 0 && i > 0 && p[i] == '\n' && p[i-1] != '\\' {
 			// Possible stopping point. Save the earliest one we find.
 			if rest == nil {
 				rest = p[i:]
@@ -644,14 +650,15 @@ func (in *input) skipStmt(p []byte) []byte {
 				return rest
 			}
 			// In the legacy mode we need to find where the current block ends
-			if !isBlankOrComment(p[i:]) {
-				if !hasPythonContinuation(p[i:]) && c != ' ' && c != '\t' {
+			if isOutsideBlock(p[i+1:]) {
+				if !hasPythonContinuation(p[i+1:]) && c != ' ' && c != '\t' {
 					// Yes, stop here.
 					return rest
 				}
-				// Not a stopping point after all.
-				rest = nil
 			}
+			// Not a stopping point after all.
+			rest = nil
+
 		}
 
 		switch c {
@@ -660,6 +667,8 @@ func (in *input) skipStmt(p []byte) []byte {
 			for i < len(p) && p[i] != '\n' {
 				i++
 			}
+			// Rewind 1 position back because \n should be handled at the next iteration
+			i--
 
 		case '(', '[', '{':
 			depth++

--- a/build/lex.go
+++ b/build/lex.go
@@ -335,9 +335,7 @@ func (in *input) Lex(val *yySymType) int {
 		return _EOF
 	}
 
-	// If endStmt is 0, we need to recompute where the end
-	// of the next statement is, so that we can
-	// generate a virtual end-of-rule semicolon (see above).
+	// If endStmt is 0, we need to recompute where the end of the next statement is.
 	if in.endStmt == -1 {
 		in.endStmt = len(in.skipStmt(in.remaining))
 	}
@@ -592,8 +590,8 @@ var continuations = []string{
 	"else",
 }
 
-// skipStmt returns the data remaining after the uninterpreted
-// Python block beginning at p. It does not advance the input position.
+// skipStmt returns the data remaining after the statement  beginning at p.
+// It does not advance the input position.
 // (The only reason for the input receiver is to be able to call in.Error.)
 func (in *input) skipStmt(p []byte) []byte {
 	quote := byte(0)     // if non-zero, the kind of quote we're in

--- a/build/parse.y
+++ b/build/parse.y
@@ -198,7 +198,6 @@ stmts:
 		// attach the comments to the statement.
 		if cb, ok := $<lastRule>1.(*CommentBlock); ok {
 			$$ = append($1[:len($1)-1], $2...)
-			//$$[len($1)-1] = $2
 			$2[0].Comment().Before = cb.After
 			$<lastRule>$ = $2[len($2)-1]
 			break

--- a/build/parse.y
+++ b/build/parse.y
@@ -107,13 +107,17 @@ package build
 %type	<expr>		ident
 %type	<ifs>		if_clauses_opt
 %type	<exprs>		stmts
-%type	<expr>		stmt
+%type	<exprs>		stmt        // a simple_stmt or a for/if/def block
+%type	<expr>		block_stmt  // a single for/if/def statement
+%type	<exprs>		simple_stmt // One or many small_stmts on one line, e.g. 'a = f(x); return str(a)'
+%type	<expr>		small_stmt  // A single statement, e.g. 'a = f(x)'
+%type <exprs>		small_stmts_continuation  // A sequence of `';' small_stmt`
 %type	<expr>		keyvalue
 %type	<exprs>		keyvalues
 %type	<exprs>		keyvalues_no_comma
 %type	<string>	string
 %type	<strings>	strings
-%type	<block>		block
+%type	<block>		suite
 
 // Operator precedence.
 // Operators listed lower in the table bind tighter.
@@ -162,36 +166,47 @@ file:
 		return 0
 	}
 
-block:
-  _INDENT stmts _UNINDENT
-  {
+suite:
+	'\n' _INDENT stmts _UNINDENT
+	{
 		$$ = CodeBlock{
-			Start: $1,
-			Statements: $2,
-			End: End{Pos: $3},
+			Start: $2,
+			Statements: $3,
+			End: End{Pos: $4},
 		}
-  }
+	}
+| simple_stmt
+	{
+		// simple_stmt is never empty
+		start, _ := $1[0].Span()
+		_, end := $1[len($1)-1].Span()
+		$$ = CodeBlock{
+			Start: start,
+			Statements: $1,
+			End: End{Pos: end},
+		}
+	}
 
 stmts:
 	{
 		$$ = nil
 		$<lastRule>$ = nil
 	}
-|	stmts stmt comma_opt semi_opt
+|	stmts stmt
 	{
 		// If this statement follows a comment block,
 		// attach the comments to the statement.
 		if cb, ok := $<lastRule>1.(*CommentBlock); ok {
-			$$ = $1
-			$$[len($1)-1] = $2
-			$2.Comment().Before = cb.After
-			$<lastRule>$ = $2
+			$$ = append($1[:len($1)-1], $2...)
+			//$$[len($1)-1] = $2
+			$2[0].Comment().Before = cb.After
+			$<lastRule>$ = $2[len($2)-1]
 			break
 		}
 
 		// Otherwise add to list.
-		$$ = append($1, $2)
-		$<lastRule>$ = $2
+		$$ = append($1, $2...)
+		$<lastRule>$ = $2[len($2)-1]
 
 		// Consider this input:
 		//
@@ -204,7 +219,8 @@ stmts:
 		// for baz() instead.
 		if x := $<lastRule>1; x != nil {
 			com := x.Comment()
-			$2.Comment().Before = com.After
+			// stmt is never empty
+			$2[0].Comment().Before = com.After
 			com.After = nil
 		}
 	}
@@ -214,7 +230,7 @@ stmts:
 		$$ = $1
 		$<lastRule>$ = nil
 	}
-|	stmts _COMMENT
+|	stmts _COMMENT '\n'
 	{
 		$$ = $1
 		$<lastRule>$ = $<lastRule>1
@@ -228,6 +244,47 @@ stmts:
 	}
 
 stmt:
+	simple_stmt
+	{
+		$$ = $1
+	}
+|	block_stmt
+	{
+		$$ = []Expr{$1}
+	}
+
+block_stmt:
+	_DEF _IDENT '(' exprs_opt ')' ':' suite
+	{
+		$$ = &FuncDef{
+			Start: $1,
+			Name: $<tok>2,
+			ListStart: $3,
+			Args: $4,
+			Body: $7,
+			End: $7.End,
+			ForceCompact: forceCompact($3, $4, $5),
+			ForceMultiLine: forceMultiLine($3, $4, $5),
+		}
+	}
+
+simple_stmt:
+	small_stmt small_stmts_continuation semi_opt '\n'
+	{
+		$$ = append([]Expr{$1}, $2...)
+		$<lastRule>$ = $$[len($$)-1]
+	}
+
+small_stmts_continuation:
+	{
+		$$ = []Expr{}
+	}
+| small_stmts_continuation ';' small_stmt
+	{
+		$$ = append($1, $3)
+	}
+
+small_stmt:
 	expr %prec ShiftInstead
 |	_RETURN expr
 	{
@@ -247,7 +304,7 @@ stmt:
 	}
 
 semi_opt:
-|	semi_opt ';'
+|	';'
 
 primary_expr:
 	ident
@@ -470,20 +527,6 @@ expr:
                         Else: $5,
                 }
 	}
-| _DEF _IDENT '(' exprs_opt ')' ':' block
-	// TODO: support one-line function definitions
-	{
- 		$$ = &FuncDef{
- 			Start: $1,
- 			Name: $<tok>2,
- 			ListStart: $3,
- 			Args: $4,
- 			Body: $7,
- 			End: $7.End,
- 			ForceCompact: forceCompact($3, $4, $5),
- 			ForceMultiLine: forceMultiLine($3, $4, $5),
- 		}
- 	}
 
 expr_opt:
 	{

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -112,7 +112,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line build/parse.y:630
+//line build/parse.y:673
 
 // Go helper code.
 
@@ -245,150 +245,161 @@ var yyExca = [...]int{
 	-2, 0,
 }
 
-const yyNprod = 78
+const yyNprod = 84
 const yyPrivate = 57344
 
 var yyTokenNames []string
 var yyStates []string
 
-const yyLast = 511
+const yyLast = 571
 
 var yyAct = [...]int{
 
-	7, 2, 90, 55, 10, 60, 95, 108, 96, 45,
-	144, 24, 50, 51, 52, 23, 81, 133, 56, 58,
-	63, 86, 59, 62, 134, 65, 53, 67, 68, 69,
-	70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-	80, 129, 82, 83, 84, 85, 135, 124, 88, 89,
-	18, 87, 13, 98, 123, 20, 98, 105, 118, 104,
-	145, 98, 17, 138, 19, 101, 98, 103, 6, 100,
-	94, 137, 114, 21, 98, 18, 136, 107, 11, 22,
-	20, 12, 109, 9, 23, 14, 8, 17, 147, 19,
-	5, 99, 115, 116, 50, 112, 54, 117, 21, 25,
-	116, 92, 132, 122, 119, 91, 111, 125, 127, 23,
-	119, 128, 119, 126, 18, 131, 13, 130, 47, 20,
-	102, 119, 93, 57, 46, 66, 17, 1, 19, 143,
-	48, 16, 6, 3, 139, 49, 141, 21, 131, 140,
-	142, 64, 11, 61, 4, 12, 146, 9, 23, 14,
-	8, 120, 27, 15, 5, 26, 29, 97, 30, 121,
-	28, 106, 31, 37, 32, 0, 0, 0, 27, 38,
-	42, 26, 29, 33, 30, 36, 28, 44, 0, 39,
-	43, 0, 34, 35, 40, 41, 27, 0, 0, 26,
-	29, 0, 30, 0, 28, 0, 31, 37, 32, 0,
-	113, 0, 27, 38, 42, 26, 0, 33, 0, 36,
-	28, 44, 0, 39, 43, 0, 34, 35, 40, 41,
-	27, 0, 0, 26, 29, 0, 30, 0, 28, 0,
-	31, 37, 32, 0, 0, 0, 0, 38, 42, 0,
-	0, 33, 98, 36, 0, 44, 0, 39, 43, 0,
-	34, 35, 40, 41, 27, 0, 0, 26, 29, 0,
-	30, 0, 28, 0, 31, 37, 32, 0, 0, 0,
-	0, 38, 42, 0, 0, 33, 0, 36, 0, 44,
-	110, 39, 43, 0, 34, 35, 40, 41, 27, 0,
-	0, 26, 29, 0, 30, 0, 28, 0, 31, 37,
-	32, 0, 0, 0, 0, 38, 42, 0, 0, 33,
-	0, 36, 0, 44, 0, 39, 43, 0, 34, 35,
-	40, 41, 27, 0, 0, 26, 29, 0, 30, 0,
-	28, 0, 31, 37, 32, 0, 0, 0, 0, 38,
-	42, 0, 0, 33, 0, 36, 0, 0, 0, 39,
-	43, 0, 34, 35, 40, 41, 27, 0, 0, 26,
-	29, 0, 30, 0, 28, 0, 31, 0, 32, 0,
-	0, 0, 0, 0, 42, 0, 0, 33, 0, 36,
-	0, 44, 0, 39, 43, 0, 34, 35, 40, 41,
-	27, 0, 0, 26, 29, 0, 30, 0, 28, 0,
-	31, 0, 32, 0, 0, 0, 0, 0, 42, 0,
-	0, 33, 0, 36, 18, 0, 13, 39, 43, 20,
-	34, 35, 40, 41, 0, 0, 17, 0, 19, 0,
-	0, 0, 0, 0, 0, 0, 0, 21, 0, 0,
-	0, 0, 11, 0, 0, 12, 0, 27, 23, 14,
-	26, 29, 0, 30, 0, 28, 0, 31, 0, 32,
-	0, 0, 0, 27, 0, 42, 26, 29, 33, 30,
-	36, 28, 0, 31, 0, 32, 0, 34, 35, 27,
-	41, 42, 26, 29, 33, 30, 36, 28, 0, 31,
-	0, 32, 0, 34, 35, 0, 0, 0, 0, 0,
-	33, 0, 36, 0, 0, 0, 0, 0, 0, 34,
-	35,
+	11, 2, 95, 7, 63, 99, 58, 100, 9, 70,
+	112, 27, 151, 49, 26, 86, 54, 55, 56, 138,
+	91, 59, 61, 66, 29, 135, 14, 102, 62, 65,
+	109, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+	81, 82, 83, 84, 85, 102, 87, 88, 89, 90,
+	68, 139, 93, 94, 21, 129, 17, 123, 92, 23,
+	128, 102, 152, 108, 25, 102, 20, 105, 22, 107,
+	143, 98, 54, 140, 60, 142, 141, 24, 114, 113,
+	102, 120, 15, 51, 57, 16, 111, 115, 26, 50,
+	53, 21, 103, 17, 133, 52, 23, 121, 122, 118,
+	117, 106, 97, 20, 122, 22, 96, 124, 71, 69,
+	1, 130, 132, 124, 24, 124, 131, 134, 147, 15,
+	19, 137, 16, 136, 13, 26, 124, 12, 21, 127,
+	67, 148, 64, 23, 28, 31, 8, 4, 30, 144,
+	20, 146, 22, 32, 137, 149, 150, 21, 125, 17,
+	18, 24, 23, 153, 101, 126, 104, 0, 0, 20,
+	0, 22, 26, 0, 0, 6, 145, 0, 0, 0,
+	24, 0, 21, 0, 17, 15, 0, 23, 16, 0,
+	13, 26, 10, 12, 20, 154, 22, 5, 0, 0,
+	6, 3, 0, 31, 0, 24, 30, 33, 0, 34,
+	15, 32, 0, 16, 0, 13, 26, 10, 12, 0,
+	31, 0, 5, 30, 33, 0, 34, 0, 32, 110,
+	35, 41, 36, 0, 0, 0, 0, 42, 46, 0,
+	0, 37, 0, 40, 0, 48, 0, 43, 47, 0,
+	38, 39, 44, 45, 31, 0, 0, 30, 33, 0,
+	34, 0, 32, 0, 35, 41, 36, 0, 119, 0,
+	0, 42, 46, 0, 0, 37, 0, 40, 0, 48,
+	0, 43, 47, 0, 38, 39, 44, 45, 31, 0,
+	0, 30, 33, 0, 34, 0, 32, 0, 35, 41,
+	36, 0, 0, 0, 0, 42, 46, 0, 0, 37,
+	102, 40, 0, 48, 0, 43, 47, 0, 38, 39,
+	44, 45, 31, 0, 0, 30, 33, 0, 34, 0,
+	32, 0, 35, 41, 36, 0, 0, 0, 0, 42,
+	46, 0, 0, 37, 0, 40, 0, 48, 116, 43,
+	47, 0, 38, 39, 44, 45, 31, 0, 0, 30,
+	33, 0, 34, 0, 32, 0, 35, 41, 36, 0,
+	0, 0, 0, 42, 46, 0, 0, 37, 0, 40,
+	0, 48, 0, 43, 47, 0, 38, 39, 44, 45,
+	31, 0, 0, 30, 33, 0, 34, 0, 32, 0,
+	35, 41, 36, 0, 0, 0, 0, 42, 46, 0,
+	0, 37, 0, 40, 0, 0, 0, 43, 47, 0,
+	38, 39, 44, 45, 31, 0, 0, 30, 33, 0,
+	34, 0, 32, 0, 35, 0, 36, 0, 0, 0,
+	0, 0, 46, 0, 0, 37, 0, 40, 0, 48,
+	0, 43, 47, 0, 38, 39, 44, 45, 31, 0,
+	0, 30, 33, 0, 34, 0, 32, 0, 35, 0,
+	36, 0, 0, 0, 0, 0, 46, 0, 0, 37,
+	0, 40, 21, 0, 17, 43, 47, 23, 38, 39,
+	44, 45, 0, 0, 20, 0, 22, 0, 0, 0,
+	0, 0, 0, 0, 0, 24, 0, 0, 0, 0,
+	15, 0, 0, 16, 0, 13, 26, 31, 12, 0,
+	30, 33, 0, 34, 0, 32, 0, 35, 0, 36,
+	0, 0, 0, 31, 0, 46, 30, 33, 37, 34,
+	40, 32, 0, 35, 0, 36, 0, 38, 39, 31,
+	45, 46, 30, 33, 37, 34, 40, 32, 0, 35,
+	0, 36, 0, 38, 39, 0, 0, 0, 0, 0,
+	37, 0, 40, 0, 0, 0, 0, 0, 0, 38,
+	39,
 }
 var yyPact = [...]int{
 
-	-1000, -1000, 109, -1000, 90, -1000, -1000, 284, 409, -1000,
-	113, 409, 409, 409, -2, -1000, -24, 409, 409, 409,
-	70, -1000, -1000, -1000, -1000, -1000, 409, 409, 409, 409,
-	409, 409, 409, 409, 409, 409, 409, 409, 409, 409,
-	-15, 409, 409, 409, 409, 284, -7, 409, 409, 92,
-	284, -1000, -1000, 117, -1000, 52, 216, 82, 216, 114,
-	30, 39, 37, 148, 68, -1000, -41, -1000, -1000, -1000,
-	198, 198, 164, 164, 164, 164, 164, 164, 352, 352,
-	443, 409, 459, 475, 443, 250, -1000, 100, 216, 182,
-	59, 409, 409, 409, -1000, 40, -1000, -1000, 70, 409,
-	-1000, 48, -1000, 27, -1000, -1000, 409, 409, -1000, 443,
-	409, -1000, 35, -1000, 409, 386, 284, 96, -1000, -1000,
-	-12, 15, 113, -1000, -1000, 284, -1000, 148, 386, -1000,
-	58, 284, 50, 409, 70, 409, -1000, 409, -32, 318,
-	113, 318, 42, -1000, -1000, -1000, 45, -1000,
+	-1000, -1000, 167, -1000, -1000, -1000, -34, -1000, -1000, -1000,
+	-4, 342, 49, -1000, 78, 49, 49, 49, -1000, -25,
+	49, 49, 49, 123, -1000, -1000, -1000, -1000, -39, 103,
+	49, 49, 49, 49, 49, 49, 49, 49, 49, 49,
+	49, 49, 49, 49, -16, 49, 49, 49, 49, 342,
+	-8, 49, 49, 93, 342, -1000, -1000, -1000, 53, 274,
+	83, 274, 95, 1, 43, 10, 206, 77, -1000, -35,
+	467, 49, -1000, -1000, -1000, 131, 131, 189, 189, 189,
+	189, 189, 189, 410, 410, 503, 49, 519, 535, 503,
+	308, -1000, 94, 274, 240, 68, 49, 49, -1000, 39,
+	-1000, -1000, 123, 49, -1000, 54, -1000, 35, -1000, -1000,
+	49, 49, -1000, -1000, 88, 503, 49, -1000, 19, -1000,
+	49, 444, 342, -1000, -1000, -10, 42, 78, -1000, -1000,
+	342, -1000, 206, 63, 444, -1000, 57, 342, 49, 123,
+	49, 86, -1000, 49, 376, 78, 376, -1000, -30, -1000,
+	44, -1000, -1000, 142, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 11, 0, 2, 4, 123, 3, 159, 157, 8,
-	6, 153, 151, 1, 144, 5, 143, 141, 79, 131,
-	129, 127, 125,
+	0, 156, 0, 2, 26, 74, 6, 155, 154, 7,
+	5, 150, 148, 1, 137, 136, 3, 8, 134, 4,
+	132, 130, 64, 120, 118, 110, 109,
 }
 var yyR1 = [...]int{
 
-	0, 21, 20, 13, 13, 13, 13, 14, 14, 14,
-	14, 22, 22, 4, 4, 4, 4, 4, 4, 4,
-	4, 4, 4, 4, 4, 4, 4, 4, 4, 2,
+	0, 25, 24, 24, 13, 13, 13, 13, 14, 14,
+	15, 16, 18, 18, 17, 17, 17, 17, 26, 26,
+	4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	4, 4, 4, 4, 4, 4, 2, 2, 2, 2,
 	2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-	2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-	2, 2, 2, 3, 3, 1, 1, 15, 17, 17,
-	16, 16, 5, 5, 6, 6, 7, 7, 18, 19,
-	19, 11, 8, 9, 10, 10, 12, 12,
+	2, 2, 2, 2, 2, 2, 2, 2, 2, 3,
+	3, 1, 1, 19, 21, 21, 20, 20, 5, 5,
+	6, 6, 7, 7, 22, 23, 23, 11, 8, 9,
+	10, 10, 12, 12,
 }
 var yyR2 = [...]int{
 
-	0, 2, 3, 0, 4, 2, 2, 1, 2, 1,
-	1, 0, 2, 1, 3, 4, 4, 6, 8, 5,
-	1, 3, 4, 4, 4, 3, 3, 3, 2, 1,
-	4, 2, 2, 3, 3, 3, 3, 3, 3, 3,
-	3, 3, 3, 3, 3, 3, 3, 4, 3, 3,
-	3, 5, 7, 0, 1, 0, 1, 3, 1, 3,
-	1, 2, 1, 3, 0, 2, 1, 3, 1, 1,
-	2, 1, 4, 2, 1, 2, 0, 3,
+	0, 2, 4, 1, 0, 2, 2, 3, 1, 1,
+	7, 4, 0, 3, 1, 2, 1, 1, 0, 1,
+	1, 3, 4, 4, 6, 8, 5, 1, 3, 4,
+	4, 4, 3, 3, 3, 2, 1, 4, 2, 2,
+	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+	3, 3, 3, 3, 4, 3, 3, 3, 5, 0,
+	1, 0, 1, 3, 1, 3, 1, 2, 1, 3,
+	0, 2, 1, 3, 1, 1, 2, 1, 4, 2,
+	1, 2, 0, 3,
 }
 var yyChk = [...]int{
 
-	-1000, -21, -13, 24, -14, 45, 23, -2, 41, 38,
-	-4, 33, 36, 7, 40, -11, -19, 17, 5, 19,
-	10, 28, -18, 39, -1, 9, 7, 4, 12, 8,
-	10, 14, 16, 25, 34, 35, 27, 15, 21, 31,
-	36, 37, 22, 32, 29, -2, 11, 5, 17, -5,
-	-2, -2, -2, 28, -18, -6, -2, -5, -2, -6,
-	-15, -16, -6, -2, -17, -4, -22, -2, -2, -2,
-	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, 31, -2, -2, -2, -2, 28, -6, -2, -2,
-	-3, 13, 9, 5, 18, -10, -9, -8, 26, 9,
-	-1, -10, 6, -10, 20, 20, 13, 9, 48, -2,
-	30, 6, -10, 18, 13, -2, -2, -6, 18, -9,
-	-12, -7, -4, 6, 20, -2, -15, -2, -2, 6,
-	-3, -2, 6, 29, 9, 31, 18, 13, 13, -2,
-	-4, -2, -3, -20, 42, 18, -13, 43,
+	-1000, -25, -13, 24, -14, 45, 23, -16, -15, -17,
+	40, -2, 41, 38, -4, 33, 36, 7, -11, -23,
+	17, 5, 19, 10, 28, -22, 39, 45, -18, 28,
+	7, 4, 12, 8, 10, 14, 16, 25, 34, 35,
+	27, 15, 21, 31, 36, 37, 22, 32, 29, -2,
+	11, 5, 17, -5, -2, -2, -2, -22, -6, -2,
+	-5, -2, -6, -19, -20, -6, -2, -21, -4, -26,
+	48, 5, -2, -2, -2, -2, -2, -2, -2, -2,
+	-2, -2, -2, -2, -2, -2, 31, -2, -2, -2,
+	-2, 28, -6, -2, -2, -3, 13, 9, 18, -10,
+	-9, -8, 26, 9, -1, -10, 6, -10, 20, 20,
+	13, 9, 45, -17, -6, -2, 30, 6, -10, 18,
+	13, -2, -2, 18, -9, -12, -7, -4, 6, 20,
+	-2, -19, -2, 6, -2, 6, -3, -2, 29, 9,
+	31, 13, 18, 13, -2, -4, -2, -24, 45, -16,
+	-3, 42, 18, -13, 43,
 }
 var yyDef = [...]int{
 
-	3, -2, 0, 1, 55, 5, 6, 7, 9, 10,
-	29, 0, 0, 0, 0, 13, 20, 64, 64, 64,
-	0, 71, 69, 68, 11, 56, 0, 0, 0, 0,
+	4, -2, 0, 1, 5, 6, 0, 8, 9, 12,
+	0, 14, 16, 17, 36, 0, 0, 0, 20, 27,
+	70, 70, 70, 0, 77, 75, 74, 7, 18, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 8, 0, 64, 53, 0,
-	62, 31, 32, 0, 70, 0, 62, 55, 62, 0,
-	58, 0, 0, 62, 60, 28, 4, 33, 34, 35,
-	36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
-	46, 0, 48, 49, 50, 0, 14, 0, 62, 54,
-	0, 0, 0, 64, 21, 0, 74, 76, 0, 56,
-	65, 0, 27, 0, 25, 26, 0, 61, 12, 47,
-	0, 15, 0, 16, 53, 30, 63, 0, 22, 75,
-	73, 0, 66, 23, 24, 57, 59, 0, 51, 19,
-	0, 54, 0, 0, 0, 0, 17, 53, 0, 77,
-	67, 72, 0, 52, 3, 18, 0, 2,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 15,
+	0, 70, 59, 0, 68, 38, 39, 76, 0, 68,
+	61, 68, 0, 64, 0, 0, 68, 66, 35, 0,
+	19, 70, 40, 41, 42, 43, 44, 45, 46, 47,
+	48, 49, 50, 51, 52, 53, 0, 55, 56, 57,
+	0, 21, 0, 68, 60, 0, 0, 0, 28, 0,
+	80, 82, 0, 62, 71, 0, 34, 0, 32, 33,
+	0, 67, 11, 13, 0, 54, 0, 22, 0, 23,
+	59, 37, 69, 29, 81, 79, 0, 72, 30, 31,
+	63, 65, 0, 0, 58, 26, 0, 60, 0, 0,
+	0, 0, 24, 59, 83, 73, 78, 10, 0, 3,
+	0, 4, 25, 0, 2,
 }
 var yyTok1 = [...]int{
 
@@ -755,45 +766,58 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:160
+		//line build/parse.y:164
 		{
 			yylex.(*input).file = &File{Stmt: yyDollar[1].exprs}
 			return 0
 		}
 	case 2:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:167
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:171
 		{
 			yyVAL.block = CodeBlock{
-				Start:      yyDollar[1].pos,
-				Statements: yyDollar[2].exprs,
-				End:        End{Pos: yyDollar[3].pos},
+				Start:      yyDollar[2].pos,
+				Statements: yyDollar[3].exprs,
+				End:        End{Pos: yyDollar[4].pos},
 			}
 		}
 	case 3:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:179
+		{
+			// simple_stmt is never empty
+			start, _ := yyDollar[1].exprs[0].Span()
+			_, end := yyDollar[1].exprs[len(yyDollar[1].exprs)-1].Span()
+			yyVAL.block = CodeBlock{
+				Start:      start,
+				Statements: yyDollar[1].exprs,
+				End:        End{Pos: end},
+			}
+		}
+	case 4:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:176
+		//line build/parse.y:191
 		{
 			yyVAL.exprs = nil
 			yyVAL.lastRule = nil
 		}
-	case 4:
-		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:181
+	case 5:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:196
 		{
 			// If this statement follows a comment block,
 			// attach the comments to the statement.
 			if cb, ok := yyDollar[1].lastRule.(*CommentBlock); ok {
-				yyVAL.exprs = yyDollar[1].exprs
-				yyVAL.exprs[len(yyDollar[1].exprs)-1] = yyDollar[2].expr
-				yyDollar[2].expr.Comment().Before = cb.After
-				yyVAL.lastRule = yyDollar[2].expr
+				yyVAL.exprs = append(yyDollar[1].exprs[:len(yyDollar[1].exprs)-1], yyDollar[2].exprs...)
+				//$$[len($1)-1] = $2
+				yyDollar[2].exprs[0].Comment().Before = cb.After
+				yyVAL.lastRule = yyDollar[2].exprs[len(yyDollar[2].exprs)-1]
 				break
 			}
 
 			// Otherwise add to list.
-			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[2].expr)
-			yyVAL.lastRule = yyDollar[2].expr
+			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[2].exprs...)
+			yyVAL.lastRule = yyDollar[2].exprs[len(yyDollar[2].exprs)-1]
 
 			// Consider this input:
 			//
@@ -806,21 +830,22 @@ yydefault:
 			// for baz() instead.
 			if x := yyDollar[1].lastRule; x != nil {
 				com := x.Comment()
-				yyDollar[2].expr.Comment().Before = com.After
+				// stmt is never empty
+				yyDollar[2].exprs[0].Comment().Before = com.After
 				com.After = nil
 			}
 		}
-	case 5:
+	case 6:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:212
+		//line build/parse.y:228
 		{
 			// Blank line; sever last rule from future comments.
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = nil
 		}
-	case 6:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:218
+	case 7:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:234
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = yyDollar[1].lastRule
@@ -833,8 +858,54 @@ yydefault:
 			com.After = append(com.After, Comment{Start: yyDollar[2].pos, Token: yyDollar[2].tok})
 		}
 	case 8:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:248
+		{
+			yyVAL.exprs = yyDollar[1].exprs
+		}
+	case 9:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:252
+		{
+			yyVAL.exprs = []Expr{yyDollar[1].expr}
+		}
+	case 10:
+		yyDollar = yyS[yypt-7 : yypt+1]
+		//line build/parse.y:258
+		{
+			yyVAL.expr = &FuncDef{
+				Start:          yyDollar[1].pos,
+				Name:           yyDollar[2].tok,
+				ListStart:      yyDollar[3].pos,
+				Args:           yyDollar[4].exprs,
+				Body:           yyDollar[7].block,
+				End:            yyDollar[7].block.End,
+				ForceCompact:   forceCompact(yyDollar[3].pos, yyDollar[4].exprs, yyDollar[5].pos),
+				ForceMultiLine: forceMultiLine(yyDollar[3].pos, yyDollar[4].exprs, yyDollar[5].pos),
+			}
+		}
+	case 11:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:273
+		{
+			yyVAL.exprs = append([]Expr{yyDollar[1].expr}, yyDollar[2].exprs...)
+			yyVAL.lastRule = yyVAL.exprs[len(yyVAL.exprs)-1]
+		}
+	case 12:
+		yyDollar = yyS[yypt-0 : yypt+1]
+		//line build/parse.y:279
+		{
+			yyVAL.exprs = []Expr{}
+		}
+	case 13:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:283
+		{
+			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
+		}
+	case 15:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:233
+		//line build/parse.y:290
 		{
 			_, end := yyDollar[2].expr.Span()
 			yyVAL.expr = &ReturnExpr{
@@ -842,21 +913,21 @@ yydefault:
 				End: end,
 			}
 		}
-	case 9:
+	case 16:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:241
+		//line build/parse.y:298
 		{
 			yyVAL.expr = &ReturnExpr{End: yyDollar[1].pos}
 		}
-	case 10:
+	case 17:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:245
+		//line build/parse.y:302
 		{
 			yyVAL.expr = &PythonBlock{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 14:
+	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:255
+		//line build/parse.y:312
 		{
 			yyVAL.expr = &DotExpr{
 				X:       yyDollar[1].expr,
@@ -865,9 +936,9 @@ yydefault:
 				Name:    yyDollar[3].tok,
 			}
 		}
-	case 15:
+	case 22:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:264
+		//line build/parse.y:321
 		{
 			yyVAL.expr = &CallExpr{
 				X:              yyDollar[1].expr,
@@ -878,9 +949,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 16:
+	case 23:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:275
+		//line build/parse.y:332
 		{
 			yyVAL.expr = &IndexExpr{
 				X:          yyDollar[1].expr,
@@ -889,9 +960,9 @@ yydefault:
 				End:        yyDollar[4].pos,
 			}
 		}
-	case 17:
+	case 24:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:284
+		//line build/parse.y:341
 		{
 			yyVAL.expr = &SliceExpr{
 				X:          yyDollar[1].expr,
@@ -902,9 +973,9 @@ yydefault:
 				End:        yyDollar[6].pos,
 			}
 		}
-	case 18:
+	case 25:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line build/parse.y:295
+		//line build/parse.y:352
 		{
 			yyVAL.expr = &SliceExpr{
 				X:           yyDollar[1].expr,
@@ -917,9 +988,9 @@ yydefault:
 				End:         yyDollar[8].pos,
 			}
 		}
-	case 19:
+	case 26:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:308
+		//line build/parse.y:365
 		{
 			yyVAL.expr = &CallExpr{
 				X:         yyDollar[1].expr,
@@ -936,9 +1007,9 @@ yydefault:
 				End: End{Pos: yyDollar[5].pos},
 			}
 		}
-	case 20:
+	case 27:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:325
+		//line build/parse.y:382
 		{
 			if len(yyDollar[1].strings) == 1 {
 				yyVAL.expr = yyDollar[1].strings[0]
@@ -950,9 +1021,9 @@ yydefault:
 				yyVAL.expr = binary(yyVAL.expr, end, "+", x)
 			}
 		}
-	case 21:
+	case 28:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:337
+		//line build/parse.y:394
 		{
 			yyVAL.expr = &ListExpr{
 				Start:          yyDollar[1].pos,
@@ -962,9 +1033,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 22:
+	case 29:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:347
+		//line build/parse.y:404
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -976,9 +1047,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 23:
+	case 30:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:359
+		//line build/parse.y:416
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -990,9 +1061,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 24:
+	case 31:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:371
+		//line build/parse.y:428
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -1004,9 +1075,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 25:
+	case 32:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:383
+		//line build/parse.y:440
 		{
 			yyVAL.expr = &DictExpr{
 				Start:          yyDollar[1].pos,
@@ -1016,9 +1087,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 26:
+	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:393
+		//line build/parse.y:450
 		{
 			yyVAL.expr = &SetExpr{
 				Start:          yyDollar[1].pos,
@@ -1028,9 +1099,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 27:
+	case 34:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:403
+		//line build/parse.y:460
 		{
 			if len(yyDollar[2].exprs) == 1 && yyDollar[2].comma.Line == 0 {
 				// Just a parenthesized expression, not a tuple.
@@ -1051,15 +1122,15 @@ yydefault:
 				}
 			}
 		}
-	case 28:
+	case 35:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:423
+		//line build/parse.y:480
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 30:
+	case 37:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:428
+		//line build/parse.y:485
 		{
 			yyVAL.expr = &LambdaExpr{
 				Lambda: yyDollar[1].pos,
@@ -1068,123 +1139,123 @@ yydefault:
 				Expr:   yyDollar[4].expr,
 			}
 		}
-	case 31:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:436
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 32:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:437
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 33:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:438
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 34:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:439
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 35:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:440
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 36:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:441
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 37:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:442
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
 	case 38:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:443
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:493
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 39:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:444
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:494
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:445
+		//line build/parse.y:495
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 41:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:446
+		//line build/parse.y:496
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 42:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:447
+		//line build/parse.y:497
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 43:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:448
+		//line build/parse.y:498
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 44:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:449
+		//line build/parse.y:499
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 45:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:450
+		//line build/parse.y:500
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:451
+		//line build/parse.y:501
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 47:
-		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:452
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:502
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 48:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:453
+		//line build/parse.y:503
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:454
+		//line build/parse.y:504
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 50:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:456
+		//line build/parse.y:505
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 51:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:506
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 52:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:507
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 53:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:508
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 54:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:509
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+		}
+	case 55:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:510
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 56:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:511
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 57:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:513
 		{
 			if b, ok := yyDollar[3].expr.(*UnaryExpr); ok && b.Op == "not" {
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "is not", b.X)
@@ -1192,9 +1263,9 @@ yydefault:
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 			}
 		}
-	case 51:
+	case 58:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:464
+		//line build/parse.y:521
 		{
 			yyVAL.expr = &ConditionalExpr{
 				Then:      yyDollar[1].expr,
@@ -1204,36 +1275,21 @@ yydefault:
 				Else:      yyDollar[5].expr,
 			}
 		}
-	case 52:
-		yyDollar = yyS[yypt-7 : yypt+1]
-		//line build/parse.y:475
-		{
-			yyVAL.expr = &FuncDef{
-				Start:          yyDollar[1].pos,
-				Name:           yyDollar[2].tok,
-				ListStart:      yyDollar[3].pos,
-				Args:           yyDollar[4].exprs,
-				Body:           yyDollar[7].block,
-				End:            yyDollar[7].block.End,
-				ForceCompact:   forceCompact(yyDollar[3].pos, yyDollar[4].exprs, yyDollar[5].pos),
-				ForceMultiLine: forceMultiLine(yyDollar[3].pos, yyDollar[4].exprs, yyDollar[5].pos),
-			}
-		}
-	case 53:
+	case 59:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:489
+		//line build/parse.y:532
 		{
 			yyVAL.expr = nil
 		}
-	case 55:
+	case 61:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:499
+		//line build/parse.y:542
 		{
 			yyVAL.pos = Position{}
 		}
-	case 57:
+	case 63:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:505
+		//line build/parse.y:548
 		{
 			yyVAL.expr = &KeyValueExpr{
 				Key:   yyDollar[1].expr,
@@ -1241,69 +1297,69 @@ yydefault:
 				Value: yyDollar[3].expr,
 			}
 		}
-	case 58:
-		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:515
-		{
-			yyVAL.exprs = []Expr{yyDollar[1].expr}
-		}
-	case 59:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:519
-		{
-			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
-		}
-	case 60:
-		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:525
-		{
-			yyVAL.exprs = yyDollar[1].exprs
-		}
-	case 61:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:529
-		{
-			yyVAL.exprs = yyDollar[1].exprs
-		}
-	case 62:
-		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:535
-		{
-			yyVAL.exprs = []Expr{yyDollar[1].expr}
-		}
-	case 63:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:539
-		{
-			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
-		}
 	case 64:
-		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:544
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:558
 		{
-			yyVAL.exprs, yyVAL.comma = nil, Position{}
+			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 65:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:548
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:562
 		{
-			yyVAL.exprs, yyVAL.comma = yyDollar[1].exprs, yyDollar[2].pos
+			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 66:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:554
+		//line build/parse.y:568
 		{
-			yyVAL.exprs = []Expr{yyDollar[1].expr}
+			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 67:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:558
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:572
 		{
-			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
+			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 68:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:564
+		//line build/parse.y:578
+		{
+			yyVAL.exprs = []Expr{yyDollar[1].expr}
+		}
+	case 69:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:582
+		{
+			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
+		}
+	case 70:
+		yyDollar = yyS[yypt-0 : yypt+1]
+		//line build/parse.y:587
+		{
+			yyVAL.exprs, yyVAL.comma = nil, Position{}
+		}
+	case 71:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:591
+		{
+			yyVAL.exprs, yyVAL.comma = yyDollar[1].exprs, yyDollar[2].pos
+		}
+	case 72:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:597
+		{
+			yyVAL.exprs = []Expr{yyDollar[1].expr}
+		}
+	case 73:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:601
+		{
+			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
+		}
+	case 74:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:607
 		{
 			yyVAL.string = &StringExpr{
 				Start:       yyDollar[1].pos,
@@ -1313,27 +1369,27 @@ yydefault:
 				Token:       yyDollar[1].tok,
 			}
 		}
-	case 69:
+	case 75:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:576
+		//line build/parse.y:619
 		{
 			yyVAL.strings = []*StringExpr{yyDollar[1].string}
 		}
-	case 70:
+	case 76:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:580
+		//line build/parse.y:623
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[2].string)
 		}
-	case 71:
+	case 77:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:586
+		//line build/parse.y:629
 		{
 			yyVAL.expr = &LiteralExpr{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 72:
+	case 78:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:592
+		//line build/parse.y:635
 		{
 			yyVAL.forc = &ForClause{
 				For:  yyDollar[1].pos,
@@ -1342,36 +1398,36 @@ yydefault:
 				Expr: yyDollar[4].expr,
 			}
 		}
-	case 73:
+	case 79:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:602
+		//line build/parse.y:645
 		{
 			yyVAL.forifs = &ForClauseWithIfClausesOpt{
 				For: yyDollar[1].forc,
 				Ifs: yyDollar[2].ifs,
 			}
 		}
-	case 74:
+	case 80:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:611
+		//line build/parse.y:654
 		{
 			yyVAL.forsifs = []*ForClauseWithIfClausesOpt{yyDollar[1].forifs}
 		}
-	case 75:
+	case 81:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:614
+		//line build/parse.y:657
 		{
 			yyVAL.forsifs = append(yyDollar[1].forsifs, yyDollar[2].forifs)
 		}
-	case 76:
+	case 82:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:619
+		//line build/parse.y:662
 		{
 			yyVAL.ifs = nil
 		}
-	case 77:
+	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:623
+		//line build/parse.y:666
 		{
 			yyVAL.ifs = append(yyDollar[1].ifs, &IfClause{
 				If:   yyDollar[2].pos,

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -112,7 +112,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line build/parse.y:673
+//line build/parse.y:672
 
 // Go helper code.
 
@@ -809,7 +809,6 @@ yydefault:
 			// attach the comments to the statement.
 			if cb, ok := yyDollar[1].lastRule.(*CommentBlock); ok {
 				yyVAL.exprs = append(yyDollar[1].exprs[:len(yyDollar[1].exprs)-1], yyDollar[2].exprs...)
-				//$$[len($1)-1] = $2
 				yyDollar[2].exprs[0].Comment().Before = cb.After
 				yyVAL.lastRule = yyDollar[2].exprs[len(yyDollar[2].exprs)-1]
 				break
@@ -837,7 +836,7 @@ yydefault:
 		}
 	case 6:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:228
+		//line build/parse.y:227
 		{
 			// Blank line; sever last rule from future comments.
 			yyVAL.exprs = yyDollar[1].exprs
@@ -845,7 +844,7 @@ yydefault:
 		}
 	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:234
+		//line build/parse.y:233
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = yyDollar[1].lastRule
@@ -859,19 +858,19 @@ yydefault:
 		}
 	case 8:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:248
+		//line build/parse.y:247
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 9:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:252
+		//line build/parse.y:251
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 10:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line build/parse.y:258
+		//line build/parse.y:257
 		{
 			yyVAL.expr = &FuncDef{
 				Start:          yyDollar[1].pos,
@@ -886,26 +885,26 @@ yydefault:
 		}
 	case 11:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:273
+		//line build/parse.y:272
 		{
 			yyVAL.exprs = append([]Expr{yyDollar[1].expr}, yyDollar[2].exprs...)
 			yyVAL.lastRule = yyVAL.exprs[len(yyVAL.exprs)-1]
 		}
 	case 12:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:279
+		//line build/parse.y:278
 		{
 			yyVAL.exprs = []Expr{}
 		}
 	case 13:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:283
+		//line build/parse.y:282
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 15:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:290
+		//line build/parse.y:289
 		{
 			_, end := yyDollar[2].expr.Span()
 			yyVAL.expr = &ReturnExpr{
@@ -915,19 +914,19 @@ yydefault:
 		}
 	case 16:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:298
+		//line build/parse.y:297
 		{
 			yyVAL.expr = &ReturnExpr{End: yyDollar[1].pos}
 		}
 	case 17:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:302
+		//line build/parse.y:301
 		{
 			yyVAL.expr = &PythonBlock{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
 	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:312
+		//line build/parse.y:311
 		{
 			yyVAL.expr = &DotExpr{
 				X:       yyDollar[1].expr,
@@ -938,7 +937,7 @@ yydefault:
 		}
 	case 22:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:321
+		//line build/parse.y:320
 		{
 			yyVAL.expr = &CallExpr{
 				X:              yyDollar[1].expr,
@@ -951,7 +950,7 @@ yydefault:
 		}
 	case 23:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:332
+		//line build/parse.y:331
 		{
 			yyVAL.expr = &IndexExpr{
 				X:          yyDollar[1].expr,
@@ -962,7 +961,7 @@ yydefault:
 		}
 	case 24:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:341
+		//line build/parse.y:340
 		{
 			yyVAL.expr = &SliceExpr{
 				X:          yyDollar[1].expr,
@@ -975,7 +974,7 @@ yydefault:
 		}
 	case 25:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line build/parse.y:352
+		//line build/parse.y:351
 		{
 			yyVAL.expr = &SliceExpr{
 				X:           yyDollar[1].expr,
@@ -990,7 +989,7 @@ yydefault:
 		}
 	case 26:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:365
+		//line build/parse.y:364
 		{
 			yyVAL.expr = &CallExpr{
 				X:         yyDollar[1].expr,
@@ -1009,7 +1008,7 @@ yydefault:
 		}
 	case 27:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:382
+		//line build/parse.y:381
 		{
 			if len(yyDollar[1].strings) == 1 {
 				yyVAL.expr = yyDollar[1].strings[0]
@@ -1023,7 +1022,7 @@ yydefault:
 		}
 	case 28:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:394
+		//line build/parse.y:393
 		{
 			yyVAL.expr = &ListExpr{
 				Start:          yyDollar[1].pos,
@@ -1035,7 +1034,7 @@ yydefault:
 		}
 	case 29:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:404
+		//line build/parse.y:403
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -1049,7 +1048,7 @@ yydefault:
 		}
 	case 30:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:416
+		//line build/parse.y:415
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -1063,7 +1062,7 @@ yydefault:
 		}
 	case 31:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:428
+		//line build/parse.y:427
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -1077,7 +1076,7 @@ yydefault:
 		}
 	case 32:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:440
+		//line build/parse.y:439
 		{
 			yyVAL.expr = &DictExpr{
 				Start:          yyDollar[1].pos,
@@ -1089,7 +1088,7 @@ yydefault:
 		}
 	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:450
+		//line build/parse.y:449
 		{
 			yyVAL.expr = &SetExpr{
 				Start:          yyDollar[1].pos,
@@ -1101,7 +1100,7 @@ yydefault:
 		}
 	case 34:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:460
+		//line build/parse.y:459
 		{
 			if len(yyDollar[2].exprs) == 1 && yyDollar[2].comma.Line == 0 {
 				// Just a parenthesized expression, not a tuple.
@@ -1124,13 +1123,13 @@ yydefault:
 		}
 	case 35:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:480
+		//line build/parse.y:479
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 37:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:485
+		//line build/parse.y:484
 		{
 			yyVAL.expr = &LambdaExpr{
 				Lambda: yyDollar[1].pos,
@@ -1141,121 +1140,121 @@ yydefault:
 		}
 	case 38:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:493
+		//line build/parse.y:492
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:494
+		//line build/parse.y:493
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:495
+		//line build/parse.y:494
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 41:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:496
+		//line build/parse.y:495
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 42:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:497
+		//line build/parse.y:496
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 43:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:498
+		//line build/parse.y:497
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 44:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:499
+		//line build/parse.y:498
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 45:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:500
+		//line build/parse.y:499
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:501
+		//line build/parse.y:500
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 47:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:502
+		//line build/parse.y:501
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 48:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:503
+		//line build/parse.y:502
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:504
+		//line build/parse.y:503
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 50:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:505
+		//line build/parse.y:504
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 51:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:506
+		//line build/parse.y:505
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 52:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:507
+		//line build/parse.y:506
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 53:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:508
+		//line build/parse.y:507
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 54:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:509
+		//line build/parse.y:508
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
 		}
 	case 55:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:510
+		//line build/parse.y:509
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 56:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:511
+		//line build/parse.y:510
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 57:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:513
+		//line build/parse.y:512
 		{
 			if b, ok := yyDollar[3].expr.(*UnaryExpr); ok && b.Op == "not" {
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "is not", b.X)
@@ -1265,7 +1264,7 @@ yydefault:
 		}
 	case 58:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:521
+		//line build/parse.y:520
 		{
 			yyVAL.expr = &ConditionalExpr{
 				Then:      yyDollar[1].expr,
@@ -1277,19 +1276,19 @@ yydefault:
 		}
 	case 59:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:532
+		//line build/parse.y:531
 		{
 			yyVAL.expr = nil
 		}
 	case 61:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:542
+		//line build/parse.y:541
 		{
 			yyVAL.pos = Position{}
 		}
 	case 63:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:548
+		//line build/parse.y:547
 		{
 			yyVAL.expr = &KeyValueExpr{
 				Key:   yyDollar[1].expr,
@@ -1299,67 +1298,67 @@ yydefault:
 		}
 	case 64:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:558
+		//line build/parse.y:557
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 65:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:562
+		//line build/parse.y:561
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 66:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:568
+		//line build/parse.y:567
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 67:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:572
+		//line build/parse.y:571
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 68:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:578
+		//line build/parse.y:577
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 69:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:582
+		//line build/parse.y:581
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 70:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:587
+		//line build/parse.y:586
 		{
 			yyVAL.exprs, yyVAL.comma = nil, Position{}
 		}
 	case 71:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:591
+		//line build/parse.y:590
 		{
 			yyVAL.exprs, yyVAL.comma = yyDollar[1].exprs, yyDollar[2].pos
 		}
 	case 72:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:597
+		//line build/parse.y:596
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 73:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:601
+		//line build/parse.y:600
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 74:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:607
+		//line build/parse.y:606
 		{
 			yyVAL.string = &StringExpr{
 				Start:       yyDollar[1].pos,
@@ -1371,25 +1370,25 @@ yydefault:
 		}
 	case 75:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:619
+		//line build/parse.y:618
 		{
 			yyVAL.strings = []*StringExpr{yyDollar[1].string}
 		}
 	case 76:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:623
+		//line build/parse.y:622
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[2].string)
 		}
 	case 77:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:629
+		//line build/parse.y:628
 		{
 			yyVAL.expr = &LiteralExpr{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
 	case 78:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:635
+		//line build/parse.y:634
 		{
 			yyVAL.forc = &ForClause{
 				For:  yyDollar[1].pos,
@@ -1400,7 +1399,7 @@ yydefault:
 		}
 	case 79:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:645
+		//line build/parse.y:644
 		{
 			yyVAL.forifs = &ForClauseWithIfClausesOpt{
 				For: yyDollar[1].forc,
@@ -1409,25 +1408,25 @@ yydefault:
 		}
 	case 80:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:654
+		//line build/parse.y:653
 		{
 			yyVAL.forsifs = []*ForClauseWithIfClausesOpt{yyDollar[1].forifs}
 		}
 	case 81:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:657
+		//line build/parse.y:656
 		{
 			yyVAL.forsifs = append(yyDollar[1].forsifs, yyDollar[2].forifs)
 		}
 	case 82:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:662
+		//line build/parse.y:661
 		{
 			yyVAL.ifs = nil
 		}
 	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:666
+		//line build/parse.y:665
 		{
 			yyVAL.ifs = append(yyDollar[1].ifs, &IfClause{
 				If:   yyDollar[2].pos,

--- a/build/print.go
+++ b/build/print.go
@@ -143,7 +143,8 @@ func (p *printer) statements(stmts []Expr) {
 				p.printf("%s", strings.TrimSpace(com.Token))
 				p.newline()
 			}
-			p.printf("%s", stmt.Token) // includes trailing newline
+			p.printf("%s", stmt.Token)
+			p.newline()
 
 		default:
 			p.expr(stmt, precLow)
@@ -472,7 +473,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 	case *FuncDef:
 		p.printf("def ")
 		p.printf(v.Name)
-		p.seq("()", v.Args, &v.End, modeTuple, v.ForceCompact, v.ForceMultiLine)
+		p.seq("()", v.Args, &v.End, modeCall, v.ForceCompact, v.ForceMultiLine)
 		p.printf(":")
 		p.margin += nestedIndentation
 		p.newline()

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -455,9 +455,9 @@ func (x *FuncDef) Span() (start, end Position) {
 // A ReturnExpr represents a return statement: return f(x).
 type ReturnExpr struct {
 	Comments
-	Start    Position
-	X        Expr
-	End      Position
+	Start Position
+	X     Expr
+	End   Position
 }
 
 func (x *ReturnExpr) Span() (start, end Position) {

--- a/build/testdata/051.formatbzl.golden
+++ b/build/testdata/051.formatbzl.golden
@@ -10,7 +10,7 @@ bbb
 ccc
 
 def function(
-    # This shouldn't mess with indendation counting
+    # This shouldn't mess with indentation counting
     x,
     y = z,
 ):
@@ -29,6 +29,10 @@ def function(
         s = d,  # this is h
     ):
       eee
+
+    def k(g):
+      g += 1
+      return g
 
     def i():
       def j():

--- a/build/testdata/051.golden
+++ b/build/testdata/051.golden
@@ -10,7 +10,7 @@ bbb
 ccc
 
 def function(
-    # This shouldn't mess with indendation counting
+    # This shouldn't mess with indentation counting
     x, y = z
 ):
   aaa
@@ -22,6 +22,8 @@ def function(
     ddd
     def h(a, s = d):   # this is h
       eee
+
+    def k(g): g += 1; return g
 
     def i():
       def j():

--- a/build/testdata/051.in
+++ b/build/testdata/051.in
@@ -1,12 +1,11 @@
 foo(name='foo',
   srcs=[bar])
 
-aaa
-bbb
+aaa; bbb
 ccc
 
 def function(
-    # This shouldn't mess with indendation counting
+    # This shouldn't mess with indentation counting
     x, y = z
 ):
   aaa
@@ -18,6 +17,8 @@ def function(
     ddd
     def h(a, s = d):   # this is h
       eee
+
+    def k(g): g += 1; return g
 
     def i():
       def j():

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -184,9 +184,11 @@ func TestUseImplicitName(t *testing.T) {
 	}{
 		{`rule()`, 1, false, false, `Use an implicit name for one rule.`},
 		{`rule(name="a")
-		  rule(name="b")
-		  rule()`, 3, false, false, `Use an implicit name for the one unnamed rule`},
-		{`rule() rule() rule()`, 1, true, false, `Error for multiple unnamed rules`},
+rule(name="b")
+rule()`, 3, false, false, `Use an implicit name for the one unnamed rule`},
+		{`rule()
+rule()
+rule()`, 1, true, false, `Error for multiple unnamed rules`},
 		{`rule()`, 1, true, true, `Error for the root package`},
 	}
 


### PR DESCRIPTION
End statement tracking wasn't accurate and didn't always work well, but on the other hand it was used only for implicit `;` insertion (which is not required for Skylark syntax, removing an explicit `;` from the end of a line never changes Skylark semantics).

However proper end statement tracking is crucial for bzl files parsing: files are not just sequences of top-level statements, it's important to see where each node ends.

Statements are now considered ended before `\n` of their last line, and the `\n` is now passed to the parser explicitly.