### PR TITLE
edit: add new substitute command for buildozer

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -101,6 +101,13 @@ Buildozer supports the following commands(`'command args'`):
   * `replace <attr> <old_value> <new_value>`: Replaces `old_value` with `new_value`
     in the list `attr`. Wildcard `*` matches all attributes. Lists not containing
     `old_value` are not modified.
+  * `substitute <attr> <old_regexp> <new_template>`: Replaces strings which
+    match `old_regexp` in the list `attr` according to `new_template`. Wildcard
+    `*` matches all attributes. The regular expression must follow
+    [RE2 syntax](https://github.com/google/re2/wiki/Syntax). `new_template` may
+    be a simple replacement string, but it may also expand numbered or named
+    groups using `$0` or `$x`. Lists without strings that match `old_regexp`
+    are not modified.
   * `set <attr> <value(s)>`: Sets the value of an attribute. If the attribute
     was already present, its old value is replaced.
   * `set_if_absent <attr> <value(s)>`: Sets the value of an attribute. If the
@@ -138,6 +145,9 @@ buildozer 'set kind java_library' //pkg:%gwt_module
 
 # Replace the dependency on pkg_v1 with a dependency on pkg_v2
 buildozer 'replace deps //pkg_v1 //pkg_v2' //pkg:rule
+
+# Replace all dependencies using regular expressions.
+buildozer 'substitute deps //old/(.*) //new/${1}' //pkg:rule
 
 # Delete the dependency on foo in every cc_library in the package
 buildozer 'remove deps foo' //pkg:%cc_library

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -363,13 +363,13 @@ func cmdSubstitute(env CmdEnvironment) (*build.File, error) {
 	newTemplate := env.Args[2]
 	for _, key := range attrKeysForPattern(env.Rule, env.Args[0]) {
 		attr := env.Rule.Attr(key)
-		if e, ok := attr.(*build.StringExpr); ok {
-			newValue, ok := stringSubstitute(e.Value, oldRegexp, newTemplate)
-			if ok {
-				env.Rule.SetAttr(key, getAttrValueExpr(key, []string{newValue}))
-			}
-		} else {
+		e, ok := attr.(*build.StringExpr)
+		if !ok {
 			ListSubstitute(attr, oldRegexp, newTemplate)
+			continue
+		}
+		if newValue, ok := stringSubstitute(e.Value, oldRegexp, newTemplate); ok {
+			env.Rule.SetAttr(key, getAttrValueExpr(key, []string{newValue}))
 		}
 	}
 	return env.File, nil

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -355,6 +355,26 @@ func cmdReplace(env CmdEnvironment) (*build.File, error) {
 	return env.File, nil
 }
 
+func cmdSubstitute(env CmdEnvironment) (*build.File, error) {
+	oldRegexp, err := regexp.Compile(env.Args[1])
+	if err != nil {
+		return nil, err
+	}
+	newTemplate := env.Args[2]
+	for _, key := range attrKeysForPattern(env.Rule, env.Args[0]) {
+		attr := env.Rule.Attr(key)
+		if e, ok := attr.(*build.StringExpr); ok {
+			newValue, ok := stringSubstitute(e.Value, oldRegexp, newTemplate)
+			if ok {
+				env.Rule.SetAttr(key, getAttrValueExpr(key, []string{newValue}))
+			}
+		} else {
+			ListSubstitute(attr, oldRegexp, newTemplate)
+		}
+	}
+	return env.File, nil
+}
+
 func cmdSet(env CmdEnvironment) (*build.File, error) {
 	attr := env.Args[0]
 	args := env.Args[1:]
@@ -470,6 +490,7 @@ var AllCommands = map[string]CommandInfo{
 	"remove":            {cmdRemove, 1, -1, "<attr> <value(s)>"},
 	"rename":            {cmdRename, 2, 2, "<old_attr> <new_attr>"},
 	"replace":           {cmdReplace, 3, 3, "<attr> <old_value> <new_value>"},
+	"substitute":        {cmdSubstitute, 3, 3, "<attr> <old_regexp> <new_template>"},
 	"set":               {cmdSet, 2, -1, "<attr> <value(s)>"},
 	"set_if_absent":     {cmdSetIfAbsent, 2, -1, "<attr> <value(s)>"},
 	"copy":              {cmdCopy, 2, 2, "<attr> <from_rule>"},

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -535,6 +536,42 @@ func ListReplace(e build.Expr, old, value, pkg string) bool {
 		}
 	}
 	return replaced
+}
+
+// ListSubstitute replaces strings matching a regular expression in all lists
+// in e and returns a Boolean to indicate whether the replacement was
+// successful.
+func ListSubstitute(e build.Expr, oldRegexp *regexp.Regexp, newTemplate string) bool {
+	substituted := false
+	for _, li := range AllLists(e) {
+		for k, elem := range li.List {
+			str, ok := elem.(*build.StringExpr)
+			if !ok {
+				continue
+			}
+			newValue, ok := stringSubstitute(str.Value, oldRegexp, newTemplate)
+			if ok {
+				li.List[k] = &build.StringExpr{Value: newValue, Comments: *elem.Comment()}
+				substituted = true
+			}
+		}
+	}
+	return substituted
+}
+
+func stringSubstitute(oldValue string, oldRegexp *regexp.Regexp, newTemplate string) (string, bool) {
+	match := oldRegexp.FindStringSubmatchIndex(oldValue)
+	if match == nil {
+		return oldValue, false
+	}
+	newValue := string(oldRegexp.ExpandString(nil, newTemplate, oldValue, match))
+	if match[0] > 0 {
+		newValue = oldValue[:match[0]] + newValue
+	}
+	if match[1] < len(oldValue) {
+		newValue = newValue + oldValue[match[1]:]
+	}
+	return newValue, true
 }
 
 // isExprLessThan compares two Expr statements. Currently, only labels are supported.


### PR DESCRIPTION
Substitute lets users perform substitution in string values using
regular expressions. This is a more powerful command than replace; it
should be useful for updating deps after moving a large number of
libraries.

Fixes #182