### PR TITLE
Change the genfile_check_test to a go_test.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,6 @@ test_suite(
     tests = [
         "//api_proto:api.gen.pb.go_checkshtest",
         "//build:go_default_test",
-        "//build:parse.y.go_checkshtest",
         "//build_proto:build.gen.pb.go_checkshtest",
         "//deps_proto:deps.gen.pb.go_checkshtest",
         "//edit:go_default_test",

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,18 +1,10 @@
 # gazelle:exclude parse.y.go
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load(":build_defs.bzl", "genfile_check_test", "go_yacc")
+load(":build_defs.bzl", "go_yacc")
 
 go_yacc(
     src = "parse.y",
     out = "parse.y.baz.go",
-)
-
-# parse.y.go is checked in to satisfy the Go community
-# https://github.com/bazelbuild/buildtools/issues/14
-# this test ensures it doesn't get stale.
-genfile_check_test(
-    src = "parse.y.go",
-    gen = "parse.y.baz.go",
 )
 
 go_library(
@@ -35,11 +27,18 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "checkfile_test.go",
         "parse_test.go",
         "print_test.go",
         "quote_test.go",
         "rule_test.go",
     ],
-    data = glob(["testdata/*"]),
+    data = glob(["testdata/*"]) + [
+        # parse.y.go is checked in to satisfy the Go community
+        # https://github.com/bazelbuild/buildtools/issues/14
+        # this test ensures it doesn't get stale.
+        "parse.y.baz.go",
+        "parse.y.go",
+    ],
     library = ":go_default_library",
 )

--- a/build/build_defs.bzl
+++ b/build/build_defs.bzl
@@ -30,4 +30,22 @@ def go_yacc(src, out, visibility=None):
       visibility = visibility,
       local = 1,
   )
-      
+
+def genfile_check_test(src, gen):
+  """Asserts that any checked-in generated code matches regen."""
+  if not src:
+    fail("src is required", "src")
+  if not gen:
+    fail("gen is required", "gen")
+  native.genrule(
+      name = src + "_checksh",
+      outs = [src + "_check.sh"],
+      cmd = "echo 'diff $$@' > $@",
+  )
+  native.sh_test(
+      name = src + "_checkshtest",
+      size = "small",
+      srcs = [src + "_check.sh"],
+      data = [src, gen],
+      args = ["$(location " + src + ")", "$(location " + gen + ")"],
+  )

--- a/build/build_defs.bzl
+++ b/build/build_defs.bzl
@@ -30,23 +30,4 @@ def go_yacc(src, out, visibility=None):
       visibility = visibility,
       local = 1,
   )
-
-def genfile_check_test(src, gen):
-  """Asserts that any checked-in generated code matches regen."""
-  if not src:
-    fail("src is required", "src")
-  if not gen:
-    fail("gen is required", "gen")
-  native.genrule(
-      name = src + "_checksh",
-      outs = [src + "_check.sh"],
-      cmd = "echo 'diff $$@' > $@",
-  )
-  native.sh_test(
-      name = src + "_checkshtest",
-      size = "small",
-      srcs = [src + "_check.sh"],
-      data = [src, gen],
-      args = ["$(location " + src + ")", "$(location " + gen + ")"],
-  )
       

--- a/build/build_defs.bzl
+++ b/build/build_defs.bzl
@@ -49,3 +49,4 @@ def genfile_check_test(src, gen):
       data = [src, gen],
       args = ["$(location " + src + ")", "$(location " + gen + ")"],
   )
+

--- a/build/checkfile_test.go
+++ b/build/checkfile_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package build
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestFilesMatch(t *testing.T) {
+	testdata := path.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), "build")
+
+	generated, err := ioutil.ReadFile(path.Join(testdata, "parse.y.baz.go"))
+	if err != nil {
+		t.Fatalf("Unexpected error reading generated file: %v", err)
+	}
+	checkedIn, err := ioutil.ReadFile(path.Join(testdata, "parse.y.go"))
+	if err != nil {
+		t.Fatalf("Unexpected error reading checked-in file: %v", err)
+	}
+
+	d, err := diff(generated, checkedIn)
+	if err != nil {
+		t.Fatalf("Unexpected error diffing files: %v", err)
+	}
+	if len(d) != 0 {
+		t.Errorf("Mismatch! diff: %v", string(d))
+	}
+}

--- a/build/checkfile_test.go
+++ b/build/checkfile_test.go
@@ -28,18 +28,18 @@ func TestFilesMatch(t *testing.T) {
 
 	generated, err := ioutil.ReadFile(path.Join(testdata, "parse.y.baz.go"))
 	if err != nil {
-		t.Fatalf("Unexpected error reading generated file: %v", err)
+		t.Fatalf("ReadFile(%q) = %v", "parse.y.baz.go", err)
 	}
 	checkedIn, err := ioutil.ReadFile(path.Join(testdata, "parse.y.go"))
 	if err != nil {
-		t.Fatalf("Unexpected error reading checked-in file: %v", err)
+		t.Fatalf("ReadFile(%q) = %v", "parse.y.go", err)
 	}
 
 	d, err := diff(generated, checkedIn)
 	if err != nil {
-		t.Fatalf("Unexpected error diffing files: %v", err)
+		t.Fatalf("diff(generated, checkedIn) = %v", err)
 	}
 	if len(d) != 0 {
-		t.Errorf("Mismatch! diff: %v", string(d))
+		t.Errorf("diff(generated, checkedIn) = %v", string(d))
 	}
 }


### PR DESCRIPTION
See the discussion in https://github.com/kubernetes/test-infra/pull/4859

This enables dep/Gazelle to strip this test when vendoring.