### PR TITLE
All of buildozer is aware of implicit names

### DIFF
--- a/build/rule.go
+++ b/build/rule.go
@@ -18,33 +18,48 @@ distributed under the License is distributed on an "AS IS" BASIS,
 
 package build
 
-import "strings"
+import (
+	"strings"
+	"path/filepath"
+)
 
 // A Rule represents a single BUILD rule.
 type Rule struct {
-	Call *CallExpr
+	Call         *CallExpr
+	ImplicitName string // The name which should be used if the name attribute is not set. See the comment on File.implicitRuleName.
+}
+
+func (f *File) Rule(call *CallExpr) *Rule {
+	r := &Rule{call, ""}
+	if r.AttrString("name") == "" {
+		r.ImplicitName = f.implicitRuleName()
+	}
+	return r
 }
 
 // Rules returns the rules in the file of the given kind (such as "go_library").
 // If kind == "", Rules returns all rules in the file.
 func (f *File) Rules(kind string) []*Rule {
 	var all []*Rule
+
 	for _, stmt := range f.Stmt {
 		call, ok := stmt.(*CallExpr)
 		if !ok {
 			continue
 		}
-		rule := &Rule{call}
+		rule := f.Rule(call)
 		if kind != "" && rule.Kind() != kind {
 			continue
 		}
 		all = append(all, rule)
 	}
+
 	return all
 }
 
 // RuleAt returns the rule in the file that starts at the specified line, or null if no such rule.
 func (f *File) RuleAt(linenum int) *Rule {
+
 	for _, stmt := range f.Stmt {
 		call, ok := stmt.(*CallExpr)
 		if !ok {
@@ -52,7 +67,7 @@ func (f *File) RuleAt(linenum int) *Rule {
 		}
 		start, end := call.X.Span()
 		if start.Line <= linenum && linenum <= end.Line {
-			return &Rule{call}
+			return f.Rule(call)
 		}
 	}
 	return nil
@@ -65,9 +80,9 @@ func (f *File) DelRules(kind, name string) int {
 	var i int
 	for _, stmt := range f.Stmt {
 		if call, ok := stmt.(*CallExpr); ok {
-			r := &Rule{call}
+			r := f.Rule(call)
 			if (kind == "" || r.Kind() == kind) &&
-				(name == "" || r.AttrString("name") == name) {
+				(name == "" || r.Name() == name) {
 				continue
 			}
 		}
@@ -77,6 +92,42 @@ func (f *File) DelRules(kind, name string) int {
 	n := len(f.Stmt) - i
 	f.Stmt = f.Stmt[:i]
 	return n
+}
+
+// If a build file contains exactly one unnamed rule, and no rules in the file explicitly have the
+// same name as the name of the directory the build file is in, we treat the unnamed rule as if it
+// had the name of the directory containing the BUILD file.
+// This is following a convention used in the Pants build system to cut down on boilerplate.
+func (f *File) implicitRuleName() string {
+	// We disallow empty names in the top-level BUILD files.
+	dir := filepath.Dir(f.Path)
+	if dir == "." {
+		return ""
+	}
+	sawAnonymousRule := false
+	possibleImplicitName := filepath.Base(dir)
+
+	for _, stmt := range f.Stmt {
+		call, ok := stmt.(*CallExpr)
+		if !ok {
+			continue
+		}
+		temp := &Rule{call, ""}
+		if temp.AttrString("name") == possibleImplicitName {
+			// A target explicitly has the name of the dir, so no implicit targets are allowed.
+			return ""
+		}
+		if temp.Kind() != "" && temp.AttrString("name") == "" {
+			if sawAnonymousRule {
+				return ""
+			}
+			sawAnonymousRule = true
+		}
+	}
+	if sawAnonymousRule {
+		return possibleImplicitName
+	}
+	return ""
 }
 
 // Kind returns the rule's kind (such as "go_library").
@@ -118,9 +169,13 @@ func (r *Rule) SetKind(kind string) {
 }
 
 // Name returns the rule's target name.
-// If the rule has no target name, Name returns the empty string.
+// If the rule has no explicit target name, Name returns the implicit name if there is one, else the empty string.
 func (r *Rule) Name() string {
-	return r.AttrString("name")
+	explicitName := r.AttrString("name")
+	if explicitName == "" {
+		return r.ImplicitName
+	}
+	return explicitName
 }
 
 // AttrKeys returns the keys of all the rule's attributes.

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -86,12 +86,12 @@ type File struct {
 	Stmt []Expr
 }
 
-func (x *File) Span() (start, end Position) {
-	if len(x.Stmt) == 0 {
+func (f *File) Span() (start, end Position) {
+	if len(f.Stmt) == 0 {
 		return
 	}
-	start, _ = x.Stmt[0].Span()
-	_, end = x.Stmt[len(x.Stmt)-1].Span()
+	start, _ = f.Stmt[0].Span()
+	_, end = f.Stmt[len(f.Stmt)-1].Span()
 	return start, end
 }
 

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -219,7 +219,7 @@ func cmdNew(opts *Options, env CmdEnvironment) (*build.File, error) {
 	}
 
 	call := &build.CallExpr{X: &build.LiteralExpr{Token: kind}}
-	rule := &build.Rule{Call: call}
+	rule := &build.Rule{call, ""}
 	rule.SetAttr("name", &build.StringExpr{Value: name})
 
 	if addAtEOF {
@@ -237,7 +237,7 @@ func findInsertionIndex(env CmdEnvironment) (bool, int, error) {
 	}
 
 	relativeToRuleName := env.Args[3]
-	ruleIdx := IndexOfRuleByName(env.File, relativeToRuleName)
+	ruleIdx, _ := IndexOfRuleByName(env.File, relativeToRuleName)
 	if ruleIdx == -1 {
 		return true, 0, nil
 	}
@@ -268,8 +268,10 @@ func cmdPrint(opts *Options, env CmdEnvironment) (*build.File, error) {
 		value := env.Rule.Attr(str)
 		if str == "kind" {
 			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{env.Rule.Kind()}}
+		} else if str == "name" {
+			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{env.Rule.Name()}}
 		} else if str == "label" {
-			if env.Rule.Attr("name") != nil {
+			if env.Rule.Name() != "" {
 				fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{fmt.Sprintf("//%s:%s", env.Pkg, env.Rule.Name())}}
 			} else {
 				return nil, nil

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -175,49 +175,6 @@ func TestAddValueToListAttribute(t *testing.T) {
 	}
 }
 
-func TestUseImplicitName(t *testing.T) {
-	tests := []struct {
-		input            string
-		expectedRuleLine int
-		wantErr          bool
-		wantRootErr      bool
-		description      string
-	}{
-		{`rule()`, 1, false, false, `Use an implicit name for one rule.`},
-		{`rule(name="a")
-rule(name="b")
-rule()`, 3, false, false, `Use an implicit name for the one unnamed rule`},
-		{`rule()
-rule()
-rule()`, 1, true, false, `Error for multiple unnamed rules`},
-		{`rule()`, 1, true, true, `Error for the root package`},
-	}
-
-	for _, tst := range tests {
-		path := "foo/BUILD"
-		if tst.wantRootErr {
-			path = "BUILD"
-		}
-		bld, err := build.Parse(path, []byte(tst.input))
-		if err != nil {
-			t.Error(tst.description, err)
-			continue
-		}
-		got := UseImplicitName(bld, "foo")
-
-		if !tst.wantErr {
-			want := bld.RuleAt(tst.expectedRuleLine)
-			if got.Kind() != want.Kind() || got.Name() != want.Name() {
-				t.Errorf("UseImplicitName(%s): got %s, expected %s. %s", tst.input, got, want, tst.description)
-			}
-		} else {
-			if got != nil {
-				t.Errorf("UseImplicitName(%s): got %s, expected nil. %s", tst.input, got, tst.description)
-			}
-		}
-	}
-}
-
 func TestListSubstitute(t *testing.T) {
 	tests := []struct {
 		desc, input, oldPattern, newTemplate, want string


### PR DESCRIPTION
This means that 'print' commands understand implicit names, and that
implicit names are understood by default in all commands, rather than
needing to be handled as special cases everywhere.