### PR TITLE
Support augmented assignments

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -352,11 +352,11 @@ func (in *input) Lex(val *yySymType) int {
 		in.readRune()
 		return c
 
-	case '.', '-', '%', ':', ';', ',', '/', '*': // single-char tokens
+	case '.', ':', ';', ',': // single-char tokens
 		in.readRune()
 		return c
 
-	case '<', '>', '=', '!', '+': // possibly followed by =
+	case '<', '>', '=', '!', '+', '-', '*', '/', '%': // possibly followed by =
 		in.readRune()
 		if in.peekRune() == '=' {
 			in.readRune()
@@ -369,8 +369,8 @@ func (in *input) Lex(val *yySymType) int {
 				return _EQ
 			case '!':
 				return _NE
-			case '+':
-				return _ADDEQ
+			default:
+				return _AUGM
 			}
 		}
 		return c

--- a/build/parse.y
+++ b/build/parse.y
@@ -70,7 +70,7 @@ package build
 // However, we do not want to export them from the Go package
 // we are creating, so prefix them all with underscores.
 
-%token	<pos>	_ADDEQ   // operator +=
+%token	<pos>	_AUGM    // augmented assignment
 %token	<pos>	_AND     // keyword and
 %token	<pos>	_COMMENT // top-level # comment
 %token	<pos>	_EOF     // end of file
@@ -133,13 +133,13 @@ package build
 
 %left	'\n'
 %left	_ASSERT
-// '=' and '+=' have the lowest precedence
+// '=' and augmented assignments have the lowest precedence
 // e.g. "x = a if c > 0 else 'bar'"
 // followed by
 // 'if' and 'else' which have lower precedence than all other operators.
 // e.g. "a, b if c > 0 else 'foo'" is either a tuple of (a,b) or 'foo'
 // and not a tuple of "(a, (b if ... ))"
-%left  '=' _ADDEQ
+%left  '=' _AUGM
 %left  _IF _ELSE _ELIF
 %left  ','
 %left  ':'
@@ -557,7 +557,7 @@ expr:
 |	expr _NE expr      { $$ = binary($1, $2, $<tok>2, $3) }
 |	expr _GE expr      { $$ = binary($1, $2, $<tok>2, $3) }
 |	expr '=' expr      { $$ = binary($1, $2, $<tok>2, $3) }
-|	expr _ADDEQ expr   { $$ = binary($1, $2, $<tok>2, $3) }
+|	expr _AUGM expr    { $$ = binary($1, $2, $<tok>2, $3) }
 |	expr _IN expr      { $$ = binary($1, $2, $<tok>2, $3) }
 |	expr _NOT _IN expr { $$ = binary($1, $2, "not in", $4) }
 |	expr _OR expr      { $$ = binary($1, $2, $<tok>2, $3) }

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -29,7 +29,7 @@ type yySymType struct {
 	lastRule Expr     // most recent rule, to attach line comments to
 }
 
-const _ADDEQ = 57346
+const _AUGM = 57346
 const _AND = 57347
 const _COMMENT = 57348
 const _EOF = 57349
@@ -78,7 +78,7 @@ var yyToknames = [...]string{
 	"']'",
 	"'{'",
 	"'}'",
-	"_ADDEQ",
+	"_AUGM",
 	"_AND",
 	"_COMMENT",
 	"_EOF",

--- a/build/testdata/052.golden
+++ b/build/testdata/052.golden
@@ -1,0 +1,9 @@
+foo += bar
+
+foo -= bar
+
+foo *= bar
+
+foo /= bar
+
+foo %= bar

--- a/build/testdata/052.in
+++ b/build/testdata/052.in
@@ -1,0 +1,5 @@
+foo+=bar
+foo-=bar
+foo*=bar
+foo/=bar
+foo%=bar


### PR DESCRIPTION
All augmented assignments except `//=` are supported here. `//=` will be supported in a follow-up commit because `//` is currenlty not supported too.

Fixes #200 