### PR TITLE
Treat 'load' as a syntax keyword

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -509,6 +509,7 @@ var keywordToken = map[string]int{
 	"in":     _IN,
 	"is":     _IS,
 	"lambda": _LAMBDA,
+	"load":   _LOAD,
 	"not":    _NOT,
 	"or":     _OR,
 	"def":    _DEF,

--- a/build/parse.y
+++ b/build/parse.y
@@ -84,6 +84,7 @@ package build
 %token	<pos>	_IN      // keyword in
 %token	<pos>	_IS      // keyword is
 %token	<pos>	_LAMBDA  // keyword lambda
+%token	<pos>	_LOAD    // keyword load
 %token	<pos>	_LE      // operator <=
 %token	<pos>	_NE      // operator !=
 %token	<pos>	_NOT     // keyword not
@@ -368,6 +369,17 @@ primary_expr:
 			Dot: $2,
 			NamePos: $3,
 			Name: $<tok>3,
+		}
+	}
+|	_LOAD '(' exprs_opt ')'
+	{
+		$$ = &CallExpr{
+                        X: &LiteralExpr{Start: $1, Token: "load"},
+			ListStart: $2,
+			List: $3,
+			End: End{Pos: $4},
+			ForceCompact: forceCompact($2, $3, $4),
+			ForceMultiLine: forceMultiLine($2, $3, $4),
 		}
 	}
 |	primary_expr '(' exprs_opt ')'

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -43,19 +43,20 @@ const _ELIF = 57356
 const _IN = 57357
 const _IS = 57358
 const _LAMBDA = 57359
-const _LE = 57360
-const _NE = 57361
-const _NOT = 57362
-const _OR = 57363
-const _PYTHON = 57364
-const _STRING = 57365
-const _DEF = 57366
-const _RETURN = 57367
-const _INDENT = 57368
-const _UNINDENT = 57369
-const ShiftInstead = 57370
-const _ASSERT = 57371
-const _UNARY = 57372
+const _LOAD = 57360
+const _LE = 57361
+const _NE = 57362
+const _NOT = 57363
+const _OR = 57364
+const _PYTHON = 57365
+const _STRING = 57366
+const _DEF = 57367
+const _RETURN = 57368
+const _INDENT = 57369
+const _UNINDENT = 57370
+const ShiftInstead = 57371
+const _ASSERT = 57372
+const _UNARY = 57373
 
 var yyToknames = [...]string{
 	"$end",
@@ -92,6 +93,7 @@ var yyToknames = [...]string{
 	"_IN",
 	"_IS",
 	"_LAMBDA",
+	"_LOAD",
 	"_LE",
 	"_NE",
 	"_NOT",
@@ -114,7 +116,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line build/parse.y:726
+//line build/parse.y:738
 
 // Go helper code.
 
@@ -247,113 +249,117 @@ var yyExca = [...]int{
 	-2, 0,
 }
 
-const yyNprod = 91
+const yyNprod = 92
 const yyPrivate = 57344
 
 var yyTokenNames []string
 var yyStates []string
 
-const yyLast = 694
+const yyLast = 739
 
 var yyAct = [...]int{
 
-	13, 110, 133, 2, 135, 72, 17, 7, 115, 67,
-	33, 9, 114, 79, 127, 57, 30, 58, 34, 63,
-	64, 65, 157, 29, 68, 70, 75, 100, 36, 37,
-	82, 162, 106, 77, 71, 74, 83, 82, 32, 86,
-	87, 88, 89, 90, 91, 92, 93, 94, 95, 96,
-	97, 98, 99, 163, 101, 102, 103, 104, 84, 159,
-	81, 108, 109, 24, 24, 20, 20, 150, 26, 26,
-	107, 28, 145, 117, 85, 23, 23, 25, 25, 117,
-	117, 63, 130, 120, 124, 122, 27, 27, 117, 131,
-	129, 128, 18, 18, 66, 19, 19, 15, 29, 29,
-	14, 136, 24, 123, 134, 174, 168, 26, 138, 113,
-	149, 167, 143, 144, 23, 69, 25, 126, 112, 144,
-	164, 140, 111, 146, 34, 27, 151, 153, 148, 146,
-	117, 146, 152, 60, 62, 156, 142, 29, 158, 59,
-	118, 154, 139, 161, 160, 61, 121, 39, 78, 146,
-	38, 41, 80, 42, 24, 40, 20, 39, 165, 26,
-	38, 166, 35, 169, 170, 40, 23, 171, 25, 161,
-	173, 7, 6, 1, 22, 11, 76, 27, 16, 73,
-	24, 31, 20, 18, 12, 26, 19, 8, 15, 29,
-	10, 14, 23, 172, 25, 5, 4, 147, 6, 3,
-	21, 11, 116, 27, 16, 119, 0, 0, 0, 18,
-	0, 0, 19, 0, 15, 29, 10, 14, 0, 39,
-	0, 5, 38, 41, 0, 42, 0, 40, 125, 43,
-	49, 44, 0, 0, 0, 0, 50, 54, 0, 0,
-	45, 0, 48, 0, 56, 0, 0, 51, 55, 0,
-	46, 47, 52, 53, 39, 0, 0, 38, 41, 0,
-	42, 0, 40, 155, 43, 49, 44, 0, 0, 0,
-	0, 50, 54, 0, 0, 45, 0, 48, 0, 56,
-	0, 0, 51, 55, 0, 46, 47, 52, 53, 39,
-	0, 0, 38, 41, 0, 42, 0, 40, 0, 43,
-	49, 44, 0, 141, 0, 0, 50, 54, 0, 0,
-	45, 0, 48, 0, 56, 0, 0, 51, 55, 0,
-	46, 47, 52, 53, 39, 0, 0, 38, 41, 0,
-	42, 0, 40, 0, 43, 49, 44, 0, 0, 0,
-	0, 50, 54, 0, 0, 45, 117, 48, 0, 56,
-	0, 0, 51, 55, 0, 46, 47, 52, 53, 39,
-	0, 0, 38, 41, 0, 42, 0, 40, 0, 43,
-	49, 44, 0, 0, 0, 0, 50, 54, 0, 0,
-	45, 0, 48, 0, 56, 137, 0, 51, 55, 0,
-	46, 47, 52, 53, 39, 0, 0, 38, 41, 0,
-	42, 0, 40, 132, 43, 49, 44, 0, 0, 0,
-	0, 50, 54, 0, 0, 45, 0, 48, 0, 56,
-	0, 0, 51, 55, 0, 46, 47, 52, 53, 39,
-	0, 0, 38, 41, 0, 42, 0, 40, 105, 43,
-	49, 44, 0, 0, 0, 0, 50, 54, 0, 0,
-	45, 0, 48, 0, 56, 0, 0, 51, 55, 0,
-	46, 47, 52, 53, 39, 0, 0, 38, 41, 0,
-	42, 0, 40, 0, 43, 49, 44, 0, 0, 0,
-	0, 50, 54, 0, 0, 45, 0, 48, 0, 56,
-	0, 0, 51, 55, 0, 46, 47, 52, 53, 39,
-	0, 0, 38, 41, 0, 42, 0, 40, 0, 43,
-	49, 44, 0, 0, 0, 0, 50, 54, 0, 0,
-	45, 0, 48, 0, 0, 0, 0, 51, 55, 0,
-	46, 47, 52, 53, 39, 0, 0, 38, 41, 0,
-	42, 0, 40, 0, 43, 0, 44, 0, 0, 0,
-	0, 0, 54, 0, 0, 45, 0, 48, 0, 56,
-	0, 0, 51, 55, 0, 46, 47, 52, 53, 39,
-	0, 0, 38, 41, 0, 42, 0, 40, 0, 43,
-	0, 44, 0, 0, 0, 0, 0, 54, 0, 0,
-	45, 0, 48, 0, 24, 0, 20, 51, 55, 26,
-	46, 47, 52, 53, 0, 0, 23, 0, 25, 0,
-	0, 0, 39, 0, 0, 38, 41, 27, 42, 0,
-	40, 0, 43, 18, 44, 0, 19, 0, 15, 29,
-	54, 14, 0, 45, 0, 48, 0, 0, 0, 0,
-	0, 0, 0, 46, 47, 39, 53, 0, 38, 41,
-	0, 42, 0, 40, 0, 43, 0, 44, 0, 0,
-	0, 39, 0, 54, 38, 41, 45, 42, 48, 40,
-	0, 43, 0, 44, 0, 0, 46, 47, 0, 0,
-	0, 0, 45, 0, 48, 0, 0, 0, 0, 0,
-	0, 0, 46, 47,
+	13, 112, 136, 2, 138, 74, 17, 7, 118, 69,
+	34, 9, 117, 81, 130, 58, 31, 59, 35, 64,
+	65, 66, 161, 30, 102, 70, 72, 77, 37, 38,
+	166, 84, 108, 33, 79, 73, 76, 85, 84, 120,
+	88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
+	98, 99, 100, 101, 167, 103, 104, 105, 106, 86,
+	163, 83, 110, 111, 154, 149, 153, 129, 64, 127,
+	120, 109, 29, 120, 178, 87, 25, 115, 20, 126,
+	120, 27, 116, 64, 133, 123, 120, 125, 24, 172,
+	26, 134, 132, 131, 171, 61, 68, 71, 114, 28,
+	168, 60, 113, 139, 145, 18, 22, 62, 121, 19,
+	141, 158, 30, 148, 146, 147, 63, 40, 142, 82,
+	39, 124, 147, 143, 67, 41, 150, 35, 80, 155,
+	157, 152, 150, 36, 150, 156, 40, 1, 160, 39,
+	42, 162, 43, 23, 41, 78, 165, 164, 75, 32,
+	12, 8, 150, 4, 151, 21, 119, 122, 25, 0,
+	20, 0, 169, 27, 0, 170, 0, 173, 174, 0,
+	24, 175, 26, 165, 177, 7, 6, 0, 25, 11,
+	0, 28, 16, 27, 0, 0, 0, 18, 22, 0,
+	24, 19, 26, 15, 30, 10, 14, 25, 176, 20,
+	5, 28, 27, 0, 0, 0, 0, 0, 22, 24,
+	0, 26, 0, 0, 30, 6, 3, 25, 11, 20,
+	28, 16, 27, 0, 0, 0, 18, 22, 0, 24,
+	19, 26, 15, 30, 10, 14, 0, 0, 0, 5,
+	28, 0, 0, 0, 0, 0, 18, 22, 0, 0,
+	19, 0, 15, 30, 40, 14, 0, 39, 42, 137,
+	43, 0, 41, 128, 44, 50, 45, 0, 0, 0,
+	0, 51, 55, 0, 0, 46, 0, 49, 0, 57,
+	0, 0, 52, 56, 0, 0, 47, 48, 53, 54,
+	40, 0, 0, 39, 42, 0, 43, 0, 41, 159,
+	44, 50, 45, 0, 0, 0, 0, 51, 55, 0,
+	0, 46, 0, 49, 0, 57, 0, 0, 52, 56,
+	0, 0, 47, 48, 53, 54, 40, 0, 0, 39,
+	42, 0, 43, 0, 41, 0, 44, 50, 45, 0,
+	144, 0, 0, 51, 55, 0, 0, 46, 0, 49,
+	0, 57, 0, 0, 52, 56, 0, 0, 47, 48,
+	53, 54, 40, 0, 0, 39, 42, 0, 43, 0,
+	41, 0, 44, 50, 45, 0, 0, 0, 0, 51,
+	55, 0, 0, 46, 120, 49, 0, 57, 0, 0,
+	52, 56, 0, 0, 47, 48, 53, 54, 40, 0,
+	0, 39, 42, 0, 43, 0, 41, 0, 44, 50,
+	45, 0, 0, 0, 0, 51, 55, 0, 0, 46,
+	0, 49, 0, 57, 140, 0, 52, 56, 0, 0,
+	47, 48, 53, 54, 40, 0, 0, 39, 42, 0,
+	43, 0, 41, 135, 44, 50, 45, 0, 0, 0,
+	0, 51, 55, 0, 0, 46, 0, 49, 0, 57,
+	0, 0, 52, 56, 0, 0, 47, 48, 53, 54,
+	40, 0, 0, 39, 42, 0, 43, 0, 41, 107,
+	44, 50, 45, 0, 0, 0, 0, 51, 55, 0,
+	0, 46, 0, 49, 0, 57, 0, 0, 52, 56,
+	0, 0, 47, 48, 53, 54, 40, 0, 0, 39,
+	42, 0, 43, 0, 41, 0, 44, 50, 45, 0,
+	0, 0, 0, 51, 55, 0, 0, 46, 0, 49,
+	0, 57, 0, 0, 52, 56, 0, 0, 47, 48,
+	53, 54, 40, 0, 0, 39, 42, 0, 43, 0,
+	41, 0, 44, 50, 45, 0, 0, 0, 0, 51,
+	55, 0, 0, 46, 0, 49, 0, 0, 0, 0,
+	52, 56, 0, 0, 47, 48, 53, 54, 40, 0,
+	0, 39, 42, 0, 43, 0, 41, 0, 44, 0,
+	45, 0, 0, 0, 0, 0, 55, 0, 0, 46,
+	0, 49, 0, 57, 0, 0, 52, 56, 0, 0,
+	47, 48, 53, 54, 40, 0, 0, 39, 42, 0,
+	43, 0, 41, 0, 44, 0, 45, 0, 0, 0,
+	0, 0, 55, 0, 0, 46, 0, 49, 0, 25,
+	0, 20, 52, 56, 27, 0, 47, 48, 53, 54,
+	0, 24, 0, 26, 0, 40, 0, 0, 39, 42,
+	0, 43, 28, 41, 0, 44, 0, 45, 18, 22,
+	0, 0, 19, 55, 15, 30, 46, 14, 49, 0,
+	0, 0, 0, 0, 0, 0, 0, 47, 48, 40,
+	54, 0, 39, 42, 0, 43, 0, 41, 0, 44,
+	0, 45, 0, 0, 0, 40, 0, 55, 39, 42,
+	46, 43, 49, 41, 0, 44, 0, 45, 0, 0,
+	0, 47, 48, 0, 0, 0, 46, 0, 49, 0,
+	0, 0, 0, 0, 0, 0, 0, 47, 48,
 }
 var yyPact = [...]int{
 
-	-1000, -1000, 175, -1000, -1000, -1000, -30, -1000, -1000, -1000,
-	10, 97, -2, 460, 59, -1000, 59, 128, 59, 59,
-	59, -1000, -17, 59, 59, 59, 97, -1000, -1000, -1000,
-	-1000, -36, 147, 28, 128, 59, 45, -1000, 59, 59,
-	59, 59, 59, 59, 59, 59, 59, 59, 59, 59,
-	59, 59, -5, 59, 59, 59, 59, 460, 425, 4,
-	59, 59, 109, 460, -1000, -1000, -1000, 91, 320, 131,
-	320, 140, 62, 83, 64, 215, 108, -1000, -32, 589,
-	59, 59, 97, 390, 58, -1000, -1000, -1000, -1000, 153,
-	153, 143, 143, 143, 143, 143, 143, 530, 530, 608,
-	59, 641, 657, 608, 355, 58, -1000, 136, 320, 285,
-	123, 59, 59, -1000, 54, -1000, -1000, 97, 59, -1000,
-	104, -1000, 47, -1000, -1000, 59, 59, -1000, -1000, 135,
-	250, 128, 58, -1000, -21, -1000, 608, 59, -1000, -1000,
-	53, -1000, 59, 565, 460, -1000, -1000, 2, 21, -1000,
-	-1000, 460, -1000, 215, 107, 58, -1000, -1000, 565, -1000,
-	93, 460, 59, 59, 58, -1000, 149, -1000, 59, 495,
-	495, -1000, -1000, 87, -1000,
+	-1000, -1000, 192, -1000, -1000, -1000, -31, -1000, -1000, -1000,
+	5, 173, -2, 502, 71, -1000, 71, 90, 71, 71,
+	71, -1000, 119, -18, 71, 71, 71, 173, -1000, -1000,
+	-1000, -1000, -37, 114, 29, 90, 71, 46, -1000, 71,
+	71, 71, 71, 71, 71, 71, 71, 71, 71, 71,
+	71, 71, 71, -8, 71, 71, 71, 71, 502, 466,
+	4, 71, 71, 89, 502, -1000, -1000, 71, -1000, 64,
+	358, 99, 358, 115, 13, 59, 49, 250, 58, -1000,
+	-33, 634, 71, 71, 173, 430, 212, -1000, -1000, -1000,
+	-1000, 113, 113, 132, 132, 132, 132, 132, 132, 574,
+	574, 651, 71, 685, 701, 651, 394, 212, -1000, 112,
+	358, 322, 91, 71, 71, 107, -1000, 47, -1000, -1000,
+	173, 71, -1000, 60, -1000, 44, -1000, -1000, 71, 71,
+	-1000, -1000, 105, 286, 90, 212, -1000, -22, -1000, 651,
+	71, -1000, -1000, 54, -1000, 71, 610, 502, -1000, -1000,
+	-1000, 1, 22, -1000, -1000, 502, -1000, 250, 87, 212,
+	-1000, -1000, 610, -1000, 76, 502, 71, 71, 212, -1000,
+	153, -1000, 71, 538, 538, -1000, -1000, 56, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 205, 0, 1, 6, 115, 9, 10, 202, 8,
-	12, 200, 197, 3, 196, 187, 184, 4, 11, 181,
-	5, 179, 176, 71, 174, 2, 173, 162, 148,
+	0, 157, 0, 1, 6, 97, 9, 10, 156, 8,
+	12, 155, 154, 3, 153, 151, 150, 4, 11, 149,
+	5, 148, 145, 72, 143, 2, 137, 133, 128,
 }
 var yyR1 = [...]int{
 
@@ -361,76 +367,76 @@ var yyR1 = [...]int{
 	15, 15, 15, 16, 16, 16, 27, 27, 17, 19,
 	19, 18, 18, 18, 18, 28, 28, 4, 4, 4,
 	4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-	4, 4, 4, 2, 2, 2, 2, 2, 2, 2,
+	4, 4, 4, 4, 2, 2, 2, 2, 2, 2,
 	2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-	2, 2, 2, 2, 2, 2, 3, 3, 1, 1,
-	20, 22, 22, 21, 21, 5, 5, 6, 6, 7,
-	7, 23, 24, 24, 11, 8, 9, 10, 10, 12,
-	12,
+	2, 2, 2, 2, 2, 2, 2, 3, 3, 1,
+	1, 20, 22, 22, 21, 21, 5, 5, 6, 6,
+	7, 7, 23, 24, 24, 11, 8, 9, 10, 10,
+	12, 12,
 }
 var yyR2 = [...]int{
 
 	0, 2, 4, 1, 0, 2, 2, 3, 1, 1,
 	7, 6, 1, 4, 5, 4, 2, 1, 4, 0,
 	3, 1, 2, 1, 1, 0, 1, 1, 3, 4,
-	4, 6, 8, 5, 1, 3, 4, 4, 4, 3,
-	3, 3, 2, 1, 4, 2, 2, 3, 3, 3,
+	4, 4, 6, 8, 5, 1, 3, 4, 4, 4,
+	3, 3, 3, 2, 1, 4, 2, 2, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	3, 4, 3, 3, 3, 5, 0, 1, 0, 1,
-	3, 1, 3, 1, 2, 1, 3, 0, 2, 1,
-	3, 1, 1, 2, 1, 4, 2, 1, 2, 0,
-	3,
+	3, 3, 4, 3, 3, 3, 5, 0, 1, 0,
+	1, 3, 1, 3, 1, 2, 1, 3, 0, 2,
+	1, 3, 1, 1, 2, 1, 4, 2, 1, 2,
+	0, 3,
 }
 var yyChk = [...]int{
 
-	-1000, -26, -13, 24, -14, 46, 23, -17, -15, -18,
-	41, 26, -16, -2, 42, 39, 29, -4, 34, 37,
-	7, -11, -24, 17, 5, 19, 10, 28, -23, 40,
-	46, -19, 28, -7, -4, -27, 30, 31, 7, 4,
-	12, 8, 10, 14, 16, 25, 35, 36, 27, 15,
-	21, 32, 37, 38, 22, 33, 29, -2, -2, 11,
-	5, 17, -5, -2, -2, -2, -23, -6, -2, -5,
-	-2, -6, -20, -21, -6, -2, -22, -4, -28, 49,
-	5, 32, 9, -2, 13, 29, -2, -2, -2, -2,
+	-1000, -26, -13, 24, -14, 47, 23, -17, -15, -18,
+	42, 26, -16, -2, 43, 40, 29, -4, 34, 38,
+	7, -11, 35, -24, 17, 5, 19, 10, 28, -23,
+	41, 47, -19, 28, -7, -4, -27, 30, 31, 7,
+	4, 12, 8, 10, 14, 16, 25, 36, 37, 27,
+	15, 21, 32, 38, 39, 22, 33, 29, -2, -2,
+	11, 5, 17, -5, -2, -2, -2, 5, -23, -6,
+	-2, -5, -2, -6, -20, -21, -6, -2, -22, -4,
+	-28, 50, 5, 32, 9, -2, 13, 29, -2, -2,
 	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	32, -2, -2, -2, -2, 13, 28, -6, -2, -2,
-	-3, 13, 9, 18, -10, -9, -8, 26, 9, -1,
-	-10, 6, -10, 20, 20, 13, 9, 46, -18, -6,
-	-2, -4, 13, -25, 46, -17, -2, 30, -25, 6,
-	-10, 18, 13, -2, -2, 18, -9, -12, -7, 6,
-	20, -2, -20, -2, 6, 13, -25, 43, -2, 6,
-	-3, -2, 29, 32, 13, -25, -13, 18, 13, -2,
-	-2, -25, 44, -3, 18,
+	-2, -2, 32, -2, -2, -2, -2, 13, 28, -6,
+	-2, -2, -3, 13, 9, -6, 18, -10, -9, -8,
+	26, 9, -1, -10, 6, -10, 20, 20, 13, 9,
+	47, -18, -6, -2, -4, 13, -25, 47, -17, -2,
+	30, -25, 6, -10, 18, 13, -2, -2, 6, 18,
+	-9, -12, -7, 6, 20, -2, -20, -2, 6, 13,
+	-25, 44, -2, 6, -3, -2, 29, 32, 13, -25,
+	-13, 18, 13, -2, -2, -25, 45, -3, 18,
 }
 var yyDef = [...]int{
 
 	4, -2, 0, 1, 5, 6, 0, 8, 9, 19,
-	0, 0, 12, 21, 23, 24, 0, 43, 0, 0,
-	0, 27, 34, 77, 77, 77, 0, 84, 82, 81,
-	7, 25, 0, 0, 79, 0, 0, 17, 0, 0,
+	0, 0, 12, 21, 23, 24, 0, 44, 0, 0,
+	0, 27, 0, 35, 78, 78, 78, 0, 85, 83,
+	82, 7, 25, 0, 0, 80, 0, 0, 17, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 22, 0, 0,
-	77, 66, 0, 75, 45, 46, 83, 0, 75, 68,
-	75, 0, 71, 0, 0, 75, 73, 42, 0, 26,
-	77, 0, 0, 0, 0, 16, 47, 48, 49, 50,
-	51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
-	0, 62, 63, 64, 0, 0, 28, 0, 75, 67,
-	0, 0, 0, 35, 0, 87, 89, 0, 69, 78,
-	0, 41, 0, 39, 40, 0, 74, 18, 20, 0,
-	0, 80, 0, 15, 0, 3, 61, 0, 13, 29,
-	0, 30, 66, 44, 76, 36, 88, 86, 0, 37,
-	38, 70, 72, 0, 0, 0, 14, 4, 65, 33,
-	0, 67, 0, 0, 0, 11, 0, 31, 66, 90,
-	85, 10, 2, 0, 32,
+	0, 0, 0, 0, 0, 0, 0, 0, 22, 0,
+	0, 78, 67, 0, 76, 46, 47, 78, 84, 0,
+	76, 69, 76, 0, 72, 0, 0, 76, 74, 43,
+	0, 26, 78, 0, 0, 0, 0, 16, 48, 49,
+	50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	60, 61, 0, 63, 64, 65, 0, 0, 28, 0,
+	76, 68, 0, 0, 0, 0, 36, 0, 88, 90,
+	0, 70, 79, 0, 42, 0, 40, 41, 0, 75,
+	18, 20, 0, 0, 81, 0, 15, 0, 3, 62,
+	0, 13, 30, 0, 31, 67, 45, 77, 29, 37,
+	89, 87, 0, 38, 39, 71, 73, 0, 0, 0,
+	14, 4, 66, 34, 0, 68, 0, 0, 0, 11,
+	0, 32, 67, 91, 86, 10, 2, 0, 33,
 }
 var yyTok1 = [...]int{
 
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	46, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+	47, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 4, 3, 3,
 	5, 6, 7, 8, 9, 10, 11, 12, 3, 3,
-	3, 3, 3, 3, 3, 3, 3, 3, 13, 49,
+	3, 3, 3, 3, 3, 3, 3, 3, 13, 50,
 	14, 15, 16, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -443,7 +449,7 @@ var yyTok2 = [...]int{
 
 	2, 3, 21, 22, 23, 24, 25, 26, 27, 28,
 	29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
-	39, 40, 41, 42, 43, 44, 45, 47, 48,
+	39, 40, 41, 42, 43, 44, 45, 46, 48, 49,
 }
 var yyTok3 = [...]int{
 	0,
@@ -788,14 +794,14 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:166
+		//line build/parse.y:167
 		{
 			yylex.(*input).file = &File{Stmt: yyDollar[1].exprs}
 			return 0
 		}
 	case 2:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:173
+		//line build/parse.y:174
 		{
 			yyVAL.block = CodeBlock{
 				Start:      yyDollar[2].pos,
@@ -805,7 +811,7 @@ yydefault:
 		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:181
+		//line build/parse.y:182
 		{
 			// simple_stmt is never empty
 			start, _ := yyDollar[1].exprs[0].Span()
@@ -818,14 +824,14 @@ yydefault:
 		}
 	case 4:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:193
+		//line build/parse.y:194
 		{
 			yyVAL.exprs = nil
 			yyVAL.lastRule = nil
 		}
 	case 5:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:198
+		//line build/parse.y:199
 		{
 			// If this statement follows a comment block,
 			// attach the comments to the statement.
@@ -858,7 +864,7 @@ yydefault:
 		}
 	case 6:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:229
+		//line build/parse.y:230
 		{
 			// Blank line; sever last rule from future comments.
 			yyVAL.exprs = yyDollar[1].exprs
@@ -866,7 +872,7 @@ yydefault:
 		}
 	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:235
+		//line build/parse.y:236
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = yyDollar[1].lastRule
@@ -880,19 +886,19 @@ yydefault:
 		}
 	case 8:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:249
+		//line build/parse.y:250
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 9:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:253
+		//line build/parse.y:254
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 10:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line build/parse.y:259
+		//line build/parse.y:260
 		{
 			yyVAL.expr = &FuncDef{
 				Start:          yyDollar[1].pos,
@@ -907,7 +913,7 @@ yydefault:
 		}
 	case 11:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:272
+		//line build/parse.y:273
 		{
 			yyVAL.expr = &ForLoop{
 				Start:    yyDollar[1].pos,
@@ -919,13 +925,13 @@ yydefault:
 		}
 	case 12:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:282
+		//line build/parse.y:283
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 13:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:288
+		//line build/parse.y:289
 		{
 			yyVAL.expr = &IfElse{
 				Start: yyDollar[1].pos,
@@ -940,7 +946,7 @@ yydefault:
 		}
 	case 14:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:301
+		//line build/parse.y:302
 		{
 			block := yyDollar[1].expr.(*IfElse)
 			block.Conditions = append(block.Conditions, Condition{
@@ -952,7 +958,7 @@ yydefault:
 		}
 	case 15:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:311
+		//line build/parse.y:312
 		{
 			block := yyDollar[1].expr.(*IfElse)
 			block.Conditions = append(block.Conditions, Condition{
@@ -963,26 +969,26 @@ yydefault:
 		}
 	case 18:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:326
+		//line build/parse.y:327
 		{
 			yyVAL.exprs = append([]Expr{yyDollar[1].expr}, yyDollar[2].exprs...)
 			yyVAL.lastRule = yyVAL.exprs[len(yyVAL.exprs)-1]
 		}
 	case 19:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:332
+		//line build/parse.y:333
 		{
 			yyVAL.exprs = []Expr{}
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:336
+		//line build/parse.y:337
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 22:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:343
+		//line build/parse.y:344
 		{
 			_, end := yyDollar[2].expr.Span()
 			yyVAL.expr = &ReturnExpr{
@@ -992,19 +998,19 @@ yydefault:
 		}
 	case 23:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:351
+		//line build/parse.y:352
 		{
 			yyVAL.expr = &ReturnExpr{End: yyDollar[1].pos}
 		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:355
+		//line build/parse.y:356
 		{
 			yyVAL.expr = &PythonBlock{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
 	case 28:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:365
+		//line build/parse.y:366
 		{
 			yyVAL.expr = &DotExpr{
 				X:       yyDollar[1].expr,
@@ -1015,7 +1021,20 @@ yydefault:
 		}
 	case 29:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:374
+		//line build/parse.y:375
+		{
+			yyVAL.expr = &CallExpr{
+				X:              &LiteralExpr{Start: yyDollar[1].pos, Token: "load"},
+				ListStart:      yyDollar[2].pos,
+				List:           yyDollar[3].exprs,
+				End:            End{Pos: yyDollar[4].pos},
+				ForceCompact:   forceCompact(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
+				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
+			}
+		}
+	case 30:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:386
 		{
 			yyVAL.expr = &CallExpr{
 				X:              yyDollar[1].expr,
@@ -1026,9 +1045,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 30:
+	case 31:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:385
+		//line build/parse.y:397
 		{
 			yyVAL.expr = &IndexExpr{
 				X:          yyDollar[1].expr,
@@ -1037,9 +1056,9 @@ yydefault:
 				End:        yyDollar[4].pos,
 			}
 		}
-	case 31:
+	case 32:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:394
+		//line build/parse.y:406
 		{
 			yyVAL.expr = &SliceExpr{
 				X:          yyDollar[1].expr,
@@ -1050,9 +1069,9 @@ yydefault:
 				End:        yyDollar[6].pos,
 			}
 		}
-	case 32:
+	case 33:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line build/parse.y:405
+		//line build/parse.y:417
 		{
 			yyVAL.expr = &SliceExpr{
 				X:           yyDollar[1].expr,
@@ -1065,9 +1084,9 @@ yydefault:
 				End:         yyDollar[8].pos,
 			}
 		}
-	case 33:
+	case 34:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:418
+		//line build/parse.y:430
 		{
 			yyVAL.expr = &CallExpr{
 				X:         yyDollar[1].expr,
@@ -1084,9 +1103,9 @@ yydefault:
 				End: End{Pos: yyDollar[5].pos},
 			}
 		}
-	case 34:
+	case 35:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:435
+		//line build/parse.y:447
 		{
 			if len(yyDollar[1].strings) == 1 {
 				yyVAL.expr = yyDollar[1].strings[0]
@@ -1098,9 +1117,9 @@ yydefault:
 				yyVAL.expr = binary(yyVAL.expr, end, "+", x)
 			}
 		}
-	case 35:
+	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:447
+		//line build/parse.y:459
 		{
 			yyVAL.expr = &ListExpr{
 				Start:          yyDollar[1].pos,
@@ -1110,27 +1129,13 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 36:
-		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:457
-		{
-			exprStart, _ := yyDollar[2].expr.Span()
-			yyVAL.expr = &ListForExpr{
-				Brack:          "[]",
-				Start:          yyDollar[1].pos,
-				X:              yyDollar[2].expr,
-				For:            yyDollar[3].forsifs,
-				End:            End{Pos: yyDollar[4].pos},
-				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
-			}
-		}
 	case 37:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		//line build/parse.y:469
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
-				Brack:          "()",
+				Brack:          "[]",
 				Start:          yyDollar[1].pos,
 				X:              yyDollar[2].expr,
 				For:            yyDollar[3].forsifs,
@@ -1144,7 +1149,7 @@ yydefault:
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
-				Brack:          "{}",
+				Brack:          "()",
 				Start:          yyDollar[1].pos,
 				X:              yyDollar[2].expr,
 				For:            yyDollar[3].forsifs,
@@ -1153,8 +1158,22 @@ yydefault:
 			}
 		}
 	case 39:
-		yyDollar = yyS[yypt-3 : yypt+1]
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line build/parse.y:493
+		{
+			exprStart, _ := yyDollar[2].expr.Span()
+			yyVAL.expr = &ListForExpr{
+				Brack:          "{}",
+				Start:          yyDollar[1].pos,
+				X:              yyDollar[2].expr,
+				For:            yyDollar[3].forsifs,
+				End:            End{Pos: yyDollar[4].pos},
+				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
+			}
+		}
+	case 40:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:505
 		{
 			yyVAL.expr = &DictExpr{
 				Start:          yyDollar[1].pos,
@@ -1164,9 +1183,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 40:
+	case 41:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:503
+		//line build/parse.y:515
 		{
 			yyVAL.expr = &SetExpr{
 				Start:          yyDollar[1].pos,
@@ -1176,9 +1195,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 41:
+	case 42:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:513
+		//line build/parse.y:525
 		{
 			if len(yyDollar[2].exprs) == 1 && yyDollar[2].comma.Line == 0 {
 				// Just a parenthesized expression, not a tuple.
@@ -1199,15 +1218,15 @@ yydefault:
 				}
 			}
 		}
-	case 42:
+	case 43:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:533
+		//line build/parse.y:545
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 44:
+	case 45:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:538
+		//line build/parse.y:550
 		{
 			yyVAL.expr = &LambdaExpr{
 				Lambda: yyDollar[1].pos,
@@ -1216,123 +1235,123 @@ yydefault:
 				Expr:   yyDollar[4].expr,
 			}
 		}
-	case 45:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:546
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
 	case 46:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:547
+		//line build/parse.y:558
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 47:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:548
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 48:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:549
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 49:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:550
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 50:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:551
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 51:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:552
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 52:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:553
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 53:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:554
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 54:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:555
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 55:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:556
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 56:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:557
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 57:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:558
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 58:
-		yyDollar = yyS[yypt-3 : yypt+1]
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line build/parse.y:559
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 59:
+	case 48:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:560
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 60:
+	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:561
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 61:
-		yyDollar = yyS[yypt-4 : yypt+1]
+	case 50:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:562
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 62:
+	case 51:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:563
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 63:
+	case 52:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:564
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 64:
+	case 53:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:565
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 54:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:566
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 55:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:567
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 56:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:568
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 57:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:569
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 58:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:570
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 59:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:571
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 60:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:572
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 61:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:573
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 62:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:574
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+		}
+	case 63:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:575
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 64:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:576
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 65:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:578
 		{
 			if b, ok := yyDollar[3].expr.(*UnaryExpr); ok && b.Op == "not" {
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "is not", b.X)
@@ -1340,9 +1359,9 @@ yydefault:
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 			}
 		}
-	case 65:
+	case 66:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:574
+		//line build/parse.y:586
 		{
 			yyVAL.expr = &ConditionalExpr{
 				Then:      yyDollar[1].expr,
@@ -1352,21 +1371,21 @@ yydefault:
 				Else:      yyDollar[5].expr,
 			}
 		}
-	case 66:
+	case 67:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:585
+		//line build/parse.y:597
 		{
 			yyVAL.expr = nil
 		}
-	case 68:
+	case 69:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:595
+		//line build/parse.y:607
 		{
 			yyVAL.pos = Position{}
 		}
-	case 70:
+	case 71:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:601
+		//line build/parse.y:613
 		{
 			yyVAL.expr = &KeyValueExpr{
 				Key:   yyDollar[1].expr,
@@ -1374,69 +1393,69 @@ yydefault:
 				Value: yyDollar[3].expr,
 			}
 		}
-	case 71:
+	case 72:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:611
+		//line build/parse.y:623
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 72:
+	case 73:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:615
+		//line build/parse.y:627
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 73:
-		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:621
-		{
-			yyVAL.exprs = yyDollar[1].exprs
-		}
 	case 74:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:625
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:633
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 75:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:637
+		{
+			yyVAL.exprs = yyDollar[1].exprs
+		}
+	case 76:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:631
+		//line build/parse.y:643
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 76:
+	case 77:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:635
+		//line build/parse.y:647
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 77:
+	case 78:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:640
+		//line build/parse.y:652
 		{
 			yyVAL.exprs, yyVAL.comma = nil, Position{}
 		}
-	case 78:
+	case 79:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:644
+		//line build/parse.y:656
 		{
 			yyVAL.exprs, yyVAL.comma = yyDollar[1].exprs, yyDollar[2].pos
 		}
-	case 79:
+	case 80:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:650
+		//line build/parse.y:662
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 80:
+	case 81:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:654
+		//line build/parse.y:666
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 81:
+	case 82:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:660
+		//line build/parse.y:672
 		{
 			yyVAL.string = &StringExpr{
 				Start:       yyDollar[1].pos,
@@ -1446,27 +1465,27 @@ yydefault:
 				Token:       yyDollar[1].tok,
 			}
 		}
-	case 82:
+	case 83:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:672
+		//line build/parse.y:684
 		{
 			yyVAL.strings = []*StringExpr{yyDollar[1].string}
 		}
-	case 83:
+	case 84:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:676
+		//line build/parse.y:688
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[2].string)
 		}
-	case 84:
+	case 85:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:682
+		//line build/parse.y:694
 		{
 			yyVAL.expr = &LiteralExpr{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 85:
+	case 86:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:688
+		//line build/parse.y:700
 		{
 			yyVAL.forc = &ForClause{
 				For:  yyDollar[1].pos,
@@ -1475,36 +1494,36 @@ yydefault:
 				Expr: yyDollar[4].expr,
 			}
 		}
-	case 86:
+	case 87:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:698
+		//line build/parse.y:710
 		{
 			yyVAL.forifs = &ForClauseWithIfClausesOpt{
 				For: yyDollar[1].forc,
 				Ifs: yyDollar[2].ifs,
 			}
 		}
-	case 87:
+	case 88:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:707
+		//line build/parse.y:719
 		{
 			yyVAL.forsifs = []*ForClauseWithIfClausesOpt{yyDollar[1].forifs}
 		}
-	case 88:
+	case 89:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:710
+		//line build/parse.y:722
 		{
 			yyVAL.forsifs = append(yyDollar[1].forsifs, yyDollar[2].forifs)
 		}
-	case 89:
+	case 90:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:715
+		//line build/parse.y:727
 		{
 			yyVAL.ifs = nil
 		}
-	case 90:
+	case 91:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:719
+		//line build/parse.y:731
 		{
 			yyVAL.ifs = append(yyDollar[1].ifs, &IfClause{
 				If:   yyDollar[2].pos,


### PR DESCRIPTION
After this change, 'load' cannot be used as an identifier.
AST isn't changed though (it still uses a CallExpr). Updating the AST
will require changing users of the library.