### PR TITLE
Introduce "Ident" node, to distinguish between numbers and idents.

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -485,6 +485,9 @@ func (in *input) Lex(val *yySymType) int {
 		return k
 	}
 
+	if '0' <= val.tok[0] && val.tok[0] <= '9' {
+		return _NUMBER
+	}
 	return _IDENT
 }
 
@@ -708,6 +711,8 @@ func (in *input) order(v Expr) {
 		}
 		in.order(&v.End)
 	case *PythonBlock:
+		// nothing
+	case *Ident:
 		// nothing
 	case *LiteralExpr:
 		// nothing

--- a/build/parse.y
+++ b/build/parse.y
@@ -77,7 +77,8 @@ package build
 %token	<pos>	_EQ      // operator ==
 %token	<pos>	_FOR     // keyword for
 %token	<pos>	_GE      // operator >=
-%token	<pos>	_IDENT   // non-keyword identifier or number
+%token	<pos>	_IDENT   // non-keyword identifier
+%token	<pos>	_NUMBER  // number
 %token	<pos>	_IF      // keyword if
 %token	<pos>	_ELSE    // keyword else
 %token	<pos>	_ELIF    // keyword elif
@@ -107,6 +108,7 @@ package build
 %type	<forifs>	for_clause_with_if_clauses_opt
 %type	<forsifs>	for_clauses_with_if_clauses_opt
 %type	<expr>		ident
+%type	<expr>		number
 %type	<ifs>		if_clauses_opt
 %type	<exprs>		stmts
 %type	<exprs>		stmt          // a simple_stmt or a for/if/def block
@@ -362,6 +364,7 @@ semi_opt:
 
 primary_expr:
 	ident
+|	number
 |	primary_expr '.' _IDENT
 	{
 		$$ = &DotExpr{
@@ -374,7 +377,7 @@ primary_expr:
 |	_LOAD '(' exprs_opt ')'
 	{
 		$$ = &CallExpr{
-                        X: &LiteralExpr{Start: $1, Token: "load"},
+                        X: &Ident{NamePos: $1, Name: "load"},
 			ListStart: $2,
 			List: $3,
 			End: End{Pos: $4},
@@ -692,6 +695,12 @@ strings:
 ident:
 	_IDENT
 	{
+		$$ = &Ident{NamePos: $1, Name: $<tok>1}
+	}
+
+number:
+	_NUMBER
+	{
 		$$ = &LiteralExpr{Start: $1, Token: $<tok>1}
 	}
 
@@ -769,11 +778,10 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 // a literal (variable, string or a number), a literal with a unary operator or an empty sequence.
 func isSimpleExpression(expr *Expr) bool {
 	switch x := (*expr).(type) {
-	case *LiteralExpr, *StringExpr:
+	case *Ident, *LiteralExpr, *StringExpr:
 		return true
 	case *UnaryExpr:
-		_, ok := x.X.(*LiteralExpr)
-		return ok
+                return isSimpleExpression(&x.X)
 	case *ListExpr:
 		return len(x.List) == 0
 	case *TupleExpr:

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -37,26 +37,27 @@ const _EQ = 57350
 const _FOR = 57351
 const _GE = 57352
 const _IDENT = 57353
-const _IF = 57354
-const _ELSE = 57355
-const _ELIF = 57356
-const _IN = 57357
-const _IS = 57358
-const _LAMBDA = 57359
-const _LOAD = 57360
-const _LE = 57361
-const _NE = 57362
-const _NOT = 57363
-const _OR = 57364
-const _PYTHON = 57365
-const _STRING = 57366
-const _DEF = 57367
-const _RETURN = 57368
-const _INDENT = 57369
-const _UNINDENT = 57370
-const ShiftInstead = 57371
-const _ASSERT = 57372
-const _UNARY = 57373
+const _NUMBER = 57354
+const _IF = 57355
+const _ELSE = 57356
+const _ELIF = 57357
+const _IN = 57358
+const _IS = 57359
+const _LAMBDA = 57360
+const _LOAD = 57361
+const _LE = 57362
+const _NE = 57363
+const _NOT = 57364
+const _OR = 57365
+const _PYTHON = 57366
+const _STRING = 57367
+const _DEF = 57368
+const _RETURN = 57369
+const _INDENT = 57370
+const _UNINDENT = 57371
+const ShiftInstead = 57372
+const _ASSERT = 57373
+const _UNARY = 57374
 
 var yyToknames = [...]string{
 	"$end",
@@ -87,6 +88,7 @@ var yyToknames = [...]string{
 	"_FOR",
 	"_GE",
 	"_IDENT",
+	"_NUMBER",
 	"_IF",
 	"_ELSE",
 	"_ELIF",
@@ -116,7 +118,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line build/parse.y:738
+//line build/parse.y:747
 
 // Go helper code.
 
@@ -150,11 +152,10 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 // a literal (variable, string or a number), a literal with a unary operator or an empty sequence.
 func isSimpleExpression(expr *Expr) bool {
 	switch x := (*expr).(type) {
-	case *LiteralExpr, *StringExpr:
+	case *Ident, *LiteralExpr, *StringExpr:
 		return true
 	case *UnaryExpr:
-		_, ok := x.X.(*LiteralExpr)
-		return ok
+		return isSimpleExpression(&x.X)
 	case *ListExpr:
 		return len(x.List) == 0
 	case *TupleExpr:
@@ -251,188 +252,199 @@ var yyExca = [...]int{
 
 const yyPrivate = 57344
 
-const yyLast = 739
+const yyLast = 814
 
 var yyAct = [...]int{
 
-	13, 112, 136, 2, 138, 74, 17, 7, 118, 69,
-	34, 9, 117, 81, 130, 58, 31, 59, 35, 64,
-	65, 66, 161, 30, 102, 70, 72, 77, 37, 38,
-	166, 84, 108, 33, 79, 73, 76, 85, 84, 120,
-	88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
-	98, 99, 100, 101, 167, 103, 104, 105, 106, 86,
-	163, 83, 110, 111, 154, 149, 153, 129, 64, 127,
-	120, 109, 29, 120, 178, 87, 25, 115, 20, 126,
-	120, 27, 116, 64, 133, 123, 120, 125, 24, 172,
-	26, 134, 132, 131, 171, 61, 68, 71, 114, 28,
-	168, 60, 113, 139, 145, 18, 22, 62, 121, 19,
-	141, 158, 30, 148, 146, 147, 63, 40, 142, 82,
-	39, 124, 147, 143, 67, 41, 150, 35, 80, 155,
-	157, 152, 150, 36, 150, 156, 40, 1, 160, 39,
-	42, 162, 43, 23, 41, 78, 165, 164, 75, 32,
-	12, 8, 150, 4, 151, 21, 119, 122, 25, 0,
-	20, 0, 169, 27, 0, 170, 0, 173, 174, 0,
-	24, 175, 26, 165, 177, 7, 6, 0, 25, 11,
-	0, 28, 16, 27, 0, 0, 0, 18, 22, 0,
-	24, 19, 26, 15, 30, 10, 14, 25, 176, 20,
-	5, 28, 27, 0, 0, 0, 0, 0, 22, 24,
-	0, 26, 0, 0, 30, 6, 3, 25, 11, 20,
-	28, 16, 27, 0, 0, 0, 18, 22, 0, 24,
-	19, 26, 15, 30, 10, 14, 0, 0, 0, 5,
-	28, 0, 0, 0, 0, 0, 18, 22, 0, 0,
-	19, 0, 15, 30, 40, 14, 0, 39, 42, 137,
-	43, 0, 41, 128, 44, 50, 45, 0, 0, 0,
-	0, 51, 55, 0, 0, 46, 0, 49, 0, 57,
-	0, 0, 52, 56, 0, 0, 47, 48, 53, 54,
-	40, 0, 0, 39, 42, 0, 43, 0, 41, 159,
-	44, 50, 45, 0, 0, 0, 0, 51, 55, 0,
-	0, 46, 0, 49, 0, 57, 0, 0, 52, 56,
-	0, 0, 47, 48, 53, 54, 40, 0, 0, 39,
-	42, 0, 43, 0, 41, 0, 44, 50, 45, 0,
-	144, 0, 0, 51, 55, 0, 0, 46, 0, 49,
-	0, 57, 0, 0, 52, 56, 0, 0, 47, 48,
-	53, 54, 40, 0, 0, 39, 42, 0, 43, 0,
-	41, 0, 44, 50, 45, 0, 0, 0, 0, 51,
-	55, 0, 0, 46, 120, 49, 0, 57, 0, 0,
-	52, 56, 0, 0, 47, 48, 53, 54, 40, 0,
-	0, 39, 42, 0, 43, 0, 41, 0, 44, 50,
-	45, 0, 0, 0, 0, 51, 55, 0, 0, 46,
-	0, 49, 0, 57, 140, 0, 52, 56, 0, 0,
-	47, 48, 53, 54, 40, 0, 0, 39, 42, 0,
-	43, 0, 41, 135, 44, 50, 45, 0, 0, 0,
-	0, 51, 55, 0, 0, 46, 0, 49, 0, 57,
-	0, 0, 52, 56, 0, 0, 47, 48, 53, 54,
-	40, 0, 0, 39, 42, 0, 43, 0, 41, 107,
-	44, 50, 45, 0, 0, 0, 0, 51, 55, 0,
-	0, 46, 0, 49, 0, 57, 0, 0, 52, 56,
-	0, 0, 47, 48, 53, 54, 40, 0, 0, 39,
-	42, 0, 43, 0, 41, 0, 44, 50, 45, 0,
-	0, 0, 0, 51, 55, 0, 0, 46, 0, 49,
-	0, 57, 0, 0, 52, 56, 0, 0, 47, 48,
-	53, 54, 40, 0, 0, 39, 42, 0, 43, 0,
-	41, 0, 44, 50, 45, 0, 0, 0, 0, 51,
-	55, 0, 0, 46, 0, 49, 0, 0, 0, 0,
-	52, 56, 0, 0, 47, 48, 53, 54, 40, 0,
-	0, 39, 42, 0, 43, 0, 41, 0, 44, 0,
-	45, 0, 0, 0, 0, 0, 55, 0, 0, 46,
-	0, 49, 0, 57, 0, 0, 52, 56, 0, 0,
-	47, 48, 53, 54, 40, 0, 0, 39, 42, 0,
-	43, 0, 41, 0, 44, 0, 45, 0, 0, 0,
-	0, 0, 55, 0, 0, 46, 0, 49, 0, 25,
-	0, 20, 52, 56, 27, 0, 47, 48, 53, 54,
-	0, 24, 0, 26, 0, 40, 0, 0, 39, 42,
-	0, 43, 28, 41, 0, 44, 0, 45, 18, 22,
-	0, 0, 19, 55, 15, 30, 46, 14, 49, 0,
-	0, 0, 0, 0, 0, 0, 0, 47, 48, 40,
-	54, 0, 39, 42, 0, 43, 0, 41, 0, 44,
-	0, 45, 0, 0, 0, 40, 0, 55, 39, 42,
-	46, 43, 49, 41, 0, 44, 0, 45, 0, 0,
-	0, 47, 48, 0, 0, 0, 46, 0, 49, 0,
-	0, 0, 0, 0, 0, 0, 0, 47, 48,
+	13, 114, 138, 2, 140, 76, 17, 7, 120, 71,
+	36, 9, 119, 83, 132, 60, 33, 61, 37, 66,
+	67, 68, 163, 32, 104, 168, 72, 74, 79, 39,
+	40, 110, 86, 35, 156, 81, 75, 78, 86, 87,
+	122, 165, 90, 91, 92, 93, 94, 95, 96, 97,
+	98, 99, 100, 101, 102, 103, 169, 105, 106, 107,
+	108, 122, 85, 88, 112, 113, 151, 122, 131, 129,
+	66, 155, 31, 111, 122, 128, 26, 174, 20, 117,
+	89, 28, 173, 73, 180, 66, 135, 125, 25, 127,
+	27, 122, 63, 136, 134, 133, 118, 70, 62, 29,
+	30, 170, 65, 147, 64, 141, 18, 23, 123, 160,
+	19, 150, 143, 32, 144, 42, 148, 149, 41, 44,
+	126, 45, 116, 43, 149, 145, 115, 42, 152, 37,
+	41, 157, 159, 154, 152, 43, 152, 158, 84, 69,
+	162, 82, 38, 164, 1, 24, 80, 77, 167, 166,
+	34, 12, 8, 4, 152, 153, 22, 21, 121, 124,
+	26, 0, 20, 0, 171, 28, 0, 172, 0, 175,
+	176, 0, 25, 177, 27, 167, 179, 7, 6, 0,
+	0, 11, 0, 29, 30, 16, 0, 0, 0, 0,
+	18, 23, 0, 0, 19, 0, 15, 32, 10, 14,
+	26, 178, 20, 5, 0, 28, 0, 0, 0, 0,
+	0, 0, 25, 0, 27, 0, 0, 0, 6, 3,
+	0, 11, 0, 29, 30, 16, 0, 0, 0, 0,
+	18, 23, 0, 0, 19, 0, 15, 32, 10, 14,
+	26, 0, 20, 5, 0, 28, 0, 0, 0, 0,
+	0, 0, 25, 0, 27, 0, 0, 0, 0, 0,
+	0, 0, 0, 29, 30, 0, 0, 0, 0, 0,
+	18, 23, 0, 0, 19, 0, 15, 32, 42, 14,
+	0, 41, 44, 139, 45, 0, 43, 130, 46, 52,
+	47, 0, 0, 0, 0, 53, 57, 0, 0, 48,
+	0, 51, 0, 0, 59, 0, 0, 54, 58, 0,
+	0, 49, 50, 55, 56, 42, 0, 0, 41, 44,
+	0, 45, 0, 43, 161, 46, 52, 47, 0, 0,
+	0, 0, 53, 57, 0, 0, 48, 0, 51, 0,
+	0, 59, 0, 0, 54, 58, 0, 0, 49, 50,
+	55, 56, 42, 0, 0, 41, 44, 0, 45, 0,
+	43, 0, 46, 52, 47, 0, 146, 0, 0, 53,
+	57, 0, 0, 48, 0, 51, 0, 0, 59, 0,
+	0, 54, 58, 0, 0, 49, 50, 55, 56, 42,
+	0, 0, 41, 44, 0, 45, 0, 43, 0, 46,
+	52, 47, 0, 0, 0, 0, 53, 57, 0, 0,
+	48, 122, 51, 0, 0, 59, 0, 0, 54, 58,
+	0, 0, 49, 50, 55, 56, 42, 0, 0, 41,
+	44, 0, 45, 0, 43, 0, 46, 52, 47, 0,
+	0, 0, 0, 53, 57, 0, 0, 48, 0, 51,
+	0, 0, 59, 142, 0, 54, 58, 0, 0, 49,
+	50, 55, 56, 42, 0, 0, 41, 44, 0, 45,
+	0, 43, 137, 46, 52, 47, 0, 0, 0, 0,
+	53, 57, 0, 0, 48, 0, 51, 0, 0, 59,
+	0, 0, 54, 58, 0, 0, 49, 50, 55, 56,
+	42, 0, 0, 41, 44, 0, 45, 0, 43, 109,
+	46, 52, 47, 0, 0, 0, 0, 53, 57, 0,
+	0, 48, 0, 51, 0, 0, 59, 0, 0, 54,
+	58, 0, 0, 49, 50, 55, 56, 42, 0, 0,
+	41, 44, 0, 45, 0, 43, 0, 46, 52, 47,
+	0, 0, 0, 0, 53, 57, 0, 0, 48, 0,
+	51, 0, 0, 59, 0, 0, 54, 58, 0, 0,
+	49, 50, 55, 56, 42, 0, 0, 41, 44, 0,
+	45, 0, 43, 0, 46, 52, 47, 0, 0, 0,
+	0, 53, 57, 0, 0, 48, 0, 51, 0, 0,
+	0, 0, 0, 54, 58, 0, 0, 49, 50, 55,
+	56, 42, 0, 0, 41, 44, 0, 45, 0, 43,
+	0, 46, 0, 47, 0, 0, 0, 0, 0, 57,
+	0, 0, 48, 0, 51, 0, 0, 59, 0, 0,
+	54, 58, 0, 0, 49, 50, 55, 56, 26, 0,
+	20, 0, 0, 28, 0, 0, 0, 0, 0, 0,
+	25, 0, 27, 0, 0, 0, 0, 0, 0, 0,
+	0, 29, 30, 0, 0, 0, 0, 0, 18, 23,
+	0, 0, 19, 0, 15, 32, 42, 14, 0, 41,
+	44, 0, 45, 0, 43, 0, 46, 0, 47, 0,
+	0, 0, 0, 0, 57, 0, 0, 48, 0, 51,
+	0, 0, 0, 0, 0, 54, 58, 0, 0, 49,
+	50, 55, 56, 42, 0, 0, 41, 44, 0, 45,
+	0, 43, 0, 46, 0, 47, 0, 26, 0, 0,
+	0, 57, 28, 0, 48, 0, 51, 0, 0, 25,
+	0, 27, 0, 0, 0, 0, 49, 50, 0, 56,
+	29, 30, 0, 42, 0, 0, 41, 44, 23, 45,
+	0, 43, 0, 46, 32, 47, 0, 0, 0, 42,
+	0, 57, 41, 44, 48, 45, 51, 43, 0, 46,
+	0, 47, 0, 0, 0, 0, 49, 50, 0, 0,
+	48, 0, 51, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 49, 50,
 }
 var yyPact = [...]int{
 
-	-1000, -1000, 192, -1000, -1000, -1000, -31, -1000, -1000, -1000,
-	5, 173, -2, 502, 71, -1000, 71, 90, 71, 71,
-	71, -1000, 119, -18, 71, 71, 71, 173, -1000, -1000,
-	-1000, -1000, -37, 114, 29, 90, 71, 46, -1000, 71,
-	71, 71, 71, 71, 71, 71, 71, 71, 71, 71,
-	71, 71, 71, -8, 71, 71, 71, 71, 502, 466,
-	4, 71, 71, 89, 502, -1000, -1000, 71, -1000, 64,
-	358, 99, 358, 115, 13, 59, 49, 250, 58, -1000,
-	-33, 634, 71, 71, 173, 430, 212, -1000, -1000, -1000,
-	-1000, 113, 113, 132, 132, 132, 132, 132, 132, 574,
-	574, 651, 71, 685, 701, 651, 394, 212, -1000, 112,
-	358, 322, 91, 71, 71, 107, -1000, 47, -1000, -1000,
-	173, 71, -1000, 60, -1000, 44, -1000, -1000, 71, 71,
-	-1000, -1000, 105, 286, 90, 212, -1000, -22, -1000, 651,
-	71, -1000, -1000, 54, -1000, 71, 610, 502, -1000, -1000,
-	-1000, 1, 22, -1000, -1000, 502, -1000, 250, 87, 212,
-	-1000, -1000, 610, -1000, 76, 502, 71, 71, 212, -1000,
-	153, -1000, 71, 538, 538, -1000, -1000, 56, -1000,
+	-1000, -1000, 195, -1000, -1000, -1000, -32, -1000, -1000, -1000,
+	5, 732, -2, 533, 71, -1000, 71, 87, 71, 71,
+	71, -1000, -1000, 134, -19, 71, 71, 71, 732, -1000,
+	-1000, -1000, -1000, -1000, -38, 133, 29, 87, 71, 50,
+	-1000, 71, 71, 71, 71, 71, 71, 71, 71, 71,
+	71, 71, 71, 71, 71, -9, 71, 71, 71, 71,
+	533, 496, 3, 71, 71, 113, 533, -1000, -1000, 71,
+	-1000, 78, 385, 99, 385, 114, 41, 55, 49, 274,
+	59, -1000, -34, 643, 71, 71, 732, 459, 235, -1000,
+	-1000, -1000, -1000, 123, 123, 111, 111, 111, 111, 111,
+	111, 607, 607, 719, 71, 759, 775, 719, 422, 235,
+	-1000, 108, 385, 348, 90, 71, 71, 105, -1000, 48,
+	-1000, -1000, 732, 71, -1000, 65, -1000, 14, -1000, -1000,
+	71, 71, -1000, -1000, 103, 311, 87, 235, -1000, -23,
+	-1000, 719, 71, -1000, -1000, 35, -1000, 71, 682, 533,
+	-1000, -1000, -1000, -5, 23, -1000, -1000, 533, -1000, 274,
+	88, 235, -1000, -1000, 682, -1000, 64, 533, 71, 71,
+	235, -1000, 155, -1000, 71, 570, 570, -1000, -1000, 66,
+	-1000,
 }
 var yyPgo = [...]int{
 
-	0, 157, 0, 1, 6, 97, 9, 10, 156, 8,
-	12, 155, 154, 3, 153, 151, 150, 4, 11, 149,
-	5, 148, 145, 72, 143, 2, 137, 133, 128,
+	0, 159, 0, 1, 6, 83, 9, 10, 158, 8,
+	12, 157, 156, 155, 3, 153, 152, 151, 4, 11,
+	150, 5, 147, 146, 72, 145, 2, 144, 142, 141,
 }
 var yyR1 = [...]int{
 
-	0, 26, 25, 25, 13, 13, 13, 13, 14, 14,
-	15, 15, 15, 16, 16, 16, 27, 27, 17, 19,
-	19, 18, 18, 18, 18, 28, 28, 4, 4, 4,
+	0, 27, 26, 26, 14, 14, 14, 14, 15, 15,
+	16, 16, 16, 17, 17, 17, 28, 28, 18, 20,
+	20, 19, 19, 19, 19, 29, 29, 4, 4, 4,
 	4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-	4, 4, 4, 4, 2, 2, 2, 2, 2, 2,
+	4, 4, 4, 4, 4, 2, 2, 2, 2, 2,
 	2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-	2, 2, 2, 2, 2, 2, 2, 3, 3, 1,
-	1, 20, 22, 22, 21, 21, 5, 5, 6, 6,
-	7, 7, 23, 24, 24, 11, 8, 9, 10, 10,
-	12, 12,
+	2, 2, 2, 2, 2, 2, 2, 2, 3, 3,
+	1, 1, 21, 23, 23, 22, 22, 5, 5, 6,
+	6, 7, 7, 24, 25, 25, 11, 12, 8, 9,
+	10, 10, 13, 13,
 }
 var yyR2 = [...]int{
 
 	0, 2, 4, 1, 0, 2, 2, 3, 1, 1,
 	7, 6, 1, 4, 5, 4, 2, 1, 4, 0,
-	3, 1, 2, 1, 1, 0, 1, 1, 3, 4,
-	4, 4, 6, 8, 5, 1, 3, 4, 4, 4,
-	3, 3, 3, 2, 1, 4, 2, 2, 3, 3,
+	3, 1, 2, 1, 1, 0, 1, 1, 1, 3,
+	4, 4, 4, 6, 8, 5, 1, 3, 4, 4,
+	4, 3, 3, 3, 2, 1, 4, 2, 2, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	3, 3, 4, 3, 3, 3, 5, 0, 1, 0,
-	1, 3, 1, 3, 1, 2, 1, 3, 0, 2,
-	1, 3, 1, 1, 2, 1, 4, 2, 1, 2,
-	0, 3,
+	3, 3, 3, 4, 3, 3, 3, 5, 0, 1,
+	0, 1, 3, 1, 3, 1, 2, 1, 3, 0,
+	2, 1, 3, 1, 1, 2, 1, 1, 4, 2,
+	1, 2, 0, 3,
 }
 var yyChk = [...]int{
 
-	-1000, -26, -13, 24, -14, 47, 23, -17, -15, -18,
-	42, 26, -16, -2, 43, 40, 29, -4, 34, 38,
-	7, -11, 35, -24, 17, 5, 19, 10, 28, -23,
-	41, 47, -19, 28, -7, -4, -27, 30, 31, 7,
-	4, 12, 8, 10, 14, 16, 25, 36, 37, 27,
-	15, 21, 32, 38, 39, 22, 33, 29, -2, -2,
-	11, 5, 17, -5, -2, -2, -2, 5, -23, -6,
-	-2, -5, -2, -6, -20, -21, -6, -2, -22, -4,
-	-28, 50, 5, 32, 9, -2, 13, 29, -2, -2,
+	-1000, -27, -14, 24, -15, 48, 23, -18, -16, -19,
+	43, 26, -17, -2, 44, 41, 30, -4, 35, 39,
+	7, -11, -12, 36, -25, 17, 5, 19, 10, 28,
+	29, -24, 42, 48, -20, 28, -7, -4, -28, 31,
+	32, 7, 4, 12, 8, 10, 14, 16, 25, 37,
+	38, 27, 15, 21, 33, 39, 40, 22, 34, 30,
+	-2, -2, 11, 5, 17, -5, -2, -2, -2, 5,
+	-24, -6, -2, -5, -2, -6, -21, -22, -6, -2,
+	-23, -4, -29, 51, 5, 33, 9, -2, 13, 30,
 	-2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-	-2, -2, 32, -2, -2, -2, -2, 13, 28, -6,
-	-2, -2, -3, 13, 9, -6, 18, -10, -9, -8,
-	26, 9, -1, -10, 6, -10, 20, 20, 13, 9,
-	47, -18, -6, -2, -4, 13, -25, 47, -17, -2,
-	30, -25, 6, -10, 18, 13, -2, -2, 6, 18,
-	-9, -12, -7, 6, 20, -2, -20, -2, 6, 13,
-	-25, 44, -2, 6, -3, -2, 29, 32, 13, -25,
-	-13, 18, 13, -2, -2, -25, 45, -3, 18,
+	-2, -2, -2, -2, 33, -2, -2, -2, -2, 13,
+	28, -6, -2, -2, -3, 13, 9, -6, 18, -10,
+	-9, -8, 26, 9, -1, -10, 6, -10, 20, 20,
+	13, 9, 48, -19, -6, -2, -4, 13, -26, 48,
+	-18, -2, 31, -26, 6, -10, 18, 13, -2, -2,
+	6, 18, -9, -13, -7, 6, 20, -2, -21, -2,
+	6, 13, -26, 45, -2, 6, -3, -2, 30, 33,
+	13, -26, -14, 18, 13, -2, -2, -26, 46, -3,
+	18,
 }
 var yyDef = [...]int{
 
 	4, -2, 0, 1, 5, 6, 0, 8, 9, 19,
-	0, 0, 12, 21, 23, 24, 0, 44, 0, 0,
-	0, 27, 0, 35, 78, 78, 78, 0, 85, 83,
-	82, 7, 25, 0, 0, 80, 0, 0, 17, 0,
+	0, 0, 12, 21, 23, 24, 0, 45, 0, 0,
+	0, 27, 28, 0, 36, 79, 79, 79, 0, 86,
+	87, 84, 83, 7, 25, 0, 0, 81, 0, 0,
+	17, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 22, 0,
-	0, 78, 67, 0, 76, 46, 47, 78, 84, 0,
-	76, 69, 76, 0, 72, 0, 0, 76, 74, 43,
-	0, 26, 78, 0, 0, 0, 0, 16, 48, 49,
-	50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-	60, 61, 0, 63, 64, 65, 0, 0, 28, 0,
-	76, 68, 0, 0, 0, 0, 36, 0, 88, 90,
-	0, 70, 79, 0, 42, 0, 40, 41, 0, 75,
-	18, 20, 0, 0, 81, 0, 15, 0, 3, 62,
-	0, 13, 30, 0, 31, 67, 45, 77, 29, 37,
-	89, 87, 0, 38, 39, 71, 73, 0, 0, 0,
-	14, 4, 66, 34, 0, 68, 0, 0, 0, 11,
-	0, 32, 67, 91, 86, 10, 2, 0, 33,
+	22, 0, 0, 79, 68, 0, 77, 47, 48, 79,
+	85, 0, 77, 70, 77, 0, 73, 0, 0, 77,
+	75, 44, 0, 26, 79, 0, 0, 0, 0, 16,
+	49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
+	59, 60, 61, 62, 0, 64, 65, 66, 0, 0,
+	29, 0, 77, 69, 0, 0, 0, 0, 37, 0,
+	90, 92, 0, 71, 80, 0, 43, 0, 41, 42,
+	0, 76, 18, 20, 0, 0, 82, 0, 15, 0,
+	3, 63, 0, 13, 31, 0, 32, 68, 46, 78,
+	30, 38, 91, 89, 0, 39, 40, 72, 74, 0,
+	0, 0, 14, 4, 67, 35, 0, 69, 0, 0,
+	0, 11, 0, 33, 68, 93, 88, 10, 2, 0,
+	34,
 }
 var yyTok1 = [...]int{
 
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	47, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+	48, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 4, 3, 3,
 	5, 6, 7, 8, 9, 10, 11, 12, 3, 3,
-	3, 3, 3, 3, 3, 3, 3, 3, 13, 50,
+	3, 3, 3, 3, 3, 3, 3, 3, 13, 51,
 	14, 15, 16, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -445,7 +457,8 @@ var yyTok2 = [...]int{
 
 	2, 3, 21, 22, 23, 24, 25, 26, 27, 28,
 	29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
-	39, 40, 41, 42, 43, 44, 45, 46, 48, 49,
+	39, 40, 41, 42, 43, 44, 45, 46, 47, 49,
+	50,
 }
 var yyTok3 = [...]int{
 	0,
@@ -790,14 +803,14 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:167
+		//line build/parse.y:169
 		{
 			yylex.(*input).file = &File{Stmt: yyDollar[1].exprs}
 			return 0
 		}
 	case 2:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:174
+		//line build/parse.y:176
 		{
 			yyVAL.block = CodeBlock{
 				Start:      yyDollar[2].pos,
@@ -807,7 +820,7 @@ yydefault:
 		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:182
+		//line build/parse.y:184
 		{
 			// simple_stmt is never empty
 			start, _ := yyDollar[1].exprs[0].Span()
@@ -820,14 +833,14 @@ yydefault:
 		}
 	case 4:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:194
+		//line build/parse.y:196
 		{
 			yyVAL.exprs = nil
 			yyVAL.lastRule = nil
 		}
 	case 5:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:199
+		//line build/parse.y:201
 		{
 			// If this statement follows a comment block,
 			// attach the comments to the statement.
@@ -860,7 +873,7 @@ yydefault:
 		}
 	case 6:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:230
+		//line build/parse.y:232
 		{
 			// Blank line; sever last rule from future comments.
 			yyVAL.exprs = yyDollar[1].exprs
@@ -868,7 +881,7 @@ yydefault:
 		}
 	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:236
+		//line build/parse.y:238
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = yyDollar[1].lastRule
@@ -882,19 +895,19 @@ yydefault:
 		}
 	case 8:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:250
+		//line build/parse.y:252
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 9:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:254
+		//line build/parse.y:256
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 10:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line build/parse.y:260
+		//line build/parse.y:262
 		{
 			yyVAL.expr = &FuncDef{
 				Start:          yyDollar[1].pos,
@@ -909,7 +922,7 @@ yydefault:
 		}
 	case 11:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:273
+		//line build/parse.y:275
 		{
 			yyVAL.expr = &ForLoop{
 				Start:    yyDollar[1].pos,
@@ -921,13 +934,13 @@ yydefault:
 		}
 	case 12:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:283
+		//line build/parse.y:285
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 13:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:289
+		//line build/parse.y:291
 		{
 			yyVAL.expr = &IfElse{
 				Start: yyDollar[1].pos,
@@ -942,7 +955,7 @@ yydefault:
 		}
 	case 14:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:302
+		//line build/parse.y:304
 		{
 			block := yyDollar[1].expr.(*IfElse)
 			block.Conditions = append(block.Conditions, Condition{
@@ -954,7 +967,7 @@ yydefault:
 		}
 	case 15:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:312
+		//line build/parse.y:314
 		{
 			block := yyDollar[1].expr.(*IfElse)
 			block.Conditions = append(block.Conditions, Condition{
@@ -965,26 +978,26 @@ yydefault:
 		}
 	case 18:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:327
+		//line build/parse.y:329
 		{
 			yyVAL.exprs = append([]Expr{yyDollar[1].expr}, yyDollar[2].exprs...)
 			yyVAL.lastRule = yyVAL.exprs[len(yyVAL.exprs)-1]
 		}
 	case 19:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:333
+		//line build/parse.y:335
 		{
 			yyVAL.exprs = []Expr{}
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:337
+		//line build/parse.y:339
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 22:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:344
+		//line build/parse.y:346
 		{
 			_, end := yyDollar[2].expr.Span()
 			yyVAL.expr = &ReturnExpr{
@@ -994,19 +1007,19 @@ yydefault:
 		}
 	case 23:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:352
+		//line build/parse.y:354
 		{
 			yyVAL.expr = &ReturnExpr{End: yyDollar[1].pos}
 		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:356
+		//line build/parse.y:358
 		{
 			yyVAL.expr = &PythonBlock{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 28:
+	case 29:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:366
+		//line build/parse.y:369
 		{
 			yyVAL.expr = &DotExpr{
 				X:       yyDollar[1].expr,
@@ -1015,12 +1028,12 @@ yydefault:
 				Name:    yyDollar[3].tok,
 			}
 		}
-	case 29:
+	case 30:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:375
+		//line build/parse.y:378
 		{
 			yyVAL.expr = &CallExpr{
-				X:              &LiteralExpr{Start: yyDollar[1].pos, Token: "load"},
+				X:              &Ident{NamePos: yyDollar[1].pos, Name: "load"},
 				ListStart:      yyDollar[2].pos,
 				List:           yyDollar[3].exprs,
 				End:            End{Pos: yyDollar[4].pos},
@@ -1028,9 +1041,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 30:
+	case 31:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:386
+		//line build/parse.y:389
 		{
 			yyVAL.expr = &CallExpr{
 				X:              yyDollar[1].expr,
@@ -1041,9 +1054,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 31:
+	case 32:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:397
+		//line build/parse.y:400
 		{
 			yyVAL.expr = &IndexExpr{
 				X:          yyDollar[1].expr,
@@ -1052,9 +1065,9 @@ yydefault:
 				End:        yyDollar[4].pos,
 			}
 		}
-	case 32:
+	case 33:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:406
+		//line build/parse.y:409
 		{
 			yyVAL.expr = &SliceExpr{
 				X:          yyDollar[1].expr,
@@ -1065,9 +1078,9 @@ yydefault:
 				End:        yyDollar[6].pos,
 			}
 		}
-	case 33:
+	case 34:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line build/parse.y:417
+		//line build/parse.y:420
 		{
 			yyVAL.expr = &SliceExpr{
 				X:           yyDollar[1].expr,
@@ -1080,9 +1093,9 @@ yydefault:
 				End:         yyDollar[8].pos,
 			}
 		}
-	case 34:
+	case 35:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:430
+		//line build/parse.y:433
 		{
 			yyVAL.expr = &CallExpr{
 				X:         yyDollar[1].expr,
@@ -1099,9 +1112,9 @@ yydefault:
 				End: End{Pos: yyDollar[5].pos},
 			}
 		}
-	case 35:
+	case 36:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:447
+		//line build/parse.y:450
 		{
 			if len(yyDollar[1].strings) == 1 {
 				yyVAL.expr = yyDollar[1].strings[0]
@@ -1113,9 +1126,9 @@ yydefault:
 				yyVAL.expr = binary(yyVAL.expr, end, "+", x)
 			}
 		}
-	case 36:
+	case 37:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:459
+		//line build/parse.y:462
 		{
 			yyVAL.expr = &ListExpr{
 				Start:          yyDollar[1].pos,
@@ -1125,9 +1138,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 37:
+	case 38:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:469
+		//line build/parse.y:472
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -1139,9 +1152,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 38:
+	case 39:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:481
+		//line build/parse.y:484
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -1153,9 +1166,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 39:
+	case 40:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:493
+		//line build/parse.y:496
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &ListForExpr{
@@ -1167,9 +1180,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 40:
+	case 41:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:505
+		//line build/parse.y:508
 		{
 			yyVAL.expr = &DictExpr{
 				Start:          yyDollar[1].pos,
@@ -1179,9 +1192,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 41:
+	case 42:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:515
+		//line build/parse.y:518
 		{
 			yyVAL.expr = &SetExpr{
 				Start:          yyDollar[1].pos,
@@ -1191,9 +1204,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 42:
+	case 43:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:525
+		//line build/parse.y:528
 		{
 			if len(yyDollar[2].exprs) == 1 && yyDollar[2].comma.Line == 0 {
 				// Just a parenthesized expression, not a tuple.
@@ -1214,15 +1227,15 @@ yydefault:
 				}
 			}
 		}
-	case 43:
+	case 44:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:545
+		//line build/parse.y:548
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 45:
+	case 46:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:550
+		//line build/parse.y:553
 		{
 			yyVAL.expr = &LambdaExpr{
 				Lambda: yyDollar[1].pos,
@@ -1231,123 +1244,123 @@ yydefault:
 				Expr:   yyDollar[4].expr,
 			}
 		}
-	case 46:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:558
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
 	case 47:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:559
+		//line build/parse.y:561
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 48:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:560
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 49:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:561
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 50:
-		yyDollar = yyS[yypt-3 : yypt+1]
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line build/parse.y:562
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 51:
+	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:563
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 52:
+	case 50:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:564
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 53:
+	case 51:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:565
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 54:
+	case 52:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:566
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 55:
+	case 53:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:567
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 56:
+	case 54:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:568
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 57:
+	case 55:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:569
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 58:
+	case 56:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:570
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 59:
+	case 57:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:571
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 60:
+	case 58:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:572
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 61:
+	case 59:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:573
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 62:
-		yyDollar = yyS[yypt-4 : yypt+1]
+	case 60:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:574
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 63:
+	case 61:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:575
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 64:
+	case 62:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:576
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 65:
+	case 63:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:577
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+		}
+	case 64:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:578
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 65:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:579
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 66:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:581
 		{
 			if b, ok := yyDollar[3].expr.(*UnaryExpr); ok && b.Op == "not" {
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "is not", b.X)
@@ -1355,9 +1368,9 @@ yydefault:
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 			}
 		}
-	case 66:
+	case 67:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:586
+		//line build/parse.y:589
 		{
 			yyVAL.expr = &ConditionalExpr{
 				Then:      yyDollar[1].expr,
@@ -1367,21 +1380,21 @@ yydefault:
 				Else:      yyDollar[5].expr,
 			}
 		}
-	case 67:
+	case 68:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:597
+		//line build/parse.y:600
 		{
 			yyVAL.expr = nil
 		}
-	case 69:
+	case 70:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:607
+		//line build/parse.y:610
 		{
 			yyVAL.pos = Position{}
 		}
-	case 71:
+	case 72:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:613
+		//line build/parse.y:616
 		{
 			yyVAL.expr = &KeyValueExpr{
 				Key:   yyDollar[1].expr,
@@ -1389,69 +1402,69 @@ yydefault:
 				Value: yyDollar[3].expr,
 			}
 		}
-	case 72:
+	case 73:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:623
+		//line build/parse.y:626
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 73:
+	case 74:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:627
+		//line build/parse.y:630
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 74:
-		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:633
-		{
-			yyVAL.exprs = yyDollar[1].exprs
-		}
 	case 75:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:637
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:636
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 76:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:640
+		{
+			yyVAL.exprs = yyDollar[1].exprs
+		}
+	case 77:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:643
+		//line build/parse.y:646
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 77:
+	case 78:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:647
+		//line build/parse.y:650
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 78:
+	case 79:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:652
+		//line build/parse.y:655
 		{
 			yyVAL.exprs, yyVAL.comma = nil, Position{}
 		}
-	case 79:
+	case 80:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:656
+		//line build/parse.y:659
 		{
 			yyVAL.exprs, yyVAL.comma = yyDollar[1].exprs, yyDollar[2].pos
 		}
-	case 80:
+	case 81:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:662
+		//line build/parse.y:665
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 81:
+	case 82:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:666
+		//line build/parse.y:669
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 82:
+	case 83:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:672
+		//line build/parse.y:675
 		{
 			yyVAL.string = &StringExpr{
 				Start:       yyDollar[1].pos,
@@ -1461,27 +1474,33 @@ yydefault:
 				Token:       yyDollar[1].tok,
 			}
 		}
-	case 83:
+	case 84:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:684
+		//line build/parse.y:687
 		{
 			yyVAL.strings = []*StringExpr{yyDollar[1].string}
 		}
-	case 84:
+	case 85:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:688
+		//line build/parse.y:691
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[2].string)
 		}
-	case 85:
+	case 86:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:694
+		//line build/parse.y:697
+		{
+			yyVAL.expr = &Ident{NamePos: yyDollar[1].pos, Name: yyDollar[1].tok}
+		}
+	case 87:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line build/parse.y:703
 		{
 			yyVAL.expr = &LiteralExpr{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 86:
+	case 88:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:700
+		//line build/parse.y:709
 		{
 			yyVAL.forc = &ForClause{
 				For:  yyDollar[1].pos,
@@ -1490,36 +1509,36 @@ yydefault:
 				Expr: yyDollar[4].expr,
 			}
 		}
-	case 87:
+	case 89:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:710
+		//line build/parse.y:719
 		{
 			yyVAL.forifs = &ForClauseWithIfClausesOpt{
 				For: yyDollar[1].forc,
 				Ifs: yyDollar[2].ifs,
 			}
 		}
-	case 88:
+	case 90:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:719
+		//line build/parse.y:728
 		{
 			yyVAL.forsifs = []*ForClauseWithIfClausesOpt{yyDollar[1].forifs}
 		}
-	case 89:
+	case 91:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:722
+		//line build/parse.y:731
 		{
 			yyVAL.forsifs = append(yyDollar[1].forsifs, yyDollar[2].forifs)
 		}
-	case 90:
+	case 92:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:727
+		//line build/parse.y:736
 		{
 			yyVAL.ifs = nil
 		}
-	case 91:
+	case 93:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:731
+		//line build/parse.y:740
 		{
 			yyVAL.ifs = append(yyDollar[1].ifs, &IfClause{
 				If:   yyDollar[2].pos,

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -132,16 +132,16 @@ var parseTests = []struct {
 			Path: "test",
 			Stmt: []Expr{
 				&CallExpr{
-					X: &LiteralExpr{
-						Start: Position{1, 1, 0},
-						Token: "go_binary",
+					X: &Ident{
+						NamePos: Position{1, 1, 0},
+						Name:    "go_binary",
 					},
 					ListStart: Position{1, 10, 9},
 					List: []Expr{
 						&BinaryExpr{
-							X: &LiteralExpr{
-								Start: Position{1, 11, 10},
-								Token: "name",
+							X: &Ident{
+								NamePos: Position{1, 11, 10},
+								Name:    "name",
 							},
 							OpStart: Position{1, 16, 15},
 							Op:      "=",
@@ -167,9 +167,9 @@ var parseTests = []struct {
 				&CallExpr{
 					X: &DotExpr{
 						X: &DotExpr{
-							X: &LiteralExpr{
-								Start: Position{1, 1, 0},
-								Token: "foo",
+							X: &Ident{
+								NamePos: Position{1, 1, 0},
+								Name:    "foo",
 							},
 							Dot:     Position{1, 4, 3},
 							NamePos: Position{1, 5, 4},
@@ -182,9 +182,9 @@ var parseTests = []struct {
 					ListStart: Position{1, 12, 11},
 					List: []Expr{
 						&BinaryExpr{
-							X: &LiteralExpr{
-								Start: Position{1, 13, 12},
-								Token: "name",
+							X: &Ident{
+								NamePos: Position{1, 13, 12},
+								Name:    "name",
 							},
 							OpStart: Position{1, 18, 17},
 							Op:      "=",

--- a/build/print.go
+++ b/build/print.go
@@ -189,11 +189,11 @@ func isCall(x Expr, name string) bool {
 	if !ok {
 		return false
 	}
-	nam, ok := c.X.(*LiteralExpr)
+	nam, ok := c.X.(*Ident)
 	if !ok {
 		return false
 	}
-	return nam.Token == name
+	return nam.Name == name
 }
 
 // isCodeBlock checks if the statement is a code block (def, if, for, etc.)
@@ -329,6 +329,9 @@ func (p *printer) expr(v Expr, outerPrec int) {
 
 	case *LiteralExpr:
 		p.printf("%s", v.Token)
+
+	case *Ident:
+		p.printf("%s", v.Name)
 
 	case *StringExpr:
 		// If the Token is a correct quoting of Value, use it.

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -259,8 +259,8 @@ func fixLabels(f *File, info *RewriteInfo) {
 				if !ok || as.Op != "=" {
 					continue
 				}
-				key, ok := as.X.(*LiteralExpr)
-				if !ok || !tables.IsLabelArg[key.Token] || tables.LabelBlacklist[callName(v)+"."+key.Token] {
+				key, ok := as.X.(*Ident)
+				if !ok || !tables.IsLabelArg[key.Name] || tables.LabelBlacklist[callName(v)+"."+key.Name] {
 					continue
 				}
 				if leaveAlone1(as.Y) {
@@ -295,11 +295,11 @@ func fixLabels(f *File, info *RewriteInfo) {
 // callName returns the name of the rule being called by call.
 // If the call is not to a literal rule name, callName returns "".
 func callName(call *CallExpr) string {
-	rule, ok := call.X.(*LiteralExpr)
+	rule, ok := call.X.(*Ident)
 	if !ok {
 		return ""
 	}
-	return rule.Token
+	return rule.Name
 }
 
 // sortCallArgs sorts lists of named arguments to a call.
@@ -369,8 +369,8 @@ func ruleNamePriority(rule, arg string) int {
 // Otherwise argName returns "".
 func argName(x Expr) string {
 	if as, ok := x.(*BinaryExpr); ok && as.Op == "=" {
-		if id, ok := as.X.(*LiteralExpr); ok {
-			return id.Token
+		if id, ok := as.X.(*Ident); ok {
+			return id.Name
 		}
 	}
 	return ""
@@ -420,12 +420,12 @@ func sortStringLists(f *File, info *RewriteInfo) {
 				if !ok || as.Op != "=" || leaveAlone1(as) || doNotSort(as) {
 					continue
 				}
-				key, ok := as.X.(*LiteralExpr)
+				key, ok := as.X.(*Ident)
 				if !ok {
 					continue
 				}
-				context := rule + "." + key.Token
-				if !tables.IsSortableListArg[key.Token] || tables.SortableBlacklist[context] {
+				context := rule + "." + key.Name
+				if !tables.IsSortableListArg[key.Name] || tables.SortableBlacklist[context] {
 					continue
 				}
 				if disabled("unsafesort") && !tables.SortableWhitelist[context] && !allowedSort(context) {
@@ -569,11 +569,11 @@ func callArgName(stk []Expr) string {
 	if !ok {
 		return ""
 	}
-	rule, ok := call.X.(*LiteralExpr)
+	rule, ok := call.X.(*Ident)
 	if !ok {
 		return ""
 	}
-	return rule.Token + "." + arg
+	return rule.Name + "." + arg
 }
 
 // A stringSortKey records information about a single string literal to be

--- a/build/rule.go
+++ b/build/rule.go
@@ -145,11 +145,11 @@ func (r *Rule) Kind() string {
 		names = append(names, x.Name)
 		expr = x.X
 	}
-	x, ok := expr.(*LiteralExpr)
+	x, ok := expr.(*Ident)
 	if !ok {
 		return ""
 	}
-	names = append(names, x.Token)
+	names = append(names, x.Name)
 	// Reverse the elements since the deepest expression contains the leading literal
 	for l, r := 0, len(names)-1; l < r; l, r = l+1, r-1 {
 		names[l], names[r] = names[r], names[l]
@@ -161,7 +161,7 @@ func (r *Rule) Kind() string {
 func (r *Rule) SetKind(kind string) {
 	names := strings.Split(kind, ".")
 	var expr Expr
-	expr = &LiteralExpr{Token: names[0]}
+	expr = &Ident{Name: names[0]}
 	for _, name := range names[1:] {
 		expr = &DotExpr{X: expr, Name: name}
 	}
@@ -183,8 +183,8 @@ func (r *Rule) AttrKeys() []string {
 	var keys []string
 	for _, expr := range r.Call.List {
 		if binExpr, ok := expr.(*BinaryExpr); ok && binExpr.Op == "=" {
-			if keyExpr, ok := binExpr.X.(*LiteralExpr); ok {
-				keys = append(keys, keyExpr.Token)
+			if keyExpr, ok := binExpr.X.(*Ident); ok {
+				keys = append(keys, keyExpr.Name)
 			}
 		}
 	}
@@ -200,8 +200,8 @@ func (r *Rule) AttrDefn(key string) *BinaryExpr {
 		if !ok || as.Op != "=" {
 			continue
 		}
-		k, ok := as.X.(*LiteralExpr)
-		if !ok || k.Token != key {
+		k, ok := as.X.(*Ident)
+		if !ok || k.Name != key {
 			continue
 		}
 		return as
@@ -229,8 +229,8 @@ func (r *Rule) DelAttr(key string) Expr {
 		if !ok || as.Op != "=" {
 			continue
 		}
-		k, ok := as.X.(*LiteralExpr)
-		if !ok || k.Token != key {
+		k, ok := as.X.(*Ident)
+		if !ok || k.Name != key {
 			continue
 		}
 		copy(list[i:], list[i+1:])
@@ -265,11 +265,11 @@ func (r *Rule) SetAttr(key string, val Expr) {
 // If the rule has no such attribute or the attribute is not an identifier or number,
 // AttrLiteral returns "".
 func (r *Rule) AttrLiteral(key string) string {
-	lit, ok := r.Attr(key).(*LiteralExpr)
+	lit, ok := r.Attr(key).(*Ident)
 	if !ok {
 		return ""
 	}
-	return lit.Token
+	return lit.Name
 }
 
 // AttrString returns the value of the rule's attribute

--- a/build/rule_test.go
+++ b/build/rule_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 var simpleCall *CallExpr = &CallExpr{
-	X: &LiteralExpr{
-		Token: "java_library",
+	X: &Ident{
+		Name: "java_library",
 	},
 	List: []Expr{
 		&BinaryExpr{
-			X: &LiteralExpr{
-				Token: "name",
+			X: &Ident{
+				Name: "name",
 			},
 			Op: "=",
 			Y: &StringExpr{
@@ -39,8 +39,8 @@ var simpleRule *Rule = &Rule{simpleCall, ""}
 var structCall *CallExpr = &CallExpr{
 	X: &DotExpr{
 		X: &DotExpr{
-			X: &LiteralExpr{
-				Token: "foo",
+			X: &Ident{
+				Name: "foo",
 			},
 			Name: "bar",
 		},
@@ -48,8 +48,8 @@ var structCall *CallExpr = &CallExpr{
 	},
 	List: []Expr{
 		&BinaryExpr{
-			X: &LiteralExpr{
-				Token: "name",
+			X: &Ident{
+				Name: "name",
 			},
 			Op: "=",
 			Y: &StringExpr{
@@ -73,13 +73,13 @@ func TestKind(t *testing.T) {
 func TestSetKind(t *testing.T) {
 	rule := &Rule{
 		&CallExpr{
-			X: &LiteralExpr{
-				Token: "java_library",
+			X: &Ident{
+				Name: "java_library",
 			},
 			List: []Expr{
 				&BinaryExpr{
-					X: &LiteralExpr{
-						Token: "name",
+					X: &Ident{
+						Name: "name",
 					},
 					Op: "=",
 					Y: &StringExpr{
@@ -92,13 +92,13 @@ func TestSetKind(t *testing.T) {
 	}
 
 	rule.SetKind("java_binary")
-	compare(t, rule.Call.X, &LiteralExpr{Token: "java_binary"})
+	compare(t, rule.Call.X, &Ident{Name: "java_binary"})
 
 	rule.SetKind("foo.bar.baz")
 	compare(t, rule.Call.X, &DotExpr{
 		X: &DotExpr{
-			X: &LiteralExpr{
-				Token: "foo",
+			X: &Ident{
+				Name: "foo",
 			},
 			Name: "bar",
 		},

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -117,7 +117,18 @@ func (x *PythonBlock) Span() (start, end Position) {
 	return x.Start, x.Start.add(x.Token)
 }
 
-// A LiteralExpr represents a literal identifier or number.
+// An Ident represents an identifier.
+type Ident struct {
+	Comments
+	NamePos Position
+	Name    string
+}
+
+func (x *Ident) Span() (start, end Position) {
+	return x.NamePos, x.NamePos.add(x.Name)
+}
+
+// A LiteralExpr represents a literal number.
 type LiteralExpr struct {
 	Comments
 	Start Position

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -81,7 +81,7 @@ func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	attr := env.Args[0]
 	for _, val := range env.Args[1:] {
 		if IsIntList(attr) {
-			AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
+			AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.Ident{Name: val}, &env.Vars)
 			continue
 		}
 		strVal := &build.StringExpr{Value: ShortenLabel(val, env.Pkg)}
@@ -218,7 +218,7 @@ func cmdNew(opts *Options, env CmdEnvironment) (*build.File, error) {
 		return nil, fmt.Errorf("rule '%s' already exists", name)
 	}
 
-	call := &build.CallExpr{X: &build.LiteralExpr{Token: kind}}
+	call := &build.CallExpr{X: &build.Ident{Name: kind}}
 	rule := &build.Rule{call, ""}
 	rule.SetAttr("name", &build.StringExpr{Value: name})
 
@@ -288,8 +288,8 @@ func cmdPrint(opts *Options, env CmdEnvironment) (*build.File, error) {
 			fmt.Fprintf(os.Stderr, "rule \"//%s:%s\" has no attribute \"%s\"\n",
 				env.Pkg, env.Rule.Name(), str)
 			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Error{Error: apipb.Output_Record_Field_MISSING}}
-		} else if lit, ok := value.(*build.LiteralExpr); ok {
-			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{lit.Token}}
+		} else if lit, ok := value.(*build.Ident); ok {
+			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{lit.Name}}
 		} else if string, ok := value.(*build.StringExpr); ok {
 			fields[i] = &apipb.Output_Record_Field{
 				Value:             &apipb.Output_Record_Field_Text{string.Value},
@@ -409,7 +409,7 @@ func getAttrValueExpr(attr string, args []string) build.Expr {
 	case IsIntList(attr):
 		var list []build.Expr
 		for _, i := range args {
-			list = append(list, &build.LiteralExpr{Token: i})
+			list = append(list, &build.Ident{Name: i})
 		}
 		return &build.ListExpr{List: list}
 	case IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")):
@@ -421,7 +421,7 @@ func getAttrValueExpr(attr string, args []string) build.Expr {
 	case IsString(attr):
 		return &build.StringExpr{Value: args[0]}
 	default:
-		return &build.LiteralExpr{Token: args[0]}
+		return &build.Ident{Name: args[0]}
 	}
 }
 
@@ -638,8 +638,8 @@ func getGlobalVariables(exprs []build.Expr) (vars map[string]*build.BinaryExpr) 
 			if binExpr.Op != "=" {
 				continue
 			}
-			if lhs, ok := binExpr.X.(*build.LiteralExpr); ok {
-				vars[lhs.Token] = binExpr
+			if lhs, ok := binExpr.X.(*build.Ident); ok {
+				vars[lhs.Name] = binExpr
 			}
 		}
 	}

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -162,8 +162,8 @@ func ExprToRule(expr build.Expr, kind string) (*build.Rule, bool) {
 	if !ok {
 		return nil, false
 	}
-	k, ok := call.X.(*build.LiteralExpr)
-	if !ok || k.Token != kind {
+	k, ok := call.X.(*build.Ident)
+	if !ok || k.Name != kind {
 		return nil, false
 	}
 	return &build.Rule{call, ""}, true
@@ -188,7 +188,7 @@ func PackageDeclaration(f *build.File) *build.Rule {
 	}
 	all := []build.Expr{}
 	added := false
-	call := &build.CallExpr{X: &build.LiteralExpr{Token: "package"}}
+	call := &build.CallExpr{X: &build.Ident{Name: "package"}}
 	// Skip CommentBlocks and find a place to insert the package declaration.
 	for _, stmt := range f.Stmt {
 		_, ok := stmt.(*build.CommentBlock)
@@ -213,8 +213,8 @@ func RemoveEmptyPackage(f *build.File) *build.File {
 	var all []build.Expr
 	for _, stmt := range f.Stmt {
 		if call, ok := stmt.(*build.CallExpr); ok {
-			functionName, ok := call.X.(*build.LiteralExpr)
-			if ok && functionName.Token == "package" && len(call.List) == 0 {
+			functionName, ok := call.X.(*build.Ident)
+			if ok && functionName.Name == "package" && len(call.List) == 0 {
 				continue
 			}
 		}
@@ -241,8 +241,8 @@ func IndexOfLast(stmt []build.Expr, Kind string) int {
 		if !ok {
 			continue
 		}
-		literal, ok := sAsCallExpr.X.(*build.LiteralExpr)
-		if ok && literal.Token == Kind {
+		literal, ok := sAsCallExpr.X.(*build.Ident)
+		if ok && literal.Name == Kind {
 			lastIndex = i
 		}
 	}
@@ -251,7 +251,7 @@ func IndexOfLast(stmt []build.Expr, Kind string) int {
 
 // InsertAfterLastOfSameKind inserts an expression after the last expression of the same kind.
 func InsertAfterLastOfSameKind(stmt []build.Expr, expr *build.CallExpr) []build.Expr {
-	index := IndexOfLast(stmt, expr.X.(*build.LiteralExpr).Token)
+	index := IndexOfLast(stmt, expr.X.(*build.Ident).Name)
 	if index == -1 {
 		return InsertAtEnd(stmt, expr)
 	}
@@ -360,8 +360,8 @@ func DeleteRuleByKind(f *build.File, kind string) *build.File {
 			all = append(all, stmt)
 			continue
 		}
-		k, ok := call.X.(*build.LiteralExpr)
-		if !ok || k.Token != kind {
+		k, ok := call.X.(*build.Ident)
+		if !ok || k.Name != kind {
 			all = append(all, stmt)
 		}
 	}
@@ -587,8 +587,8 @@ func getVariable(expr build.Expr, vars *map[string]*build.BinaryExpr) (varAssign
 		return nil
 	}
 
-	if literal, ok := expr.(*build.LiteralExpr); ok {
-		if varAssignment = (*vars)[literal.Token]; varAssignment != nil {
+	if literal, ok := expr.(*build.Ident); ok {
+		if varAssignment = (*vars)[literal.Name]; varAssignment != nil {
 			return varAssignment
 		}
 	}
@@ -682,11 +682,11 @@ func RenameAttribute(r *build.Rule, oldName, newName string) error {
 		if !ok || as.Op != "=" {
 			continue
 		}
-		k, ok := as.X.(*build.LiteralExpr)
-		if !ok || k.Token != oldName {
+		k, ok := as.X.(*build.Ident)
+		if !ok || k.Name != oldName {
 			continue
 		}
-		k.Token = newName
+		k.Name = newName
 		return nil
 	}
 	return fmt.Errorf("no attribute %s found in rule %s", oldName, r.Name())
@@ -700,8 +700,8 @@ func EditFunction(v build.Expr, name string, f func(x *build.CallExpr, stk []bui
 		if !ok {
 			return nil
 		}
-		fct, ok := call.X.(*build.LiteralExpr)
-		if !ok || fct.Token != name {
+		fct, ok := call.X.(*build.Ident)
+		if !ok || fct.Name != name {
 			return nil
 		}
 		return f(call, stk)
@@ -712,7 +712,7 @@ func EditFunction(v build.Expr, name string, f func(x *build.CallExpr, stk []bui
 func UsedSymbols(f *build.File) map[string]bool {
 	symbols := make(map[string]bool)
 	build.Walk(f, func(expr build.Expr, stack []build.Expr) {
-		literal, ok := expr.(*build.LiteralExpr)
+		literal, ok := expr.(*build.Ident)
 		if !ok {
 			return
 		}
@@ -724,15 +724,15 @@ func UsedSymbols(f *build.File) map[string]bool {
 				}
 			}
 		}
-		symbols[literal.Token] = true
+		symbols[literal.Name] = true
 	})
 	return symbols
 }
 
 func newLoad(args []string) *build.CallExpr {
 	load := &build.CallExpr{
-		X: &build.LiteralExpr{
-			Token: "load",
+		X: &build.Ident{
+			Name: "load",
 		},
 		List:         []build.Expr{},
 		ForceCompact: true,
@@ -759,7 +759,7 @@ func appendLoad(stmts []build.Expr, args []string) bool {
 		if !ok {
 			continue
 		}
-		if l, ok := call.X.(*build.LiteralExpr); !ok || l.Token != "load" {
+		if l, ok := call.X.(*build.Ident); !ok || l.Name != "load" {
 			continue
 		}
 		if len(call.List) < 2 {

--- a/edit/fix.go
+++ b/edit/fix.go
@@ -315,7 +315,7 @@ func usePlusEqual(f *build.File) bool {
 		if !ok || len(call.List) != 1 {
 			continue
 		}
-		obj, ok := dot.X.(*build.LiteralExpr)
+		obj, ok := dot.X.(*build.Ident)
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
Add more information to the AST, which will help tools build on top of
it. The definition of Ident matches the one from
https://github.com/google/skylark/blob/master/syntax/syntax.go

This is a breaking change, some users might need to be updated.