### PR TITLE
Change a flag for switching between build and bzl modes

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -52,7 +52,7 @@ var (
 	disable   = stringList("buildifier_disable", "list of buildifier rewrites to disable")
 
 	// Experimental flags
-	inputType = flag.String("type", "build", "input file type: build (default, for BUILD files) or bzl (for .bzl files).")
+	inputType = flag.String("type", "build", "Experimental: input file type: build (default, for BUILD files) or bzl (for .bzl files).")
 )
 
 func stringList(name, help string) func() []string {
@@ -107,15 +107,15 @@ func main() {
 
 	// Check input type.
 	switch *inputType {
-	default:
-		fmt.Fprintf(os.Stderr, "buildifier: unrecognized input type %s; valid types are build, bzl, default\n", *inputType)
-		os.Exit(2)
-
 	case "bzl":
 		tables.FormatBzlFiles = true
 
 	case "build", "":
 		tables.FormatBzlFiles = false
+
+	default:
+		fmt.Fprintf(os.Stderr, "buildifier: unrecognized input type %s; valid types are build, bzl\n", *inputType)
+		os.Exit(2)
 	}
 
 	if *dflag {
@@ -128,15 +128,15 @@ func main() {
 
 	// Check mode.
 	switch *mode {
-	default:
-		fmt.Fprintf(os.Stderr, "buildifier: unrecognized mode %s; valid modes are check, diff, fix\n", *mode)
-		os.Exit(2)
-
 	case "":
 		*mode = "fix"
 
 	case "check", "diff", "fix", "print_if_changed":
 		// ok
+
+	default:
+		fmt.Fprintf(os.Stderr, "buildifier: unrecognized mode %s; valid modes are check, diff, fix\n", *mode)
+		os.Exit(2)
 	}
 
 	// If the path flag is set, must only be formatting a single file.

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -52,7 +52,7 @@ var (
 	disable   = stringList("buildifier_disable", "list of buildifier rewrites to disable")
 
 	// Experimental flags
-	formatBzlFiles = flag.Bool("format_bzl", false, "format bzl-specific blocks (experimental)")
+	inputType = flag.String("type", "build", "input file type: build (default, for BUILD files) or bzl (for .bzl files).")
 )
 
 func stringList(name, help string) func() []string {
@@ -105,7 +105,18 @@ func main() {
 	build.DisableRewrites = disable()
 	build.AllowSort = allowSort()
 
-	tables.FormatBzlFiles = *formatBzlFiles
+	// Check input type.
+	switch *inputType {
+	default:
+		fmt.Fprintf(os.Stderr, "buildifier: unrecognized input type %s; valid types are build, bzl, default\n", *inputType)
+		os.Exit(2)
+
+	case "bzl":
+		tables.FormatBzlFiles = true
+
+	case "build", "":
+		tables.FormatBzlFiles = false
+	}
 
 	if *dflag {
 		if *mode != "" {


### PR DESCRIPTION
In the future the default behavior for buildifier will be to format files as if they are bzl files (at least when they're passed through stdin, when the file names are not known).

For now the default behavior will remain the same (format files as they are BUILD files) for compatibility reasons, but users will be able to provide `--type=build` explicitly to avoid breaking in the future.