### PR TITLE
Format def statements

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -732,8 +732,7 @@ func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mod
 
 		p.newline()
 		p.expr(x, precLow)
-		// Don't print a comma after the last element in modeParen and in modeDef if the closing
-		// bracket will be placed on the same line
+		// Don't print a comma after the last element in modeParen and in modeDef
 		if !(mode == modeDef || mode == modeParen) || i+1 < len(*list) {
 			p.printf(",")
 		}

--- a/build/print.go
+++ b/build/print.go
@@ -25,8 +25,11 @@ import (
 	"github.com/bazelbuild/buildtools/tables"
 )
 
-const nestedIndentation = 4 // Indentation of nested blocks
-const listIndentation = 4   // Indentation of multiline expressions
+const (
+	nestedIndentation = 4 // Indentation of nested blocks
+	listIndentation = 4   // Indentation of multiline expressions
+	defIndentation = 8    // Indentation of multiline function definitions
+)
 
 // Format returns the formatted form of the given BUILD file.
 func Format(f *File) []byte {
@@ -540,7 +543,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 	case *DefStmt:
 		p.printf("def ")
 		p.printf(v.Name)
-		p.seq("()", &v.StartPos, &v.Params, nil, modeCall, v.ForceCompact, v.ForceMultiLine)
+		p.seq("()", &v.StartPos, &v.Params, nil, modeDef, v.ForceCompact, v.ForceMultiLine)
 		p.printf(":")
 		p.margin += nestedIndentation
 		p.newline()
@@ -629,6 +632,7 @@ const (
 	modeParen // (x)
 	modeDict  // {x:y}
 	modeSeq   // x, y
+	modeDef   // def f(x, y)
 )
 
 // useCompactMode reports whether a sequence should be formatted in a compact mode
@@ -709,7 +713,11 @@ func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mod
 		return
 	}
 	// Multi-line form.
-	p.margin += listIndentation
+	indentation := listIndentation
+	if mode == modeDef {
+		indentation = defIndentation
+	}
+	p.margin += indentation
 	for i, x := range *list {
 		// If we are about to break the line before the first
 		// element and there are trailing end-of-line comments
@@ -724,9 +732,18 @@ func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mod
 
 		p.newline()
 		p.expr(x, precLow)
-		if mode != modeParen || i+1 < len(*list) {
-			p.printf(",")
+		// Don't print a comma after the last element in modeParen and in modeDef if the closing
+		// bracket will be placed on the same line
+
+		if i + 1 == len(*list) {
+			if mode == modeParen {
+				continue
+			}
+			if mode == modeDef && len(p.comment) == 0 {
+				continue
+			}
 		}
+		p.printf(",")
 	}
 	// Final comments.
 	if end != nil {
@@ -735,8 +752,11 @@ func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mod
 			p.printf("%s", strings.TrimSpace(com.Token))
 		}
 	}
-	p.margin -= listIndentation
-	p.newline()
+	p.margin -= indentation
+	// in modeDef print the closing bracket on the same line unless there are pending suffix comments
+	if mode != modeDef || len(p.comment) != 0 {
+		p.newline()
+	}
 }
 
 // listFor formats a ListForExpr (list comprehension).

--- a/build/print.go
+++ b/build/print.go
@@ -745,8 +745,8 @@ func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mod
 		}
 	}
 	p.margin -= indentation
-	// in modeDef print the closing bracket on the same line unless there are pending suffix comments
-	if mode != modeDef || len(p.comment) != 0 {
+	// in modeDef print the closing bracket on the same line
+	if mode != modeDef {
 		p.newline()
 	}
 }

--- a/build/print.go
+++ b/build/print.go
@@ -734,16 +734,9 @@ func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mod
 		p.expr(x, precLow)
 		// Don't print a comma after the last element in modeParen and in modeDef if the closing
 		// bracket will be placed on the same line
-
-		if i + 1 == len(*list) {
-			if mode == modeParen {
-				continue
-			}
-			if mode == modeDef && len(p.comment) == 0 {
-				continue
-			}
+		if !(mode == modeDef || mode == modeParen) || i+1 < len(*list) {
+			p.printf(",")
 		}
-		p.printf(",")
 	}
 	// Final comments.
 	if end != nil {

--- a/build/testdata/051.build.golden
+++ b/build/testdata/051.build.golden
@@ -27,7 +27,7 @@ def function(
   bbb
   def g(a, s,
     d # this is d
-  ):
+  ): # this is function definition
     ccc
 # Misalingned comments
       # are not a syntax error

--- a/build/testdata/051.build.golden
+++ b/build/testdata/051.build.golden
@@ -25,7 +25,9 @@ def function(
 ):
   aaa
   bbb
-  def g(a, s, d):
+  def g(a, s,
+    d # this is d
+  ):
     ccc
 # Misalingned comments
       # are not a syntax error

--- a/build/testdata/051.bzl.golden
+++ b/build/testdata/051.bzl.golden
@@ -26,7 +26,7 @@ def function(
     def g(
             a,
             s,
-            d,  # this is d
+            d  # this is d
     ):
         ccc
 

--- a/build/testdata/051.bzl.golden
+++ b/build/testdata/051.bzl.golden
@@ -17,14 +17,17 @@ fff
 ggg
 
 def function(
-    # This shouldn't mess with indentation counting
-    x,
-    y = z,
-):
+        # This shouldn't mess with indentation counting
+        x,
+        y = z):
     aaa
     bbb
 
-    def g(a, s, d):
+    def g(
+            a,
+            s,
+            d,  # this is d
+    ):
         ccc
 
         # Misalingned comments

--- a/build/testdata/051.bzl.golden
+++ b/build/testdata/051.bzl.golden
@@ -26,8 +26,8 @@ def function(
     def g(
             a,
             s,
-            d  # this is d
-    ):
+            d):  # this is d
+        # this is function definition
         ccc
 
         # Misalingned comments

--- a/build/testdata/051.in
+++ b/build/testdata/051.in
@@ -18,7 +18,9 @@ def function(
 ):
   aaa
   bbb
-  def g(a, s, d):
+  def g(a, s,
+    d # this is d
+  ):
     ccc
 # Misalingned comments
       # are not a syntax error

--- a/build/testdata/051.in
+++ b/build/testdata/051.in
@@ -20,7 +20,7 @@ def function(
   bbb
   def g(a, s,
     d # this is d
-  ):
+  ): # this is function definition
     ccc
 # Misalingned comments
       # are not a syntax error


### PR DESCRIPTION
Format def statements in a multiline mode differently:

  * Use 8 spaces instead of 4 for indentation
  * If the last argument doesn't have a comment, the closing bracket is printed on the same line
  * The comma after the last argument is never printed (it's not valid to print it after *args or **kwargs)