### PR TITLE
Fix if-else statements

### DIFF
--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -114,7 +114,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line build/parse.y:866
+//line build/parse.y:859
 
 // Go helper code.
 
@@ -249,184 +249,180 @@ var yyExca = [...]int{
 
 const yyPrivate = 57344
 
-const yyLast = 606
+const yyLast = 596
 
 var yyAct = [...]int{
 
-	17, 153, 190, 2, 7, 144, 151, 41, 116, 125,
-	77, 129, 19, 35, 9, 23, 128, 114, 85, 200,
-	208, 202, 70, 71, 36, 140, 32, 75, 80, 83,
-	31, 44, 45, 170, 107, 29, 113, 34, 131, 136,
-	91, 199, 88, 74, 201, 88, 146, 95, 96, 97,
-	98, 99, 100, 101, 102, 103, 104, 105, 106, 13,
-	108, 109, 110, 111, 173, 193, 117, 29, 87, 93,
-	131, 79, 82, 117, 40, 168, 211, 147, 63, 30,
-	69, 118, 135, 131, 204, 94, 133, 39, 118, 203,
-	126, 127, 28, 37, 134, 180, 160, 89, 90, 38,
-	141, 149, 145, 92, 26, 73, 27, 39, 154, 39,
-	39, 65, 194, 183, 150, 29, 163, 64, 164, 156,
-	161, 162, 24, 66, 47, 158, 121, 46, 49, 31,
-	50, 39, 48, 172, 47, 112, 123, 46, 174, 176,
-	169, 179, 48, 159, 36, 171, 169, 148, 39, 175,
-	138, 132, 124, 178, 177, 167, 187, 184, 157, 139,
-	117, 189, 181, 182, 86, 191, 72, 84, 188, 186,
-	1, 192, 185, 25, 81, 118, 78, 33, 43, 42,
-	16, 196, 12, 165, 166, 195, 8, 4, 130, 67,
-	197, 68, 198, 76, 205, 145, 122, 142, 143, 28,
-	115, 206, 0, 207, 22, 191, 0, 209, 0, 7,
-	0, 26, 0, 27, 0, 0, 0, 6, 0, 0,
+	17, 151, 188, 2, 7, 142, 149, 114, 123, 75,
+	35, 127, 19, 9, 126, 23, 112, 83, 205, 197,
+	199, 138, 68, 69, 36, 32, 31, 73, 78, 81,
+	105, 42, 43, 168, 29, 111, 144, 34, 129, 86,
+	89, 196, 86, 134, 198, 93, 94, 95, 96, 97,
+	98, 99, 100, 101, 102, 103, 104, 29, 106, 107,
+	108, 109, 191, 13, 115, 85, 72, 145, 171, 91,
+	30, 115, 166, 133, 129, 208, 201, 125, 40, 116,
+	129, 200, 61, 131, 67, 92, 116, 124, 178, 158,
+	132, 192, 39, 162, 77, 80, 71, 139, 37, 147,
+	143, 87, 88, 63, 38, 90, 152, 121, 177, 62,
+	39, 28, 39, 157, 181, 64, 39, 154, 159, 160,
+	148, 161, 156, 26, 45, 27, 39, 44, 119, 175,
+	110, 170, 46, 39, 29, 136, 172, 174, 167, 130,
+	169, 24, 36, 122, 167, 165, 173, 155, 31, 146,
+	176, 137, 84, 70, 185, 182, 82, 184, 115, 187,
+	179, 180, 1, 189, 45, 186, 183, 44, 47, 190,
+	48, 25, 46, 116, 79, 76, 33, 41, 16, 194,
+	12, 8, 4, 193, 128, 163, 164, 65, 195, 28,
+	66, 74, 202, 143, 22, 120, 140, 141, 113, 203,
+	204, 26, 189, 27, 206, 0, 7, 6, 0, 0,
 	11, 0, 29, 18, 0, 0, 0, 28, 20, 24,
 	0, 0, 22, 21, 0, 15, 31, 10, 14, 26,
-	210, 27, 5, 0, 0, 6, 3, 0, 11, 0,
+	207, 27, 5, 0, 0, 6, 3, 0, 11, 0,
 	29, 18, 0, 0, 0, 28, 20, 24, 0, 0,
 	22, 21, 0, 15, 31, 10, 14, 26, 0, 27,
 	5, 0, 0, 0, 0, 0, 0, 0, 29, 0,
 	0, 0, 0, 0, 20, 24, 0, 0, 0, 21,
-	0, 15, 31, 47, 14, 0, 46, 49, 152, 50,
-	0, 48, 137, 51, 0, 52, 0, 0, 0, 0,
-	0, 60, 0, 0, 53, 0, 56, 0, 62, 0,
-	0, 57, 61, 0, 0, 54, 55, 47, 58, 59,
-	46, 49, 0, 50, 0, 48, 0, 51, 0, 52,
-	0, 0, 0, 0, 0, 60, 0, 0, 53, 0,
-	56, 0, 62, 155, 0, 57, 61, 0, 0, 54,
-	55, 47, 58, 59, 46, 49, 0, 50, 0, 48,
-	0, 51, 0, 52, 0, 0, 0, 0, 0, 60,
-	0, 0, 53, 131, 56, 0, 62, 0, 0, 57,
-	61, 0, 0, 54, 55, 47, 58, 59, 46, 49,
-	0, 50, 0, 48, 0, 51, 0, 52, 0, 0,
-	0, 0, 0, 60, 0, 0, 53, 0, 56, 0,
-	62, 0, 0, 57, 61, 0, 0, 54, 55, 47,
-	58, 59, 46, 49, 0, 50, 0, 48, 0, 51,
-	0, 52, 0, 0, 0, 0, 0, 60, 0, 0,
-	53, 0, 56, 0, 0, 0, 0, 57, 61, 0,
-	0, 54, 55, 47, 58, 59, 46, 49, 0, 50,
-	0, 48, 0, 51, 0, 52, 0, 0, 28, 0,
-	0, 60, 0, 22, 53, 0, 56, 0, 0, 0,
-	26, 57, 27, 0, 0, 54, 55, 0, 58, 59,
-	0, 29, 0, 0, 28, 0, 119, 20, 24, 22,
+	0, 15, 31, 45, 14, 0, 44, 47, 150, 48,
+	0, 46, 135, 49, 0, 50, 0, 0, 0, 0,
+	0, 58, 0, 0, 51, 0, 54, 0, 60, 0,
+	0, 55, 59, 0, 0, 52, 53, 45, 56, 57,
+	44, 47, 0, 48, 0, 46, 0, 49, 0, 50,
+	0, 0, 0, 0, 0, 58, 0, 0, 51, 0,
+	54, 0, 60, 153, 0, 55, 59, 0, 0, 52,
+	53, 45, 56, 57, 44, 47, 0, 48, 0, 46,
+	0, 49, 0, 50, 0, 0, 0, 0, 0, 58,
+	0, 0, 51, 129, 54, 0, 60, 0, 0, 55,
+	59, 0, 0, 52, 53, 45, 56, 57, 44, 47,
+	0, 48, 0, 46, 0, 49, 0, 50, 0, 0,
+	0, 0, 0, 58, 0, 0, 51, 0, 54, 0,
+	60, 0, 0, 55, 59, 0, 0, 52, 53, 45,
+	56, 57, 44, 47, 0, 48, 0, 46, 0, 49,
+	0, 50, 0, 0, 0, 0, 0, 58, 0, 0,
+	51, 0, 54, 0, 0, 0, 0, 55, 59, 0,
+	0, 52, 53, 45, 56, 57, 44, 47, 0, 48,
+	0, 46, 0, 49, 0, 50, 0, 0, 28, 0,
+	0, 58, 0, 22, 51, 0, 54, 0, 0, 0,
+	26, 55, 27, 0, 0, 52, 53, 0, 56, 57,
+	0, 29, 0, 0, 28, 0, 117, 20, 24, 22,
 	0, 0, 21, 0, 15, 31, 26, 14, 27, 0,
 	0, 0, 0, 0, 0, 0, 0, 29, 0, 0,
-	0, 0, 0, 20, 24, 0, 47, 120, 21, 46,
-	49, 31, 50, 0, 48, 0, 51, 0, 52, 0,
-	0, 0, 0, 0, 60, 0, 0, 53, 0, 56,
-	0, 0, 0, 0, 57, 0, 0, 28, 54, 55,
-	47, 58, 22, 46, 49, 0, 50, 0, 48, 26,
-	51, 27, 52, 0, 0, 0, 0, 0, 0, 0,
-	29, 53, 0, 56, 0, 0, 20, 24, 57, 0,
-	0, 21, 54, 55, 31, 58,
+	0, 0, 0, 20, 24, 0, 45, 118, 21, 44,
+	47, 31, 48, 0, 46, 0, 49, 0, 50, 0,
+	0, 0, 0, 0, 58, 0, 0, 51, 0, 54,
+	0, 0, 0, 0, 55, 0, 0, 28, 52, 53,
+	45, 56, 22, 44, 47, 0, 48, 0, 46, 26,
+	49, 27, 50, 0, 0, 0, 0, 0, 0, 0,
+	29, 51, 0, 54, 0, 0, 20, 24, 55, 0,
+	0, 21, 52, 53, 31, 56,
 }
 var yyPact = [...]int{
 
-	-1000, -1000, 222, -1000, -1000, -1000, -22, -1000, -1000, -1000,
-	9, 87, -1000, 78, 562, -1000, 1, 391, 562, 106,
-	562, 562, 562, -1000, 161, -12, 562, 562, 562, -1000,
-	-1000, -1000, -1000, -33, 159, 36, 106, 562, 562, 562,
-	139, -1000, -1000, 562, 56, -1000, 562, 562, 562, 562,
-	562, 562, 562, 562, 562, 562, 562, 562, 2, 562,
-	562, 562, 562, 122, 8, 499, 562, 123, 143, 139,
-	-1000, -1000, 499, -1000, 73, 357, 142, 12, 62, 19,
-	289, 141, 153, 391, -23, 473, 39, 562, 87, 139,
-	139, 425, 101, 250, -1000, -1000, -1000, -1000, 130, 130,
-	120, 120, 120, 120, 120, 120, 120, 562, 532, 566,
-	459, 323, 250, -1000, 152, 134, -1000, 391, 81, 562,
-	562, 98, 105, 562, 562, -1000, 149, -1000, 57, 4,
-	-1000, 87, 562, -1000, 44, -1000, -1000, 562, 562, -1000,
-	-1000, -1000, 148, 132, -1000, 80, 7, 7, 100, 106,
-	250, -1000, -1000, -1000, 120, 562, -1000, -1000, -1000, 499,
-	562, 391, 391, -1000, 562, -1000, -1000, -1000, -1000, 4,
-	562, 33, 391, -1000, 391, -1000, 289, 99, -1000, 39,
-	562, -1000, -1000, 250, 1, -4, -27, 425, -1000, 391,
-	71, 391, 425, 562, 250, -1000, 391, -1000, -1000, -1000,
-	-28, -1000, -1000, -1000, 562, 425, -1000, 194, -1000, 58,
-	-1000, -1000,
+	-1000, -1000, 212, -1000, -1000, -1000, -23, -1000, -1000, -1000,
+	9, 106, -1000, 83, 552, -1000, 1, 381, 552, 98,
+	552, 552, 552, -1000, 148, -16, 552, 552, 552, -1000,
+	-1000, -1000, -1000, -34, 147, 33, 98, 552, 552, 552,
+	124, 552, 56, -1000, 552, 552, 552, 552, 552, 552,
+	552, 552, 552, 552, 552, 552, -2, 552, 552, 552,
+	552, 117, 7, 489, 552, 94, 134, 124, -1000, -1000,
+	489, -1000, 59, 347, 130, 12, 53, 23, 279, 126,
+	145, 381, -27, 463, 29, 552, 106, 124, 124, 415,
+	107, 240, -1000, -1000, -1000, -1000, 120, 120, 160, 160,
+	160, 160, 160, 160, 160, 552, 522, 556, 449, 313,
+	240, -1000, 141, 104, -1000, 381, 74, 552, 552, 103,
+	80, 552, 552, -1000, 139, -1000, 54, 4, -1000, 106,
+	552, -1000, 48, -1000, -1000, 552, 552, -1000, -1000, -1000,
+	123, 99, -1000, 73, 6, 6, 101, 98, 240, -1000,
+	-1000, -1000, 160, 552, -1000, -1000, -1000, 489, 552, 381,
+	381, -1000, 552, -1000, -1000, -1000, -1000, 4, 552, 30,
+	381, -1000, 381, -1000, 279, 78, -1000, 29, 552, -1000,
+	-1000, 240, -1000, -4, -28, 415, -1000, 381, 63, 381,
+	415, 552, 240, -1000, 381, -1000, -1000, -30, -1000, -1000,
+	-1000, 552, 415, -1000, 184, -1000, 57, -1000, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 9, 8, 200, 17, 5, 198, 197, 0, 2,
-	43, 12, 59, 196, 193, 191, 189, 13, 188, 11,
-	16, 15, 3, 187, 186, 182, 180, 179, 7, 178,
-	1, 14, 177, 10, 176, 174, 79, 173, 6, 172,
-	170, 169, 167,
+	0, 8, 7, 198, 16, 5, 197, 196, 0, 2,
+	66, 12, 63, 195, 191, 190, 187, 10, 184, 11,
+	14, 15, 3, 182, 181, 180, 178, 177, 1, 13,
+	176, 9, 175, 174, 70, 171, 6, 166, 162, 157,
+	156,
 }
 var yyR1 = [...]int{
 
-	0, 40, 38, 38, 41, 41, 39, 39, 39, 22,
-	22, 22, 22, 23, 23, 24, 24, 24, 27, 28,
-	28, 26, 25, 25, 29, 29, 30, 32, 32, 31,
-	31, 31, 31, 31, 31, 42, 42, 11, 11, 11,
-	11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
-	11, 4, 4, 3, 3, 2, 2, 2, 2, 7,
-	7, 6, 6, 5, 5, 5, 5, 12, 12, 13,
-	13, 15, 15, 16, 16, 8, 8, 8, 8, 8,
+	0, 38, 36, 36, 39, 39, 37, 37, 37, 22,
+	22, 22, 22, 23, 23, 24, 24, 24, 26, 26,
+	25, 25, 27, 27, 28, 30, 30, 29, 29, 29,
+	29, 29, 29, 40, 40, 11, 11, 11, 11, 11,
+	11, 11, 11, 11, 11, 11, 11, 11, 11, 4,
+	4, 3, 3, 2, 2, 2, 2, 7, 7, 6,
+	6, 5, 5, 5, 5, 12, 12, 13, 13, 15,
+	15, 16, 16, 8, 8, 8, 8, 8, 8, 8,
 	8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-	8, 8, 8, 8, 8, 8, 14, 14, 9, 9,
-	10, 10, 1, 1, 33, 35, 35, 34, 34, 17,
-	17, 36, 37, 37, 21, 18, 19, 19, 20, 20,
+	8, 8, 8, 8, 14, 14, 9, 9, 10, 10,
+	1, 1, 31, 33, 33, 32, 32, 17, 17, 34,
+	35, 35, 21, 18, 19, 19, 20, 20,
 }
 var yyR2 = [...]int{
 
 	0, 2, 5, 2, 0, 2, 0, 3, 2, 0,
-	2, 2, 3, 1, 1, 7, 6, 1, 3, 1,
-	5, 4, 1, 2, 2, 1, 4, 0, 3, 1,
-	2, 1, 3, 3, 1, 0, 1, 1, 3, 4,
-	4, 4, 6, 8, 1, 3, 4, 4, 3, 3,
-	3, 0, 2, 1, 3, 1, 3, 2, 2, 0,
-	2, 1, 3, 1, 3, 2, 2, 1, 3, 0,
-	1, 1, 3, 0, 2, 1, 4, 2, 2, 3,
-	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	3, 4, 3, 3, 3, 5, 1, 3, 0, 1,
-	0, 2, 0, 1, 3, 1, 3, 1, 2, 1,
-	3, 1, 1, 2, 1, 4, 1, 3, 1, 2,
+	2, 2, 3, 1, 1, 7, 6, 1, 4, 5,
+	1, 4, 2, 1, 4, 0, 3, 1, 2, 1,
+	3, 3, 1, 0, 1, 1, 3, 4, 4, 4,
+	6, 8, 1, 3, 4, 4, 3, 3, 3, 0,
+	2, 1, 3, 1, 3, 2, 2, 0, 2, 1,
+	3, 1, 3, 2, 2, 1, 3, 0, 1, 1,
+	3, 0, 2, 1, 4, 2, 2, 3, 3, 3,
+	3, 3, 3, 3, 3, 3, 3, 3, 3, 4,
+	3, 3, 3, 5, 1, 3, 0, 1, 0, 2,
+	0, 1, 3, 1, 3, 1, 2, 1, 3, 1,
+	1, 2, 1, 4, 1, 3, 1, 2,
 }
 var yyChk = [...]int{
 
-	-1000, -40, -22, 24, -23, 48, 23, -30, -24, -31,
+	-1000, -38, -22, 24, -23, 48, 23, -28, -24, -29,
 	43, 26, -25, -12, 44, 41, -26, -8, 29, -11,
-	34, 39, 10, -21, 35, -37, 17, 19, 5, 28,
-	-36, 42, 48, -32, 28, -17, -11, 15, 21, 9,
-	-12, -28, -27, -29, 30, 31, 7, 4, 12, 8,
-	10, 14, 16, 25, 36, 37, 27, 32, 39, 40,
-	22, 33, 29, -12, 11, 5, 17, -16, -15, -12,
-	-8, -8, 5, -36, -10, -8, -14, -33, -34, -10,
-	-8, -35, -10, -8, -42, 51, 5, 32, 9, -12,
-	-12, -8, -12, 13, 29, -8, -8, -8, -8, -8,
-	-8, -8, -8, -8, -8, -8, -8, 32, -8, -8,
-	-8, -8, 13, 28, -4, -3, -2, -8, -21, 7,
-	38, -12, -13, 13, 9, -1, -4, 18, -20, -19,
-	-18, 26, 9, -1, -20, 20, 20, 13, 9, 6,
-	48, -31, -7, -6, -5, -21, 7, 38, -12, -11,
-	13, -38, 48, -30, -8, 30, -38, 6, -1, 9,
-	15, -8, -8, 18, 13, -12, -12, 6, 18, -19,
-	29, -17, -8, 20, -8, -33, -8, 6, -1, 9,
-	15, -21, -21, 13, -38, -39, -41, -8, -2, -8,
-	-9, -8, -8, 32, 13, -5, -8, -38, -28, 45,
-	23, 48, 48, 18, 13, -8, -38, -22, 48, -9,
-	46, 18,
+	34, 39, 10, -21, 35, -35, 17, 19, 5, 28,
+	-34, 42, 48, -30, 28, -17, -11, 15, 21, 9,
+	-12, -27, 30, 31, 7, 4, 12, 8, 10, 14,
+	16, 25, 36, 37, 27, 32, 39, 40, 22, 33,
+	29, -12, 11, 5, 17, -16, -15, -12, -8, -8,
+	5, -34, -10, -8, -14, -31, -32, -10, -8, -33,
+	-10, -8, -40, 51, 5, 32, 9, -12, -12, -8,
+	-12, 13, 29, -8, -8, -8, -8, -8, -8, -8,
+	-8, -8, -8, -8, -8, 32, -8, -8, -8, -8,
+	13, 28, -4, -3, -2, -8, -21, 7, 38, -12,
+	-13, 13, 9, -1, -4, 18, -20, -19, -18, 26,
+	9, -1, -20, 20, 20, 13, 9, 6, 48, -29,
+	-7, -6, -5, -21, 7, 38, -12, -11, 13, -36,
+	48, -28, -8, 30, -36, 6, -1, 9, 15, -8,
+	-8, 18, 13, -12, -12, 6, 18, -19, 29, -17,
+	-8, 20, -8, -31, -8, 6, -1, 9, 15, -21,
+	-21, 13, -36, -37, -39, -8, -2, -8, -9, -8,
+	-8, 32, 13, -5, -8, -36, 45, 23, 48, 48,
+	18, 13, -8, -36, -22, 48, -9, 46, 18,
 }
 var yyDef = [...]int{
 
-	9, -2, 0, 1, 10, 11, 0, 13, 14, 27,
-	0, 0, 17, 29, 31, 34, 22, 67, 0, 75,
-	73, 0, 0, 37, 0, 44, 100, 100, 100, 114,
-	112, 111, 12, 35, 0, 0, 109, 0, 0, 0,
-	30, 23, 19, 0, 0, 25, 0, 0, 0, 0,
+	9, -2, 0, 1, 10, 11, 0, 13, 14, 25,
+	0, 0, 17, 27, 29, 32, 20, 65, 0, 73,
+	71, 0, 0, 35, 0, 42, 98, 98, 98, 112,
+	110, 109, 12, 33, 0, 0, 107, 0, 0, 0,
+	28, 0, 0, 23, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 51, 69, 0, 102, 71,
-	77, 78, 51, 113, 0, 96, 102, 105, 0, 0,
-	96, 107, 0, 96, 0, 36, 59, 0, 0, 32,
-	33, 68, 0, 0, 24, 79, 80, 81, 82, 83,
-	84, 85, 86, 87, 88, 89, 90, 0, 92, 93,
-	94, 0, 0, 38, 0, 102, 53, 55, 37, 0,
-	0, 70, 0, 0, 103, 74, 0, 45, 0, 118,
-	116, 0, 103, 101, 0, 48, 49, 0, 108, 50,
-	26, 28, 0, 102, 61, 63, 0, 0, 0, 110,
-	0, 18, 6, 4, 91, 0, 21, 40, 52, 103,
-	0, 57, 58, 41, 98, 76, 72, 39, 46, 119,
-	0, 0, 97, 47, 104, 106, 0, 0, 60, 103,
-	0, 65, 66, 0, 0, 0, 3, 95, 54, 56,
-	0, 99, 117, 0, 0, 62, 64, 16, 20, 9,
-	0, 8, 5, 42, 98, 115, 15, 0, 7, 0,
-	2, 43,
+	0, 0, 0, 49, 67, 0, 100, 69, 75, 76,
+	49, 111, 0, 94, 100, 103, 0, 0, 94, 105,
+	0, 94, 0, 34, 57, 0, 0, 30, 31, 66,
+	0, 0, 22, 77, 78, 79, 80, 81, 82, 83,
+	84, 85, 86, 87, 88, 0, 90, 91, 92, 0,
+	0, 36, 0, 100, 51, 53, 35, 0, 0, 68,
+	0, 0, 101, 72, 0, 43, 0, 116, 114, 0,
+	101, 99, 0, 46, 47, 0, 106, 48, 24, 26,
+	0, 100, 59, 61, 0, 0, 0, 108, 0, 21,
+	6, 4, 89, 0, 18, 38, 50, 101, 0, 55,
+	56, 39, 96, 74, 70, 37, 44, 117, 0, 0,
+	95, 45, 102, 104, 0, 0, 58, 101, 0, 63,
+	64, 0, 19, 0, 3, 93, 52, 54, 0, 97,
+	115, 0, 0, 60, 62, 16, 9, 0, 8, 5,
+	40, 96, 113, 15, 0, 7, 0, 2, 41,
 }
 var yyTok1 = [...]int{
 
@@ -794,14 +790,14 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:178
+		//line build/parse.y:176
 		{
 			yylex.(*input).file = &File{Stmt: yyDollar[1].exprs}
 			return 0
 		}
 	case 2:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:185
+		//line build/parse.y:183
 		{
 			statements := yyDollar[4].exprs
 			if yyDollar[2].exprs != nil {
@@ -822,20 +818,20 @@ yydefault:
 		}
 	case 3:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:204
+		//line build/parse.y:202
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 6:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:212
+		//line build/parse.y:210
 		{
 			yyVAL.exprs = nil
 			yyVAL.lastRule = nil
 		}
 	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:217
+		//line build/parse.y:215
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = yyDollar[1].lastRule
@@ -849,21 +845,21 @@ yydefault:
 		}
 	case 8:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:229
+		//line build/parse.y:227
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = nil
 		}
 	case 9:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:235
+		//line build/parse.y:233
 		{
 			yyVAL.exprs = nil
 			yyVAL.lastRule = nil
 		}
 	case 10:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:240
+		//line build/parse.y:238
 		{
 			// If this statement follows a comment block,
 			// attach the comments to the statement.
@@ -896,7 +892,7 @@ yydefault:
 		}
 	case 11:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:271
+		//line build/parse.y:269
 		{
 			// Blank line; sever last rule from future comments.
 			yyVAL.exprs = yyDollar[1].exprs
@@ -904,7 +900,7 @@ yydefault:
 		}
 	case 12:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:277
+		//line build/parse.y:275
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastRule = yyDollar[1].lastRule
@@ -918,19 +914,19 @@ yydefault:
 		}
 	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:291
+		//line build/parse.y:289
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 14:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:295
+		//line build/parse.y:293
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
 	case 15:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line build/parse.y:301
+		//line build/parse.y:299
 		{
 			yyVAL.expr = &DefStmt{
 				Function: Function{
@@ -945,7 +941,7 @@ yydefault:
 		}
 	case 16:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:314
+		//line build/parse.y:312
 		{
 			yyVAL.expr = &ForStmt{
 				For:  yyDollar[1].pos,
@@ -956,35 +952,13 @@ yydefault:
 		}
 	case 17:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:323
+		//line build/parse.y:321
 		{
 			yyVAL.expr = yyDollar[1].ifstmt
 		}
 	case 18:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:330
-		{
-			yyVAL.ifstmt = &IfStmt{
-				ElsePos: yyDollar[1].pos,
-				False:   yyDollar[3].exprs,
-			}
-		}
-	case 20:
-		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:341
-		{
-			inner := yyDollar[5].ifstmt
-			inner.If = yyDollar[1].pos
-			inner.Cond = yyDollar[2].expr
-			inner.True = yyDollar[4].exprs
-			yyVAL.ifstmt = &IfStmt{
-				ElsePos: yyDollar[1].pos,
-				False:   []Expr{inner},
-			}
-		}
-	case 21:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:355
+		//line build/parse.y:328
 		{
 			yyVAL.ifstmt = &IfStmt{
 				If:   yyDollar[1].pos,
@@ -992,71 +966,93 @@ yydefault:
 				True: yyDollar[4].exprs,
 			}
 		}
-	case 23:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:367
+	case 19:
+		yyDollar = yyS[yypt-5 : yypt+1]
+		//line build/parse.y:336
 		{
 			yyVAL.ifstmt = yyDollar[1].ifstmt
-			yyVAL.ifstmt.ElsePos = yyDollar[2].ifstmt.ElsePos
-			yyVAL.ifstmt.False = yyDollar[2].ifstmt.False
+			inner := yyDollar[1].ifstmt
+			for len(inner.False) == 1 {
+				inner = inner.False[0].(*IfStmt)
+			}
+			inner.ElsePos = yyDollar[2].pos
+			inner.False = []Expr{
+				&IfStmt{
+					If:   yyDollar[2].pos,
+					Cond: yyDollar[3].expr,
+					True: yyDollar[5].exprs,
+				},
+			}
 		}
-	case 26:
+	case 21:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:379
+		//line build/parse.y:356
+		{
+			yyVAL.ifstmt = yyDollar[1].ifstmt
+			inner := yyDollar[1].ifstmt
+			for len(inner.False) == 1 {
+				inner = inner.False[0].(*IfStmt)
+			}
+			inner.ElsePos = yyDollar[2].pos
+			inner.False = yyDollar[4].exprs
+		}
+	case 24:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:372
 		{
 			yyVAL.exprs = append([]Expr{yyDollar[1].expr}, yyDollar[2].exprs...)
 			yyVAL.lastRule = yyVAL.exprs[len(yyVAL.exprs)-1]
 		}
-	case 27:
+	case 25:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:385
+		//line build/parse.y:378
 		{
 			yyVAL.exprs = []Expr{}
 		}
-	case 28:
+	case 26:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:389
+		//line build/parse.y:382
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 30:
+	case 28:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:396
+		//line build/parse.y:389
 		{
 			yyVAL.expr = &ReturnStmt{
 				Return: yyDollar[1].pos,
 				Result: yyDollar[2].expr,
 			}
 		}
-	case 31:
+	case 29:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:403
+		//line build/parse.y:396
 		{
 			yyVAL.expr = &ReturnStmt{
 				Return: yyDollar[1].pos,
 			}
 		}
+	case 30:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:401
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 31:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:402
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
 	case 32:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:408
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 33:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:409
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 34:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:411
+		//line build/parse.y:404
 		{
 			yyVAL.expr = &PythonBlock{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 38:
+	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:421
+		//line build/parse.y:414
 		{
 			yyVAL.expr = &DotExpr{
 				X:       yyDollar[1].expr,
@@ -1065,9 +1061,9 @@ yydefault:
 				Name:    yyDollar[3].tok,
 			}
 		}
-	case 39:
+	case 37:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:430
+		//line build/parse.y:423
 		{
 			yyVAL.expr = &CallExpr{
 				X:              &LiteralExpr{Start: yyDollar[1].pos, Token: "load"},
@@ -1078,9 +1074,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 40:
+	case 38:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:441
+		//line build/parse.y:434
 		{
 			yyVAL.expr = &CallExpr{
 				X:              yyDollar[1].expr,
@@ -1091,9 +1087,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 41:
+	case 39:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:452
+		//line build/parse.y:445
 		{
 			yyVAL.expr = &IndexExpr{
 				X:          yyDollar[1].expr,
@@ -1102,9 +1098,9 @@ yydefault:
 				End:        yyDollar[4].pos,
 			}
 		}
-	case 42:
+	case 40:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line build/parse.y:461
+		//line build/parse.y:454
 		{
 			yyVAL.expr = &SliceExpr{
 				X:          yyDollar[1].expr,
@@ -1115,9 +1111,9 @@ yydefault:
 				End:        yyDollar[6].pos,
 			}
 		}
-	case 43:
+	case 41:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line build/parse.y:472
+		//line build/parse.y:465
 		{
 			yyVAL.expr = &SliceExpr{
 				X:           yyDollar[1].expr,
@@ -1130,9 +1126,9 @@ yydefault:
 				End:         yyDollar[8].pos,
 			}
 		}
-	case 44:
+	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:485
+		//line build/parse.y:478
 		{
 			if len(yyDollar[1].strings) == 1 {
 				yyVAL.expr = yyDollar[1].strings[0]
@@ -1144,9 +1140,9 @@ yydefault:
 				yyVAL.expr = binary(yyVAL.expr, end, "+", x)
 			}
 		}
-	case 45:
+	case 43:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:497
+		//line build/parse.y:490
 		{
 			yyVAL.expr = &ListExpr{
 				Start:          yyDollar[1].pos,
@@ -1155,9 +1151,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 46:
+	case 44:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:506
+		//line build/parse.y:499
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &Comprehension{
@@ -1169,9 +1165,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 47:
+	case 45:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:518
+		//line build/parse.y:511
 		{
 			exprStart, _ := yyDollar[2].expr.Span()
 			yyVAL.expr = &Comprehension{
@@ -1183,9 +1179,9 @@ yydefault:
 				ForceMultiLine: yyDollar[1].pos.Line != exprStart.Line,
 			}
 		}
-	case 48:
+	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:530
+		//line build/parse.y:523
 		{
 			yyVAL.expr = &DictExpr{
 				Start:          yyDollar[1].pos,
@@ -1194,9 +1190,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 49:
+	case 47:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:539
+		//line build/parse.y:532
 		{
 			yyVAL.expr = &SetExpr{
 				Start:          yyDollar[1].pos,
@@ -1205,9 +1201,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 50:
+	case 48:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:548
+		//line build/parse.y:541
 		{
 			if len(yyDollar[2].exprs) == 1 && yyDollar[2].comma.Line == 0 {
 				// Just a parenthesized expression, not a tuple.
@@ -1227,93 +1223,93 @@ yydefault:
 				}
 			}
 		}
-	case 51:
+	case 49:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:569
+		//line build/parse.y:562
 		{
 			yyVAL.exprs = nil
 		}
-	case 52:
+	case 50:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:573
+		//line build/parse.y:566
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 53:
+	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:579
+		//line build/parse.y:572
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
+		}
+	case 52:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:576
+		{
+			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 54:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:583
 		{
-			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
-		}
-	case 56:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:590
-		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
+	case 55:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:587
+		{
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
+		}
+	case 56:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:591
+		{
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
+		}
 	case 57:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:594
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 58:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:598
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 59:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:603
+		//line build/parse.y:596
 		{
 			yyVAL.exprs = nil
 		}
-	case 60:
+	case 58:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:607
+		//line build/parse.y:600
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 61:
+	case 59:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:613
+		//line build/parse.y:606
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
+		}
+	case 60:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:610
+		{
+			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 62:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line build/parse.y:617
 		{
-			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
-		}
-	case 64:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:624
-		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 65:
+	case 63:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:628
+		//line build/parse.y:621
+		{
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
+		}
+	case 64:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:625
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 66:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:632
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 68:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:639
+		//line build/parse.y:632
 		{
 			tuple, ok := yyDollar[1].expr.(*TupleExpr)
 			if !ok || !tuple.NoBrackets {
@@ -1327,39 +1323,39 @@ yydefault:
 			tuple.List = append(tuple.List, yyDollar[3].expr)
 			yyVAL.expr = tuple
 		}
-	case 69:
+	case 67:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:654
+		//line build/parse.y:647
 		{
 			yyVAL.expr = nil
 		}
-	case 71:
+	case 69:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:661
+		//line build/parse.y:654
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 72:
+	case 70:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:665
+		//line build/parse.y:658
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 73:
+	case 71:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:670
+		//line build/parse.y:663
 		{
 			yyVAL.exprs = nil
 		}
-	case 74:
+	case 72:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:674
+		//line build/parse.y:667
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 76:
+	case 74:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:681
+		//line build/parse.y:674
 		{
 			yyVAL.expr = &LambdaExpr{
 				Function: Function{
@@ -1369,111 +1365,111 @@ yydefault:
 				},
 			}
 		}
-	case 77:
+	case 75:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:690
+		//line build/parse.y:683
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 78:
+	case 76:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:691
+		//line build/parse.y:684
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
+		}
+	case 77:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:685
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 78:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:686
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 79:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:692
+		//line build/parse.y:687
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 80:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:693
+		//line build/parse.y:688
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 81:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:694
+		//line build/parse.y:689
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 82:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:695
+		//line build/parse.y:690
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:696
+		//line build/parse.y:691
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 84:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:697
+		//line build/parse.y:692
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 85:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:698
+		//line build/parse.y:693
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 86:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:699
+		//line build/parse.y:694
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 87:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:700
+		//line build/parse.y:695
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 88:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:701
+		//line build/parse.y:696
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 89:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:702
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line build/parse.y:697
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
 		}
 	case 90:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:703
+		//line build/parse.y:698
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 91:
-		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:704
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line build/parse.y:699
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 92:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:705
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 93:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:706
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
-	case 94:
-		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:708
+		//line build/parse.y:701
 		{
 			if b, ok := yyDollar[3].expr.(*UnaryExpr); ok && b.Op == "not" {
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "is not", b.X)
@@ -1481,9 +1477,9 @@ yydefault:
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 			}
 		}
-	case 95:
+	case 93:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line build/parse.y:716
+		//line build/parse.y:709
 		{
 			yyVAL.expr = &ConditionalExpr{
 				Then:      yyDollar[1].expr,
@@ -1493,45 +1489,45 @@ yydefault:
 				Else:      yyDollar[5].expr,
 			}
 		}
-	case 96:
+	case 94:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:728
+		//line build/parse.y:721
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 97:
+	case 95:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:732
+		//line build/parse.y:725
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 98:
+	case 96:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:737
+		//line build/parse.y:730
 		{
 			yyVAL.expr = nil
 		}
-	case 100:
+	case 98:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:743
+		//line build/parse.y:736
 		{
 			yyVAL.exprs, yyVAL.comma = nil, Position{}
 		}
-	case 101:
+	case 99:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:747
+		//line build/parse.y:740
 		{
 			yyVAL.exprs, yyVAL.comma = yyDollar[1].exprs, yyDollar[2].pos
 		}
-	case 102:
+	case 100:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line build/parse.y:756
+		//line build/parse.y:749
 		{
 			yyVAL.pos = Position{}
 		}
-	case 104:
+	case 102:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:762
+		//line build/parse.y:755
 		{
 			yyVAL.expr = &KeyValueExpr{
 				Key:   yyDollar[1].expr,
@@ -1539,33 +1535,33 @@ yydefault:
 				Value: yyDollar[3].expr,
 			}
 		}
-	case 105:
+	case 103:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:772
+		//line build/parse.y:765
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 106:
+	case 104:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:776
+		//line build/parse.y:769
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 107:
+	case 105:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:782
+		//line build/parse.y:775
+		{
+			yyVAL.exprs = yyDollar[1].exprs
+		}
+	case 106:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line build/parse.y:779
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 108:
-		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:786
-		{
-			yyVAL.exprs = yyDollar[1].exprs
-		}
-	case 110:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:793
+		//line build/parse.y:786
 		{
 			tuple, ok := yyDollar[1].expr.(*TupleExpr)
 			if !ok || !tuple.NoBrackets {
@@ -1579,9 +1575,9 @@ yydefault:
 			tuple.List = append(tuple.List, yyDollar[3].expr)
 			yyVAL.expr = tuple
 		}
-	case 111:
+	case 109:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:809
+		//line build/parse.y:802
 		{
 			yyVAL.string = &StringExpr{
 				Start:       yyDollar[1].pos,
@@ -1591,27 +1587,27 @@ yydefault:
 				Token:       yyDollar[1].tok,
 			}
 		}
-	case 112:
+	case 110:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:821
+		//line build/parse.y:814
 		{
 			yyVAL.strings = []*StringExpr{yyDollar[1].string}
 		}
-	case 113:
+	case 111:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:825
+		//line build/parse.y:818
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[2].string)
 		}
-	case 114:
+	case 112:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:831
+		//line build/parse.y:824
 		{
 			yyVAL.expr = &LiteralExpr{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 115:
+	case 113:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line build/parse.y:837
+		//line build/parse.y:830
 		{
 			yyVAL.expr = &ForClause{
 				For:  yyDollar[1].pos,
@@ -1620,30 +1616,30 @@ yydefault:
 				X:    yyDollar[4].expr,
 			}
 		}
-	case 116:
+	case 114:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:847
+		//line build/parse.y:840
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 117:
+	case 115:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line build/parse.y:850
+		//line build/parse.y:843
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, &IfClause{
 				If:   yyDollar[2].pos,
 				Cond: yyDollar[3].expr,
 			})
 		}
-	case 118:
+	case 116:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line build/parse.y:859
+		//line build/parse.y:852
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 119:
+	case 117:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line build/parse.y:862
+		//line build/parse.y:855
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[2].exprs...)
 		}

--- a/build/testdata/054.build.golden
+++ b/build/testdata/054.build.golden
@@ -22,3 +22,6 @@ else:
   else:
 
    (a,b)=(b,a)
+
+if foo:
+  bar

--- a/build/testdata/054.build.golden
+++ b/build/testdata/054.build.golden
@@ -1,0 +1,24 @@
+# If-else clauses
+
+if True:
+  pass
+
+elif False:
+  pass
+
+if foo in bar:
+ for f in foo:
+  # loop
+  f()
+
+else if True:
+  a = b
+
+else:
+  if False:
+
+    #assign
+    b=a
+  else:
+
+   (a,b)=(b,a)

--- a/build/testdata/054.bzl.golden
+++ b/build/testdata/054.bzl.golden
@@ -17,3 +17,6 @@ elif False:
     b = a
 else:
     (a, b) = (b, a)
+
+if foo:
+    bar

--- a/build/testdata/054.bzl.golden
+++ b/build/testdata/054.bzl.golden
@@ -1,0 +1,19 @@
+# If-else clauses
+
+if True:
+    pass
+elif False:
+    pass
+
+if foo in bar:
+    for f in foo:
+        # loop
+        f()
+elif True:
+    a = b
+
+elif False:
+    #assign
+    b = a
+else:
+    (a, b) = (b, a)

--- a/build/testdata/054.in
+++ b/build/testdata/054.in
@@ -1,0 +1,22 @@
+# If-else clauses
+
+if True:
+  pass
+elif False:
+  pass
+
+if foo in bar:
+ for f in foo:
+  # loop
+  f()
+else if True:
+  a = b
+
+else:
+  if False:
+
+    #assign
+    b=a
+  else:
+
+   (a,b)=(b,a)

--- a/build/testdata/054.in
+++ b/build/testdata/054.in
@@ -20,3 +20,6 @@ else:
   else:
 
    (a,b)=(b,a)
+
+if foo:
+  bar


### PR DESCRIPTION
If-else chains that don't end with an else block (e.g. a single `if` or `if-elif`) used to be a syntax error.