### PR TITLE
load statements are not eligible for "implicit rule names"

### DIFF
--- a/build/rule.go
+++ b/build/rule.go
@@ -31,7 +31,7 @@ type Rule struct {
 
 func (f *File) Rule(call *CallExpr) *Rule {
 	r := &Rule{call, ""}
-	if r.AttrString("name") == "" {
+	if r.AttrString("name") == "" && r.Kind() != "load" {
 		r.ImplicitName = f.implicitRuleName()
 	}
 	return r
@@ -117,7 +117,7 @@ func (f *File) implicitRuleName() string {
 			// A target explicitly has the name of the dir, so no implicit targets are allowed.
 			return ""
 		}
-		if temp.Kind() != "" && temp.AttrString("name") == "" {
+		if temp.Kind() != "" && temp.Kind() != "load" && temp.AttrString("name") == "" {
 			if sawAnonymousRule {
 				return ""
 			}

--- a/build/rule_test.go
+++ b/build/rule_test.go
@@ -134,6 +134,11 @@ rule()`, "foo", `Use an implicit name for the one unnamed rule`},
 		{"foo/BUILD", `rule()
 rule()
 rule()`, "", `No implicit name for multiple unnamed rules`},
+		{"foo/BUILD", `load()
+rule(name="a")
+rule(name="b")`, "", `No implicit name for load`},
+		{"foo/BUILD", `load()
+rule()`, "foo", `Use an implicit name for one unnamed rule with load`},
 		{"BUILD", `rule()`, "", `No implicit name for root package`},
 	}
 


### PR DESCRIPTION
"If a build file contains exactly one unnamed rule" currently matches the load statement in the following:

```
load("//foo", "some_rule")

some_rule(
    name = "bar",
)
```

This is clearly not the intent of the implicit rule name case, so tweak it accordingly.