### PR TITLE
Shorten cross repo labels.

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -75,7 +75,7 @@ func ShortenLabel(label string, pkg string) string {
 	if !ShortenLabelsFlag {
 		return label
 	}
-	if !strings.HasPrefix(label, "//") {
+	if !strings.Contains(label, "//") {
 		// It doesn't look like a long label, so we preserve it.
 		return label
 	}
@@ -85,7 +85,10 @@ func ShortenLabel(label string, pkg string) string {
 	}
 	slash := strings.LastIndex(labelPkg, "/")
 	if (slash >= 0 && labelPkg[slash+1:] == rule) || labelPkg == rule {
-		return "//" + labelPkg
+		if repo == "" {
+			return "//" + labelPkg
+		}
+		return "@" + repo + "//" + labelPkg
 	}
 	return label
 }


### PR DESCRIPTION
This allows `@com_google_guava_guava//jar:jar` to be shortened to `@com_google_guava_guava//jar` for example.

This affects both `buildifier` and `unused_deps`: `unused_deps` isn't able to detect unused deps specified with the short hand right now.

Is "cross repo" the right nomenclature?