### PR TITLE
Default to `//...` if no target patterns are specified.

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -256,6 +256,9 @@ func main() {
 		return
 	}
 	targetPatterns := flag.Args()
+	if len(targetPatterns) == 0 {
+		targetPatterns = []string{"//..."}
+	}
 
 	queryCmd := append([]string{"query"}, blazeFlags...)
 	queryCmd = append(


### PR DESCRIPTION
According to the best practices [a project should always be able to build `//...`](https://docs.bazel.build/versions/master/best-practices.html#running-builds-and-tests), so it seems like a good default to use for `unused_deps`.