### PR TITLE
Handle @file escapes.

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -137,6 +137,9 @@ func directDepParams(paramsFileName string) (depsByJar map[string]string) {
 			jar := scanner.Text()
 			scanner.Scan()
 			label := scanner.Text()
+			if len(label) > 2 && label[0] == '@' && label[1] == '@' {
+				label = label[1:]
+			}
 			depsByJar[jar] = label
 		}
 	}


### PR DESCRIPTION
Bazel's `-2.params` files will escape any argument starting with `@` by prepending them with `@`. This could be to escape `@file` parameter expansion but I haven't looked into it deeply enough to confirm that.