### PR TITLE
Handle `java_library` with resources.

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -120,9 +120,11 @@ func inputFileName(blazeBin, pkg, ruleName, extension string) string {
 // as a map from jar files to labels.
 func directDepParams(paramsFileNames ...string) (depsByJar map[string]string) {
 	depsByJar = make(map[string]string)
+	errs := make([]error, 0)
 	for _, paramsFileName := range paramsFileNames {
 		data, err := ioutil.ReadFile(paramsFileName)
 		if err != nil {
+			errs = append(errs, err)
 			continue
 		}
 		// the classpath param exceeds MaxScanTokenSize, so we scan just this section:
@@ -145,6 +147,11 @@ func directDepParams(paramsFileNames ...string) (depsByJar map[string]string) {
 		}
 		if err := scanner.Err(); err != nil {
 			log.Printf("reading %s: %s", paramsFileName, err)
+		}
+	}
+	if len(errs) == len(paramsFileNames) {
+		for _, err := range errs {
+			log.Println(err)
 		}
 	}
 	return depsByJar

--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -118,30 +118,31 @@ func inputFileName(blazeBin, pkg, ruleName, extension string) string {
 
 // directDepParams returns --direct_dependency entries from paramsFileName (a jar-2.params file)
 // as a map from jar files to labels.
-func directDepParams(paramsFileName string) (depsByJar map[string]string) {
+func directDepParams(paramsFileNames ...string) (depsByJar map[string]string) {
 	depsByJar = make(map[string]string)
-	data, err := ioutil.ReadFile(paramsFileName)
-	if err != nil {
-		log.Println(err)
-		return depsByJar
-	}
-	// the classpath param exceeds MaxScanTokenSize, so we scan just this section:
-	first := bytes.Index(data, []byte("--direct_dependency"))
-	if first < 0 {
-		return depsByJar
-	}
-	scanner := bufio.NewScanner(bytes.NewReader(data[first:]))
-	for scanner.Scan() {
-		if scanner.Text() == "--direct_dependency" {
-			scanner.Scan()
-			jar := scanner.Text()
-			scanner.Scan()
-			label := scanner.Text()
-			depsByJar[jar] = label
+	for _, paramsFileName := range paramsFileNames {
+		data, err := ioutil.ReadFile(paramsFileName)
+		if err != nil {
+			continue
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		log.Printf("reading %s: %s", paramsFileName, err)
+		// the classpath param exceeds MaxScanTokenSize, so we scan just this section:
+		first := bytes.Index(data, []byte("--direct_dependency"))
+		if first < 0 {
+			continue
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(data[first:]))
+		for scanner.Scan() {
+			if scanner.Text() == "--direct_dependency" {
+				scanner.Scan()
+				jar := scanner.Text()
+				scanner.Scan()
+				label := scanner.Text()
+				depsByJar[jar] = label
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			log.Printf("reading %s: %s", paramsFileName, err)
+		}
 	}
 	return depsByJar
 }
@@ -284,7 +285,7 @@ func main() {
 	anyCommandPrinted := false
 	for _, label := range strings.Fields(string(queryOut)) {
 		_, pkg, ruleName := edit.InterpretLabel(label)
-		depsByJar := directDepParams(inputFileName(blazeBin, pkg, ruleName, "jar-2.params"))
+		depsByJar := directDepParams(inputFileName(blazeBin, pkg, ruleName, "jar-2.params"), inputFileName(blazeBin, pkg, ruleName+"-class", "jar-2.params"))
 		depsToRemove := unusedDeps(inputFileName(blazeBin, pkg, ruleName, "jdeps"), depsByJar)
 		// TODO(bazel-team): instead of printing, have buildifier-like modes?
 		anyCommandPrinted = printCommands(label, depsToRemove) || anyCommandPrinted


### PR DESCRIPTION
When building a `java_library` with resources Bazel will build a class jar separately from the final jar.
This means the params file is going to have a different prefix compared to the jdeps file. If the `java_library` has no resources this is not the case, so we have to try to read both paths.