### PR TITLE
Format non-top-level statements in the default mode

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -56,6 +56,7 @@ type printer struct {
 	comment      []Comment // pending end-of-line comments
 	margin       int       // left margin (indent), a number of spaces
 	depth        int       // nesting depth inside ( ) [ ] { }
+	level        int       // nesting level of def-, if-else- and for-blocks
 	needsNewLine bool      // true if the next statement needs a new line before it
 }
 
@@ -150,7 +151,7 @@ func (p *printer) file(f *File) {
 		p.newline()
 	}
 
-	p.statements(f.Stmt)
+	p.statements(f.Stmt, true)
 
 	for _, com := range f.After {
 		p.printf("%s", strings.TrimSpace(com.Token))
@@ -160,7 +161,13 @@ func (p *printer) file(f *File) {
 	p.newlineIfNeeded()
 }
 
-func (p *printer) statements(stmts []Expr) {
+func (p *printer) statements(stmts []Expr, isTopLevel bool) {
+	if !isTopLevel {
+		p.margin += nestedIndentation
+		p.level += 1
+		p.newline()
+	}
+
 	for i, stmt := range stmts {
 		switch stmt := stmt.(type) {
 		case *CommentBlock:
@@ -195,9 +202,14 @@ func (p *printer) statements(stmts []Expr) {
 			p.newline()
 		}
 
-		if i+1 < len(stmts) && !compactStmt(stmt, stmts[i+1], p.margin == 0) {
+		if i+1 < len(stmts) && !compactStmt(stmt, stmts[i+1], p.level == 0) {
 			p.newline()
 		}
+	}
+
+	if !isTopLevel {
+		p.margin -= nestedIndentation
+		p.level -= 1
 	}
 }
 
@@ -545,10 +557,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.printf(v.Name)
 		p.seq("()", &v.StartPos, &v.Params, nil, modeDef, v.ForceCompact, v.ForceMultiLine)
 		p.printf(":")
-		p.margin += nestedIndentation
-		p.newline()
-		p.statements(v.Body)
-		p.margin -= nestedIndentation
+		p.statements(v.Body,false)
 
 	case *ForStmt:
 		p.printf("for ")
@@ -556,10 +565,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.printf(" in ")
 		p.expr(v.X, precLow)
 		p.printf(":")
-		p.margin += nestedIndentation
-		p.newline()
-		p.statements(v.Body)
-		p.margin -= nestedIndentation
+		p.statements(v.Body,false)
 
 	case *IfStmt:
 		block := v
@@ -576,10 +582,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 			p.printf("if ")
 			p.expr(block.Cond, precLow)
 			p.printf(":")
-			p.margin += nestedIndentation
-			p.newline()
-			p.statements(block.True)
-			p.margin -= nestedIndentation
+			p.statements(block.True,false)
 
 			isFirst = false
 			_, end := block.True[len(block.True)-1].Span()
@@ -601,10 +604,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 				p.newline()
 			}
 			p.printf("else:")
-			p.margin += nestedIndentation
-			p.newline()
-			p.statements(block.False)
-			p.margin -= nestedIndentation
+			p.statements(block.False,false)
 		}
 	}
 
@@ -636,7 +636,7 @@ const (
 )
 
 // useCompactMode reports whether a sequence should be formatted in a compact mode
-func useCompactMode(start *Position, list *[]Expr, end *End, mode seqMode, forceCompact, forceMultiLine bool) bool {
+func useCompactMode(start *Position, list *[]Expr, end *End, mode seqMode, forceCompact, forceMultiLine, isTopLevel bool) bool {
 	// If there are line comments, use multiline
 	// so we can print the comments before the closing bracket.
 	for _, x := range *list {
@@ -654,7 +654,8 @@ func useCompactMode(start *Position, list *[]Expr, end *End, mode seqMode, force
 	}
 
 	// In Default printing mode try to keep the original printing style
-	if tables.FormattingMode == tables.DefaultMode {
+	// Non-top-level statements should also keep the original style regardless of the mode
+	if tables.FormattingMode == tables.DefaultMode || !isTopLevel {
 		// If every element (including the brackets) ends on the same line where the next element starts,
 		// use the compact mode, otherwise use multiline mode
 		previousEnd := start.Line
@@ -699,7 +700,7 @@ func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mod
 		}
 	}()
 
-	if useCompactMode(start, list, end, mode, forceCompact, forceMultiLine) {
+	if useCompactMode(start, list, end, mode, forceCompact, forceMultiLine, p.level == 0) {
 		for i, x := range *list {
 			if i > 0 {
 				p.printf(", ")

--- a/build/print.go
+++ b/build/print.go
@@ -27,8 +27,8 @@ import (
 
 const (
 	nestedIndentation = 4 // Indentation of nested blocks
-	listIndentation = 4   // Indentation of multiline expressions
-	defIndentation = 8    // Indentation of multiline function definitions
+	listIndentation   = 4 // Indentation of multiline expressions
+	defIndentation    = 8 // Indentation of multiline function definitions
 )
 
 // Format returns the formatted form of the given BUILD file.
@@ -557,7 +557,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.printf(v.Name)
 		p.seq("()", &v.StartPos, &v.Params, nil, modeDef, v.ForceCompact, v.ForceMultiLine)
 		p.printf(":")
-		p.statements(v.Body,false)
+		p.statements(v.Body, false)
 
 	case *ForStmt:
 		p.printf("for ")
@@ -565,7 +565,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.printf(" in ")
 		p.expr(v.X, precLow)
 		p.printf(":")
-		p.statements(v.Body,false)
+		p.statements(v.Body, false)
 
 	case *IfStmt:
 		block := v
@@ -582,7 +582,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 			p.printf("if ")
 			p.expr(block.Cond, precLow)
 			p.printf(":")
-			p.statements(block.True,false)
+			p.statements(block.True, false)
 
 			isFirst = false
 			_, end := block.True[len(block.True)-1].Span()
@@ -604,7 +604,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 				p.newline()
 			}
 			p.printf("else:")
-			p.statements(block.False,false)
+			p.statements(block.False, false)
 		}
 	}
 

--- a/build/print.go
+++ b/build/print.go
@@ -166,6 +166,11 @@ func (p *printer) statements(stmts []Expr, isTopLevel bool) {
 		p.margin += nestedIndentation
 		p.level += 1
 		p.newline()
+
+		defer func() {
+			p.margin -= nestedIndentation
+			p.level -= 1
+		}()
 	}
 
 	for i, stmt := range stmts {
@@ -205,11 +210,6 @@ func (p *printer) statements(stmts []Expr, isTopLevel bool) {
 		if i+1 < len(stmts) && !compactStmt(stmt, stmts[i+1], p.level == 0) {
 			p.newline()
 		}
-	}
-
-	if !isTopLevel {
-		p.margin -= nestedIndentation
-		p.level -= 1
 	}
 }
 


### PR DESCRIPTION
Non-top-level statements (i.e. statements inside def, for, if or else blocks) should be formatted in the bzl mode even if buildifier is run in the build mode. Rationale: such blocks are not allowed in BUILD files in Bazel anyway, but if that's allowed anywhere else, contents of such blocks are usually not declarations of targets but some auxiliary commands.

The tests are not affected by this change because the build mode still uses legacy PythonBlock nodes that are printed as is. Once it's removed, the tests will be fixed accordingly.