### PR TITLE
Assign suffix comments to else statements properly

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -815,6 +815,9 @@ func (in *input) order(v Expr) {
 		for _, s := range v.True {
 			in.order(s)
 		}
+		if len(v.False) > 0 {
+			in.order(&v.ElsePos)
+		}
 		for _, s := range v.False {
 			in.order(s)
 		}

--- a/build/parse.y
+++ b/build/parse.y
@@ -344,7 +344,7 @@ if_chain:
 		for len(inner.False) == 1 {
 			inner = inner.False[0].(*IfStmt)
 		}
-		inner.ElsePos = $2
+		inner.ElsePos = End{Pos: $2}
 		inner.False = []Expr{
 			&IfStmt{
 				If: $2,
@@ -364,7 +364,7 @@ if_else_block:
 		for len(inner.False) == 1 {
 			inner = inner.False[0].(*IfStmt)
 		}
-		inner.ElsePos = $2
+		inner.ElsePos = End{Pos: $2}
 		inner.False = $4
 	}
 

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -994,7 +994,7 @@ yydefault:
 			for len(inner.False) == 1 {
 				inner = inner.False[0].(*IfStmt)
 			}
-			inner.ElsePos = yyDollar[2].pos
+			inner.ElsePos = End{Pos: yyDollar[2].pos}
 			inner.False = []Expr{
 				&IfStmt{
 					If:   yyDollar[2].pos,
@@ -1012,7 +1012,7 @@ yydefault:
 			for len(inner.False) == 1 {
 				inner = inner.False[0].(*IfStmt)
 			}
-			inner.ElsePos = yyDollar[2].pos
+			inner.ElsePos = End{Pos: yyDollar[2].pos}
 			inner.False = yyDollar[4].exprs
 		}
 	case 24:

--- a/build/print.go
+++ b/build/print.go
@@ -606,9 +606,12 @@ func (p *printer) expr(v Expr, outerPrec int) {
 
 			isFirst = false
 			_, end := block.True[len(block.True)-1].Span()
-			needsEmptyLine = block.ElsePos.Line-end.Line > 1
+			needsEmptyLine = block.ElsePos.Pos.Line-end.Line > 1
 
-			if len(block.False) == 1 {
+			// If the else-block contains just one statement which is an IfStmt, flatten it as a part
+			// of if-elif chain.
+			// Don't do it if the "else" statement has a suffix comment.
+			if len(block.ElsePos.Comment().Suffix) == 0 && len(block.False) == 1 {
 				next, ok := block.False[0].(*IfStmt)
 				if ok {
 					block = next
@@ -624,6 +627,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 				p.newline()
 			}
 			p.printf("else:")
+			p.comment = append(p.comment, block.ElsePos.Comment().Suffix...)
 			p.nestedStatements(block.False)
 		}
 	}

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -510,7 +510,7 @@ type IfStmt struct {
 	If      Position // position of if
 	Cond    Expr
 	True    []Expr
-	ElsePos Position // position of else or elif
+	ElsePos End      // position of else or elif
 	False   []Expr   // optional
 }
 

--- a/build/testdata/054.build.golden
+++ b/build/testdata/054.build.golden
@@ -25,3 +25,12 @@ else:
 
 if foo:
   bar
+
+if foo: # this is assigned to foo
+  pass
+
+else: # this is assigned to "else"
+  if bar: # this is assigned to bar
+    pass
+  else: # this is assigned to "else" too
+    pass

--- a/build/testdata/054.bzl.golden
+++ b/build/testdata/054.bzl.golden
@@ -20,3 +20,11 @@ else:
 
 if foo:
     bar
+
+if foo:  # this is assigned to foo
+    pass
+else:  # this is assigned to "else"
+    if bar:  # this is assigned to bar
+        pass
+    else:  # this is assigned to "else" too
+        pass

--- a/build/testdata/054.in
+++ b/build/testdata/054.in
@@ -23,3 +23,11 @@ else:
 
 if foo:
   bar
+
+if foo: # this is assigned to foo
+  pass
+else: # this is assigned to "else"
+  if bar: # this is assigned to bar
+    pass
+  else: # this is assigned to "else" too
+    pass


### PR DESCRIPTION
If an `else:` statement has a suffix comment, it shouldn't be lost or assigned to a different statement.

Fixes #254.