### PR TITLE
Update InsertLoad to respect docstring comments.

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -806,7 +806,9 @@ func InsertLoad(stmts []build.Expr, location string, from, to []string) []build.
 	added := false
 	for _, stmt := range stmts {
 		_, isComment := stmt.(*build.CommentBlock)
-		if isComment || added {
+		c, isString := stmt.(*build.StringExpr)
+		isDocString := isString && c.Start.Line == 1 && c.Start.LineRune == 1
+		if isComment || isDocString || added {
 			all = append(all, stmt)
 			continue
 		}


### PR DESCRIPTION
Loads should be added after the  """docstring comment""" at the top of the file.