### PR TITLE
Fix a linter error

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -174,7 +174,7 @@ func main() {
 	}
 
 	if err := diff.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\b", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		exitCode = 2
 	}
 
@@ -336,7 +336,7 @@ func processFile(filename string, data []byte, inputType string) {
 			}
 		}
 		if err := diff.Show(infile, outfile); err != nil {
-			fmt.Fprintf(os.Stderr, "%v", err)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			exitCode = 4
 		}
 

--- a/differ/diff.go
+++ b/differ/diff.go
@@ -53,7 +53,7 @@ func (d *Differ) run(command string, args ...string) error {
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		// Couldn't even start bash. Worth reporting.
-		return fmt.Errorf("buildifier: %s: %v\n", command, err)
+		return fmt.Errorf("buildifier: %s: %v", command, err)
 	}
 
 	// Assume bash reported anything else worth reporting.


### PR DESCRIPTION
"error strings should not be capitalized or end with punctuation or a newline"