### PR TITLE
Introduce new parse methods

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -25,12 +25,36 @@ import (
 	"sort"
 )
 
-// Parse parses the input data and returns the corresponding parse tree.
+// ParseBuild parses a file, marks it as a BUILD file and returns the corresponding parse tree.
 //
 // The filename is used only for generating error messages.
-func Parse(filename string, data []byte) (*File, error) {
+func ParseBuild(filename string, data []byte) (*File, error) {
 	in := newInput(filename, data)
-	return in.parse()
+	f, err := in.parse()
+	if err == nil {
+		f.Build = true
+	}
+	return f, err
+}
+
+// ParseBuild parses a file, marks it as not a BUILD file (e.g. bzl file) and returns the corresponding parse tree.
+//
+// The filename is used only for generating error messages.
+func ParseDefault(filename string, data []byte) (*File, error) {
+	in := newInput(filename, data)
+	f, err := in.parse()
+	if err == nil {
+		f.Build = false
+	}
+	return f, err
+}
+
+// Parse parses the input data and returns the corresponding parse tree.
+//
+// Currently an alias for ParseBuild for compatibility reasons, in the future will delegate
+// either to ParseBuild or to ParseDefault depending on the filename.
+func Parse(filename string, data []byte) (*File, error) {
+	return ParseBuild(filename, data)
 }
 
 // An input represents a single input file being parsed.

--- a/build/lex.go
+++ b/build/lex.go
@@ -31,7 +31,7 @@ import (
 func ParseBuild(filename string, data []byte) (*File, error) {
 	in := newInput(filename, data)
 	f, err := in.parse()
-	if err == nil {
+	if f != nil {
 		f.Build = true
 	}
 	return f, err
@@ -43,7 +43,7 @@ func ParseBuild(filename string, data []byte) (*File, error) {
 func ParseDefault(filename string, data []byte) (*File, error) {
 	in := newInput(filename, data)
 	f, err := in.parse()
-	if err == nil {
+	if f != nil {
 		f.Build = false
 	}
 	return f, err

--- a/build/lex.go
+++ b/build/lex.go
@@ -37,7 +37,7 @@ func ParseBuild(filename string, data []byte) (*File, error) {
 	return f, err
 }
 
-// ParseBuild parses a file, marks it as not a BUILD file (e.g. bzl file) and returns the corresponding parse tree.
+// ParseDefault parses a file, marks it as not a BUILD file (e.g. bzl file) and returns the corresponding parse tree.
 //
 // The filename is used only for generating error messages.
 func ParseDefault(filename string, data []byte) (*File, error) {

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -130,6 +130,7 @@ var parseTests = []struct {
 `,
 		out: &File{
 			Path: "test",
+			Build: true,
 			Stmt: []Expr{
 				&CallExpr{
 					X: &Ident{
@@ -163,6 +164,7 @@ var parseTests = []struct {
 		in: `foo.bar.baz(name = "x")`,
 		out: &File{
 			Path: "test",
+			Build: true,
 			Stmt: []Expr{
 				&CallExpr{
 					X: &DotExpr{

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -82,6 +82,7 @@ func (c *Comments) Comment() *Comments {
 // A File represents an entire BUILD file.
 type File struct {
 	Path string // file path, relative to workspace directory
+	Build bool
 	Comments
 	Stmt []Expr
 }

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -34,7 +34,6 @@ import (
 	apipb "github.com/bazelbuild/buildtools/api_proto"
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/buildtools/file"
-	"github.com/bazelbuild/buildtools/tables"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -456,7 +455,7 @@ func copyAttributeBetweenRules(env CmdEnvironment, attrName string, from string)
 		return nil, fmt.Errorf("rule '%s' does not have attribute '%s'", from, attrName)
 	}
 
-	ast, err := build.Parse("" /* filename */, []byte(build.FormatString(attr)))
+	ast, err := build.ParseBuild("" /* filename */, []byte(build.FormatString(attr)))
 	if err != nil {
 		return nil, fmt.Errorf("could not parse attribute value %v", build.FormatString(attr))
 	}
@@ -698,7 +697,7 @@ func rewrite(opts *Options, commandsForFile commandsForFile) *rewriteResult {
 		}
 	}
 
-	f, err := build.Parse(name, data)
+	f, err := build.ParseBuild(name, data)
 	if err != nil {
 		return &rewriteResult{file: name, errs: []error{err}}
 	}
@@ -934,9 +933,6 @@ func printRecord(writer io.Writer, record *apipb.Output_Record) {
 
 // Buildozer loops over all arguments on the command line fixing BUILD files.
 func Buildozer(opts *Options, args []string) int {
-	// Buildozer works with BUILD files
-	tables.FormattingMode = tables.BuildMode
-
 	commandsByFile := make(map[string][]commandsForTarget)
 	if opts.CommandsFile != "" {
 		appendCommandsFromFile(opts, commandsByFile, opts.CommandsFile)

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -13,14 +13,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 package edit
 
 import (
-	"os"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/bazelbuild/buildtools/build"
-	"github.com/bazelbuild/buildtools/tables"
 )
 
 var parseLabelTests = []struct {
@@ -216,7 +214,7 @@ func TestListSubstitute(t *testing.T) {
 
 	for _, tst := range tests {
 		t.Run(tst.desc, func(t *testing.T) {
-			f, err := build.Parse("BUILD", []byte(tst.input))
+			f, err := build.ParseBuild("BUILD", []byte(tst.input))
 			if err != nil {
 				t.Fatalf("parse error: %v", err)
 			}
@@ -231,9 +229,4 @@ func TestListSubstitute(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	tables.FormattingMode = tables.BuildMode
-	os.Exit(m.Run())
 }

--- a/tables/tables.go
+++ b/tables/tables.go
@@ -205,16 +205,6 @@ var StripLabelLeadingSlashes = false
 
 var ShortenAbsoluteLabelsToRelative = false
 
-const (
-	// DefaultMode formats files preserving the semantics and partially the original formatting (suitable for .bzl files)
-	DefaultMode = iota
-	// BuildMode formats BUILD files (with stricter formatting rules, sorted lists in arguments)
-	BuildMode
-)
-
-// FormattingMode (BUILD or .bzl)
-var FormattingMode = DefaultMode
-
 // OverrideTables allows a user of the build package to override the special-case rules. The user-provided tables replace the built-in tables.
 func OverrideTables(labelArg, blacklist, listArg, sortableListArg, sortBlacklist, sortWhitelist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes, shortenAbsoluteLabelsToRelative bool) {
 	IsLabelArg = labelArg


### PR DESCRIPTION
Currently buildifier chooses the formatting mode by looking at the global variable `tables.FormattingMode`. This approach has disadvantages: it's hard to use buildifier as a library (not clear at which step the variable should be set), it makes it impossible to format files of different types in parallel.

The proposed approach is to save the information about the file to the File object during the parsing step. In the end there should be a `Parse` method that does it automatically by looking at the file name, and two explicit methods `ParseBuild` and `ParseDefault` for selecting the build or default mode for a given file.

Currently the `Parse` method is already used for BUILD files, so it's temporarily kept as an alias for `ParseBuild`. The next step will be to make all the existing users call `ParseBuild` explicitly and change the behavior of `Parse` to make it universal.