### PR TITLE
Provide explicit formatting mode for buildozer

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -795,7 +795,7 @@ func runBuildifier(opts *Options, f *build.File) ([]byte, error) {
 		return build.Format(f), nil
 	}
 
-	cmd := exec.Command(opts.Buildifier)
+	cmd := exec.Command(opts.Buildifier, "--type=build")
 	data := build.Format(f)
 	cmd.Stdin = bytes.NewBuffer(data)
 	stdout := bytes.NewBuffer(nil)

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -25,9 +25,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bazelbuild/buildtools/build"
-	"github.com/bazelbuild/buildtools/tables"
-	"github.com/bazelbuild/buildtools/wspace"
+	"google3/devtools/buildifier/tables"
+	wspace "google3/devtools/buildozer/workspace"
+	"google3/third_party/bazel_buildifier/build/build"
 )
 
 var (
@@ -223,7 +223,7 @@ func RemoveEmptyPackage(f *build.File) *build.File {
 		}
 		all = append(all, stmt)
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
 }
 
 // InsertAfter inserts an expression after index i.
@@ -332,7 +332,7 @@ func DeleteRule(f *build.File, rule *build.Rule) *build.File {
 		}
 		all = append(all, stmt)
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
 }
 
 // DeleteRuleByName returns the AST without the rules that have the
@@ -350,7 +350,7 @@ func DeleteRuleByName(f *build.File, name string) *build.File {
 			all = append(all, stmt)
 		}
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
 }
 
 // DeleteRuleByKind removes the rules of the specified kind from the AST.
@@ -368,7 +368,7 @@ func DeleteRuleByKind(f *build.File, kind string) *build.File {
 			all = append(all, stmt)
 		}
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
 }
 
 // AllLists returns all the lists concatenated in an expression.


### PR DESCRIPTION
Buildozer always works with BUILD files, so it should provide the corresponding formatting type explicitly.