### PR TITLE
Omit trailing comma in calls with *args and **kwargs parameters

### DIFF
--- a/build/testdata/057.golden
+++ b/build/testdata/057.golden
@@ -1,0 +1,27 @@
+def foo1(x, y, **kwargs):
+    bar1(
+        x,
+        y,
+        **kwargs
+    )
+
+def foo2(x, y, *args):
+    bar2(
+        x,
+        y,
+        *args
+    )
+
+def foo3(x, y, **kwargs):
+    bar2(
+        x,
+        y,
+        **kwargs
+    )
+
+def foo4(x, y, *args):
+    bar4(
+        x,
+        y,
+        *args
+    )

--- a/build/testdata/057.in
+++ b/build/testdata/057.in
@@ -1,0 +1,27 @@
+def foo1(x, y, **kwargs):
+    bar1(
+        x,
+        y,
+        **kwargs
+    )
+
+def foo2(x, y, *args):
+    bar2(
+        x,
+        y,
+        *args
+    )
+
+def foo3(x, y, **kwargs):
+    bar2(
+        x,
+        y,
+        **kwargs,
+    )
+
+def foo4(x, y, *args):
+    bar4(
+        x,
+        y,
+        *args,
+    )


### PR DESCRIPTION
The trailing comma currently causes Skylark to fail to load formatted files.