### PR TITLE
Use sort.SliceStable instead of sort.Slice

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -815,7 +815,7 @@ func (in *input) assignLineComments() {
 		}
 		// Line comments can be sorted in a wrong order because they get assgined from different
 		// parts of the lexer and the parser. Restore the original order.
-		sort.Slice(xcom.Before, func(i, j int) bool {
+		sort.SliceStable(xcom.Before, func(i, j int) bool {
 			return xcom.Before[i].Start.Byte < xcom.Before[j].Start.Byte
 		})
 	}


### PR DESCRIPTION
In some cases the lexer adds comments with an empty string as a token to the tree to separate comment blocks inside a statement (e.g. if a list contains line comments inside). Such fake comments don't have real `Start.Byte` values, instead the value is the same as for the next real comment line.

Later, when the comments are sorted to restore the possibly broken order, such comments order can be broken by unstable sorting algorithms.