### PR TITLE
Sort load args

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -20,9 +20,9 @@ package build
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 	"unicode/utf8"
-	"sort"
 )
 
 // ParseBuild parses a file, marks it as a BUILD file and returns the corresponding parse tree.
@@ -813,7 +813,7 @@ func (in *input) assignLineComments() {
 			xcom.Before = append(xcom.Before, line[0])
 			line = line[1:]
 		}
-		// Line comments can be sorted in a wrong order because they get assgined from different
+		// Line comments can be sorted in a wrong order because they get assigned from different
 		// parts of the lexer and the parser. Restore the original order.
 		sort.SliceStable(xcom.Before, func(i, j int) bool {
 			return xcom.Before[i].Start.Byte < xcom.Before[j].Start.Byte

--- a/build/print_test.go
+++ b/build/print_test.go
@@ -159,9 +159,7 @@ func testPrint(t *testing.T, in, out string, isBuild bool) {
 		return
 	}
 
-	if file.Build {
-		Rewrite(file, nil)
-	}
+	Rewrite(file, nil)
 
 	ndata := Format(file)
 

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -156,9 +156,9 @@ func doNotSort(x Expr) bool {
 }
 
 // keepSorted reports whether x is marked with a comment containing
-// "keep changed", case-insensitive.
+// "keep sorted", case-insensitive.
 func keepSorted(x Expr) bool {
-	return hasComment(x, "keep changed")
+	return hasComment(x, "keep sorted")
 }
 
 // fixLabels rewrites labels into a canonical form.
@@ -442,7 +442,7 @@ func sortStringLists(f *File, info *RewriteInfo) {
 			if disabled("unsafesort") {
 				return
 			}
-			// "keep changed" comment on x = list forces sorting of list.
+			// "keep sorted" comment on x = list forces sorting of list.
 			as := v
 			if as.Op == "=" && keepSorted(as) {
 				sortStringList(as.Y, info, "?")
@@ -451,7 +451,7 @@ func sortStringLists(f *File, info *RewriteInfo) {
 			if disabled("unsafesort") {
 				return
 			}
-			// "keep changed" before key: list also forces sorting of list.
+			// "keep sorted" before key: list also forces sorting of list.
 			if keepSorted(v) {
 				sortStringList(v.Value, info, "?")
 			}
@@ -459,7 +459,7 @@ func sortStringLists(f *File, info *RewriteInfo) {
 			if disabled("unsafesort") {
 				return
 			}
-			// "keep changed" comment above first list element also forces sorting of list.
+			// "keep sorted" comment above first list element also forces sorting of list.
 			if len(v.List) > 0 && keepSorted(v.List[0]) {
 				sortStringList(v, info, "?")
 			}
@@ -836,7 +836,7 @@ func hasComments(list *ListExpr) (line, suffix bool) {
 }
 
 // A wrapper for a LoadStmt's From and To slices for consistent sorting of their contents.
-// It's assumed that the following slices have the same length, the contents are changed by
+// It's assumed that the following slices have the same length, the contents are sorted by
 // the `To` attribute, the items of `From` are swapped exactly the same way as the items of `To`.
 type loadArgs struct {
 	From     []*Ident

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -128,6 +128,18 @@ var rewrites = []struct {
 	{"loadsort", sortLoadArgs, scopeBoth},
 }
 
+// DisableLoadSortForBuildFiles disables the loadsort transformation for BUILD files.
+// This is a temporary function for backward compatibility, can be called if there's plenty of
+// already formatted BUILD files that shouldn't be changed by the transformation.
+func DisableLoadSortForBuildFiles() {
+	for i := range rewrites {
+		if rewrites[i].name == "loadsort" {
+			rewrites[i].scope = scopeDefault
+			break
+		}
+	}
+}
+
 // leaveAlone reports whether any of the nodes on the stack are marked
 // with a comment containing "buildifier: leave-alone".
 func leaveAlone(stk []Expr, final Expr) bool {

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -836,8 +836,9 @@ func hasComments(list *ListExpr) (line, suffix bool) {
 }
 
 // A wrapper for a LoadStmt's From and To slices for consistent sorting of their contents.
-// It's assumed that the following slices have the same length, the contents are sorted by
-// the `To` attribute, the items of `From` are swapped exactly the same way as the items of `To`.
+// It's assumed that the following slices have the same length. The contents are sorted by
+// the `To` attribute, but all items with equal "From" and "To" parts are placed before the items
+// with different parts.
 type loadArgs struct {
 	From     []*Ident
 	To       []*Ident
@@ -859,7 +860,8 @@ func (args loadArgs) Less(i, j int) bool {
 	equal_i := args.From[i].Name == args.To[i].Name
 	equal_j := args.From[j].Name == args.To[j].Name
 	if equal_i != equal_j {
-		// if equal_i == true and equal_j == false, return true, otherwise return false
+		// If equal_i and !equal_j, return true, otherwise false.
+		// Equivalently, return equal_i.
 		return equal_i
 	}
 	return args.To[i].Name < args.To[j].Name

--- a/build/testdata/055.golden
+++ b/build/testdata/055.golden
@@ -1,4 +1,4 @@
-load(":foo.bzl", "foo", "a", b = "c", "d")
+load(":foo.bzl", "a", "d", "foo", b = "c", c = "b")
 load(":bar.bzl", "bar")
 load(
     ":foobar.bzl",
@@ -7,12 +7,12 @@ load(
 load(
     # 0
     "foobar.bzl",  # 1
-    "foo",  # 2
-    "bar",  # 3
-    baz = "bazz",  # 4
 
     # 5
     "aaa",
+    "bar",  # 3
+    "foo",  # 2
+    baz = "bazz",  # 4
     # 6
 
     # 7

--- a/build/testdata/055.in
+++ b/build/testdata/055.in
@@ -1,4 +1,4 @@
-load(":foo.bzl","foo",a="a",b="c","d")
+load(":foo.bzl","foo",a="a",b="c","d", c="b")
 
 load(":bar.bzl","bar")
 load(

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -279,9 +279,7 @@ func processFile(filename string, data []byte, inputType string) {
 	}
 	beforeRewrite := build.Format(f)
 	var info build.RewriteInfo
-	if f.Build {
-		build.Rewrite(f, &info)
-	}
+	build.Rewrite(f, &info)
 
 	ndata := build.Format(f)
 


### PR DESCRIPTION
Load arguments should be sorted by the Rewrite method. Items with equal "from" and "to" parts (`foo="foo"` or just `"foo"`) should be prioritized over keyword arguments with different values (`foo="bar"`) so that the syntax remains valid Python syntax.