### PR TITLE
Fix precedence for returned expressions

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -570,7 +570,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.printf("return")
 		if v.Result != nil {
 			p.printf(" ")
-			p.expr(v.Result, precSuffix)
+			p.expr(v.Result, precLow)
 		}
 
 	case *DefStmt:

--- a/build/testdata/051.build.golden
+++ b/build/testdata/051.build.golden
@@ -74,7 +74,7 @@ def function(
                     [2],
                 )  # returns h
 
-    return u()
+    return u() + w
 
 for b in a:  # first
     for c, d in b:  # second

--- a/build/testdata/051.bzl.golden
+++ b/build/testdata/051.bzl.golden
@@ -71,7 +71,7 @@ def function(
                     [2],
                 )  # returns h
 
-    return u()
+    return u() + w
 
 for b in a:  # first
     for c, d in b:  # second

--- a/build/testdata/051.in
+++ b/build/testdata/051.in
@@ -48,7 +48,7 @@ def function(
         return h([1],
                  [2]) # returns h
 
-  return u()
+  return u()+w
 
 
 for b in a:               # first


### PR DESCRIPTION
`return  a + b` used to be formatted as `return (a + b)` by mistake.