### PR TITLE
Add quasi-idempotence tests

### DIFF
--- a/build/print_test.go
+++ b/build/print_test.go
@@ -108,6 +108,36 @@ func TestPrintRewrite(t *testing.T) {
 	}
 }
 
+// Test that golden files for the build mode aren't modified if reformatted in bzl mode
+func TestPrintBuildAsBzl(t *testing.T) {
+	ins, chdir := findTests(t, ".in")
+	defer chdir()
+	for _, in := range ins {
+		prefix := in[:len(in)-len(".in")]
+		outBuild := prefix + ".build.golden"
+		if !exists(outBuild) {
+			continue
+		}
+		testIdempotence(t, outBuild, false)
+	}
+}
+
+// Test that golden files for the bzl become golden files for the build mode after reformatting
+// in the build mode
+func TestPrintBzlAsBuild(t *testing.T) {
+	ins, chdir := findTests(t, ".in")
+	defer chdir()
+	for _, in := range ins {
+		prefix := in[:len(in)-len(".in")]
+		outBuild := prefix + ".build.golden"
+		outBzl := prefix + ".bzl.golden"
+		if !exists(outBuild) {
+			continue
+		}
+		testFormat(t, outBzl, outBuild, true)
+	}
+}
+
 // findTests finds all files of the passed suffix in the build/testdata directory.
 // It changes the working directory to be the directory containing the `testdata` directory,
 // and returns a function to call to change back to the current directory.


### PR DESCRIPTION
Two more tests to ensure that the build mode is stricter than the bzl mode:

  1. `.build.golden` files aren't changed after being formatted in the bzl mode. (bzl(build(file)) == build(file))
  2. `.bzl.golden` files become equal to the corresponding `.build.golden` after formatting in the build mode. (build(bzl(file)) == build(file))

Idempotence for equal modes has already been covered by other tests.