### PR TITLE
Revert exit(4) when fix mode does work

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -362,7 +362,6 @@ func processFile(filename string, data []byte, inputType string) {
 		if *vflag {
 			fmt.Fprintf(os.Stderr, "fixed %s\n", filename)
 		}
-		exitCode = 4
 	case "print_if_changed":
 		if bytes.Equal(data, ndata) {
 			return

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -6,7 +6,7 @@ echo -e "$INPUT" > test/BUILD
 echo -e "$INPUT" > test/test.bzl
 
 $1 < test/BUILD > stdout
-$1 test/* && exit 3 # expect non-zero buildifier exit due to re-format
+$1 test/*
 $2 test/test.bzl > test/test.bzl.out
 
 cat > test/BUILD.golden <<EOF


### PR DESCRIPTION
When adding support for exit non-zero in check or diff modes, mistakenly added 