### PR TITLE
Use original printing style for arguments of a function definition

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -678,9 +678,10 @@ func (p *printer) useCompactMode(start *Position, list *[]Expr, end *End, mode s
 		return true
 	}
 
-	// In the Default printing mode try to keep the original printing style
-	// Non-top-level statements should also keep the original style regardless of the mode
-	if p.level != 0 || !p.buildMode {
+	// In the Default printing mode try to keep the original printing style.
+	// Non-top-level statements and lists of arguments of a function definition
+	// should also keep the original style regardless of the mode.
+	if p.level != 0 || !p.buildMode || mode == modeDef {
 		// If every element (including the brackets) ends on the same line where the next element starts,
 		// use the compact mode, otherwise use multiline mode
 		previousEnd := start.Line

--- a/build/testdata/051.build.golden
+++ b/build/testdata/051.build.golden
@@ -105,6 +105,6 @@ bar
 
 bar
 
-def a():
+def a(name, foo = True, **kwargs):
     # comment here
     return

--- a/build/testdata/051.bzl.golden
+++ b/build/testdata/051.bzl.golden
@@ -101,6 +101,6 @@ bar
 
 bar
 
-def a():
+def a(name, foo = True, **kwargs):
     # comment here
     return

--- a/build/testdata/051.in
+++ b/build/testdata/051.in
@@ -81,6 +81,6 @@ if foo:
 bar
 
 bar
-def a():
+def a(name, foo=True, **kwargs):
 # comment here
   return


### PR DESCRIPTION
Fixes #296.