### PR TITLE
Keep single quotes for string literals instead of escaping double quotes inside

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -395,11 +395,9 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.printf("%s", v.Name)
 
 	case *StringExpr:
-		// If the Token is a correct quoting of Value and has double quotes, use it.
-		// This preserves the specific escaping choices that BUILD authors have made,
-		// and it also works around b/7272572.
-		// Also use it if it has single quotes and the value itself contains a double quote symbol,
-		// authors may have used single quotes on purpose to avoid escaping double quotes inside.
+		// If the Token is a correct quoting of Value and has double quotes, use it,
+		// also use it if it has single quotes and the value itself contains a double quote symbol.
+		// This preserves the specific escaping choices that BUILD authors have made.
 		s, triple, err := unquote(v.Token)
 		if s == v.Value && triple == v.TripleQuote && err == nil {
 			if strings.HasPrefix(v.Token, `"`) || strings.ContainsRune(v.Value, '"') {

--- a/build/print.go
+++ b/build/print.go
@@ -395,13 +395,14 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.printf("%s", v.Name)
 
 	case *StringExpr:
-		// If the Token is a correct quoting of Value, use it.
-		// This preserves the specific escaping choices that
-		// BUILD authors have made, and it also works around
-		// b/7272572.
-		if strings.HasPrefix(v.Token, `"`) {
-			s, triple, err := unquote(v.Token)
-			if s == v.Value && triple == v.TripleQuote && err == nil {
+		// If the Token is a correct quoting of Value and has double quotes, use it.
+		// This preserves the specific escaping choices that BUILD authors have made,
+		// and it also works around b/7272572.
+		// Also use it if it has single quotes and the value itself contains a double quote symbol,
+		// authors may have used single quotes on purpose to avoid escaping double quotes inside.
+		s, triple, err := unquote(v.Token)
+		if s == v.Value && triple == v.TripleQuote && err == nil {
+			if strings.HasPrefix(v.Token, `"`) || strings.ContainsRune(v.Value, '"') {
 				p.printf("%s", v.Token)
 				break
 			}

--- a/build/testdata/002.build.golden
+++ b/build/testdata/002.build.golden
@@ -1,5 +1,5 @@
 cc_test(
-    name = "b\"ar'\"",
+    name = 'b\"ar\'"',
     size = "small",
     srcs = [
         "a.cc",

--- a/build/testdata/002.bzl.golden
+++ b/build/testdata/002.bzl.golden
@@ -1,1 +1,1 @@
-cc_test(name = "b\"ar'\"", srcs = ["a.cc", "b.cc", "c.cc"], size = "small", deps = ["//base", ":foo", "//util:map-util"])
+cc_test(name = 'b\"ar\'"', srcs = ["a.cc", "b.cc", "c.cc"], size = "small", deps = ["//base", ":foo", "//util:map-util"])

--- a/build/testdata/060.golden
+++ b/build/testdata/060.golden
@@ -1,0 +1,31 @@
+strings = [
+    # empty
+    "",
+    "",
+    """""",
+    """""",
+
+    # ordinary
+    "foo",
+    "foo",
+    """foo""",
+    """foo""",
+
+    # contain quotes of different style
+    '"foo"',
+    "'foo'",
+    '''"""foo"""''',
+    """'''foo'''""",
+
+    # contain quotes of the same style
+    "'foo'",
+    "\"foo\"",
+    """'''foo'''""",
+    """\"\"\"foo\"\"\"""",
+
+    # contain quotes of both styles
+    '\'"foo"\'',
+    "'\"foo\"'",
+    '''\'\'\'"""foo"""\'\'\'''',
+    """'''\"\"\"foo\"\"\"'''""",
+]

--- a/build/testdata/060.in
+++ b/build/testdata/060.in
@@ -1,0 +1,31 @@
+strings = [
+  # empty
+  '',
+  "",
+  '''''',
+  """""",
+
+  # ordinary
+  'foo',
+  "foo",
+  '''foo''',
+  """foo""",
+
+  # contain quotes of different style
+  '"foo"',
+  "'foo'",
+  '''"""foo"""''',
+  """'''foo'''""",
+
+  # contain quotes of the same style
+  '\'foo\'',
+  "\"foo\"",
+  '''\'\'\'foo\'\'\'''',
+  """\"\"\"foo\"\"\"""",
+
+  # contain quotes of both styles
+  '\'"foo"\'',
+  "'\"foo\"'",
+  '''\'\'\'"""foo"""\'\'\'''',
+  """'''\"\"\"foo\"\"\"'''""",
+]


### PR DESCRIPTION
Fixes #298.