### PR TITLE
[buildozer] Add ability to print separators in output

### DIFF
--- a/buildozer/main.go
+++ b/buildozer/main.go
@@ -47,6 +47,9 @@ var (
 
 	shortenLabelsFlag  = flag.Bool("shorten_labels", true, "convert added labels to short form, e.g. //foo:bar => :bar")
 	deleteWithComments = flag.Bool("delete_with_comments", true, "If a list attribute should be deleted even if there is a comment attached to it")
+	printListSep       = flag.String("print_list_separator", " ", "when using the print command, characters that should separate list elements")
+	printFieldSep      = flag.String("print_field_separator", " ", "when using the print command, characters that should separate fields")
+	printLineSep       = flag.String("print_line_separator", "\n", "when using the print command, characters that should separate lines")
 )
 
 func stringList(name, help string) func() []string {
@@ -104,6 +107,9 @@ func main() {
 		Quiet:             *quiet,
 		EditVariables:     *editVariables,
 		IsPrintingProto:   *isPrintingProto,
+		PrintListSep:      *printListSep,
+		PrintFieldSep:     *printFieldSep,
+		PrintLineSep:      *printLineSep,
 	}
 	os.Exit(edit.Buildozer(opts, flag.Args()))
 }

--- a/edit/BUILD.bazel
+++ b/edit/BUILD.bazel
@@ -24,7 +24,11 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["edit_test.go"],
+    srcs = [
+        "buildozer_test.go",
+        "edit_test.go",
+    ],
+    data = ["//buildozer"],
     embed = [":go_default_library"],
     deps = ["//build:go_default_library"],
 )

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -52,6 +52,9 @@ type Options struct {
 	Quiet             bool     // suppress informational messages.
 	EditVariables     bool     // for attributes that simply assign a variable (e.g. hdrs = LIB_HDRS), edit the build variable instead of appending to the attribute.
 	IsPrintingProto   bool     // output serialized devtools.buildozer.Output protos instead of human-readable strings
+	PrintListSep      string   // line separator for printing out rule attributes
+	PrintFieldSep     string   // field separator for printing out rule attributes
+	PrintLineSep      string   // line separator for printing out rule attributes
 }
 
 // NewOpts returns a new Options struct with some defaults set.
@@ -992,7 +995,7 @@ func appendCommandsFromFile(opts *Options, commandsByFile map[string][]commandsF
 	}
 }
 
-func printRecord(writer io.Writer, record *apipb.Output_Record) {
+func printRecord(writer io.Writer, record *apipb.Output_Record, listSep string, fieldSep string, lineSep string) {
 	fields := record.Fields
 	line := make([]string, len(fields))
 	for i, field := range fields {
@@ -1018,12 +1021,12 @@ func printRecord(writer io.Writer, record *apipb.Output_Record) {
 			}
 			break
 		case *apipb.Output_Record_Field_List:
-			line[i] = fmt.Sprintf("[%s]", strings.Join(value.List.Strings, " "))
+			line[i] = fmt.Sprintf("[%s]", strings.Join(value.List.Strings, listSep))
 			break
 		}
 	}
 
-	fmt.Fprint(writer, strings.Join(line, " ")+"\n")
+	fmt.Fprint(writer, strings.Join(line, fieldSep)+lineSep)
 }
 
 // Buildozer loops over all arguments on the command line fixing BUILD files.
@@ -1084,7 +1087,7 @@ func Buildozer(opts *Options, args []string) int {
 		fmt.Fprintf(os.Stdout, "%s", data)
 	} else {
 		for _, record := range records {
-			printRecord(os.Stdout, record)
+			printRecord(os.Stdout, record, opts.PrintListSep, opts.PrintFieldSep, opts.PrintLineSep)
 		}
 	}
 

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package edit
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func findBuildozer(root string) string {
+	// The path for buildozer is arch specific, just search
+	// in the data dir
+	var ret string
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info.Name() == "buildozer" && !info.IsDir() {
+			ret = path
+		}
+		return nil
+	})
+	return ret
+}
+
+func getExitCode(err error) int {
+	if e2, ok := err.(*exec.ExitError); ok {
+		if status, ok := e2.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus()
+		}
+	}
+	return -1
+}
+
+func TestPrintUsesDefaultSeparators(t *testing.T) {
+	tmpDir, tmpErr := ioutil.TempDir("", "buildozer_test")
+	if tmpErr != nil {
+		panic(tmpErr)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ioutil.WriteFile(
+		path.Join(tmpDir, "BUILD"),
+		[]byte(
+			"some_rule("+
+				"name=\"foo\", "+
+				"list_attr=[\"bar\", \"baz\"], "+
+				"attr=\"attr_value\")\n"+
+				"some_rule(name=\"foo2\")"), 0644)
+
+	expected := ("foo [bar baz] attr_value\n" +
+		"foo2 (missing) (missing)\n")
+	command := exec.Command(
+		findBuildozer(os.Getenv("TEST_SRCDIR")),
+		"print name list_attr attr",
+		"//:*",
+	)
+	command.Dir = tmpDir
+
+	out, err := command.Output()
+	if err != nil && getExitCode(err) != 3 {
+		t.Fatalf("Error running buildozer: %v", err)
+	}
+
+	outStr := string(out)
+	if outStr != expected {
+		t.Fatalf("Got %v, expected %v", outStr, expected)
+	}
+}
+
+func TestPrintHonorsSeparators(t *testing.T) {
+	tmpDir, tmpErr := ioutil.TempDir("", "buildozer_test")
+	if tmpErr != nil {
+		panic(tmpErr)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ioutil.WriteFile(
+		path.Join(tmpDir, "BUILD"),
+		[]byte(
+			"some_rule("+
+				"name=\"foo\", "+
+				"list_attr=[\"bar\", \"baz\"], "+
+				"attr=\"attr_value\")\n"+
+				"some_rule(name=\"foo2\")"), 0644)
+
+	expected := ("foo\x01[bar,baz]\x01attr_value\x02" +
+		"foo2\x01(missing)\x01(missing)\x02")
+	command := exec.Command(
+		findBuildozer(os.Getenv("TEST_SRCDIR")),
+		"-print_list_separator",
+		",",
+		"-print_field_separator",
+		"\x01",
+		"-print_line_separator",
+		"\x02",
+		"print name list_attr attr",
+		"//:*",
+	)
+	command.Dir = tmpDir
+
+	out, err := command.Output()
+	if err != nil && getExitCode(err) != 3 {
+		t.Fatalf("Error running buildozer: %v", err)
+	}
+
+	outStr := string(out)
+	if outStr != expected {
+		t.Fatalf("Got %v, expected %v", outStr, expected)
+	}
+}


### PR DESCRIPTION
Sometimes we want to print out multiple fields in print commands. If any of those fields are a list, it causes the number of columns to be variable, and it's kind of hard to parse things out. This also applies to when arrays are flattened. If there is a space in any of the elements, we can't tell one element from multiple elements. This patch allows us to specify how things should be printed out. 

Also added a simple integration test that passed with bazel test edit/... . Lemme know if there's a different place to write those integration style tests, as I didn't see anything. 