### PR TITLE
Fix line comments inside comprehensions

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -638,6 +638,14 @@ func (p *printer) expr(v Expr, outerPrec int) {
 			p.comment = append(p.comment, block.ElsePos.Comment().Suffix...)
 			p.nestedStatements(block.False)
 		}
+		case *ForClause:
+			p.printf("for ")
+			p.expr(v.Vars, precLow)
+			p.printf(" in ")
+			p.expr(v.X, precLow)
+		case *IfClause:
+			p.printf("if ")
+			p.expr(v.Cond, precLow)
 	}
 
 	// Add closing parenthesis if needed.
@@ -844,17 +852,7 @@ func (p *printer) listFor(v *Comprehension) {
 
 	for _, c := range v.Clauses {
 		space()
-		switch clause := c.(type) {
-		case *ForClause:
-			p.printf("for ")
-			p.expr(clause.Vars, precLow)
-			p.printf(" in ")
-			p.expr(clause.X, precLow)
-		case *IfClause:
-			p.printf("if ")
-			p.expr(clause.Cond, precLow)
-		}
-		p.comment = append(p.comment, c.Comment().Suffix...)
+		p.expr(c, precLow)
 	}
 
 	if multiLine {

--- a/build/testdata/044.build.golden
+++ b/build/testdata/044.build.golden
@@ -37,3 +37,38 @@ flags = [
     ]  # Clarififcation.
     if flag != None
 ]  # Skip empty elements.
+
+flags = [
+    # Example comment.
+    flag
+    # Clarififcation.
+    for flag in [
+        _flag(
+            name,
+            type(default),
+            values.pop(name, default),
+        )
+        for name, default in defaults.items()
+    ]
+    # Skip empty elements.
+    if flag != None
+]
+
+flags = [
+
+    # Example comment.
+    flag
+
+    # Clarififcation.
+    for flag in [
+        _flag(
+            name,
+            type(default),
+            values.pop(name, default),
+        )
+        for name, default in defaults.items()
+    ]
+
+    # Skip empty elements.
+    if flag != None
+]

--- a/build/testdata/044.bzl.golden
+++ b/build/testdata/044.bzl.golden
@@ -29,3 +29,30 @@ flags = [
     ]  # Clarififcation.
     if flag != None
 ]  # Skip empty elements.
+
+flags = [
+    # Example comment.
+    flag
+    # Clarififcation.
+    for flag in [
+        _flag(name, type(default), values.pop(name, default))
+        for name, default in defaults.items()
+    ]
+    # Skip empty elements.
+    if flag != None
+]
+
+flags = [
+
+    # Example comment.
+    flag
+
+    # Clarififcation.
+    for flag in [
+        _flag(name, type(default), values.pop(name, default))
+        for name, default in defaults.items()
+    ]
+
+    # Skip empty elements.
+    if flag != None
+]

--- a/build/testdata/044.in
+++ b/build/testdata/044.in
@@ -21,3 +21,29 @@ flags = [flag  # Example comment.
          for flag in [_flag(name, type(default), values.pop(name, default))
                       for name, default in defaults.items()]  # Clarififcation.
          if flag != None]  # Skip empty elements.
+
+flags = [
+         # Example comment.
+         flag
+         # Clarififcation.
+         for flag in [_flag(name, type(default), values.pop(name, default))
+                      for name, default in defaults.items()]
+         # Skip empty elements.
+         if flag != None
+        ]
+
+flags = [
+
+
+         # Example comment.
+         flag
+
+
+         # Clarififcation.
+         for flag in [_flag(name, type(default), values.pop(name, default))
+                      for name, default in defaults.items()]
+
+
+         # Skip empty elements.
+         if flag != None
+        ]

--- a/build/testdata/044.in
+++ b/build/testdata/044.in
@@ -36,6 +36,7 @@ flags = [
 
 
          # Example comment.
+
          flag
 
 
@@ -45,5 +46,6 @@ flags = [
 
 
          # Skip empty elements.
+
          if flag != None
         ]


### PR DESCRIPTION
Comments for `ForClause` and `IfClause` were disappearing because these nodes weren't printed by `p.expr` that's capable of handling the comments.