### PR TITLE
Fix indented comments

### DIFF
--- a/build/parse.y
+++ b/build/parse.y
@@ -301,9 +301,9 @@ stmt:
 	{
 		$$ = []Expr{$1}
 		$<lastStmt>$ = $1
-		if cb := extractTrailingComment($1); cb != nil {
-			$$ = append($$, cb)
-			$<lastStmt>$ = cb
+		if cbs := extractTrailingComments($1); len(cbs) > 0 {
+			$$ = append($$, cbs...)
+			$<lastStmt>$ = cbs[len(cbs)-1]
 			if $<lastStmt>1 == nil {
 				$<lastStmt>$ = nil
 			}
@@ -1062,25 +1062,36 @@ func forceMultiLineComprehension(start Position, expr Expr, clauses []Expr, end 
 	return previousEnd.Line != end.Line
 }
 
-// extractTrailingComment extracts a trailing comment from a block statement
-// and returns the comment (or nil)
-func extractTrailingComment(stmt Expr) *CommentBlock {
+// extractTrailingComments extracts trailing comments from a block statement
+// and returns the comments. The comments can be either CommentBlock statements
+// or After-comments for a statement of a different type.
+func extractTrailingComments(stmt Expr) []Expr {
 	body := getLastBody(stmt)
+	var comments []Expr
 	if body != nil && len(*body) > 0 {
-		lastStmt := (*body)[len(*body)-1]
-		if cb, ok := lastStmt.(*CommentBlock); ok {
-			// Remove the comment block
-			*body = (*body)[:len(*body)-1]
-			return cb
+		// Detach and return all trailing comment blocks
+		for i := len(*body)-1; i >= 0; i-- {
+			if cb, ok := (*body)[i].(*CommentBlock); ok {
+				comments = append(comments, cb)
+				*body = (*body)[:i]
+				continue
+			}
+			break
 		}
+
 		// Detach after comments from the last statement
+		lastStmt := (*body)[len(*body)-1]
 		cb := &CommentBlock{Comments: Comments{After: lastStmt.Comment().After}}
 		if len(cb.After) > 0 {
 			lastStmt.Comment().After = []Comment{}
-			return cb
+			comments = append(comments, cb)
 		}
 	}
-	return nil
+	// The comments are collected in the reversed order, reverse them again
+	for i, j := 0, len(comments)-1; i < j; i, j = i+1, j-1 {
+ 		comments[i], comments[j] = comments[j], comments[i]
+ 	}
+	return comments
 }
 
 // getLastBody returns the last body of a block statement (the only body for For- and DefStmt

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -268,25 +268,36 @@ func forceMultiLineComprehension(start Position, expr Expr, clauses []Expr, end 
 	return previousEnd.Line != end.Line
 }
 
-// extractTrailingComment extracts a trailing comment from a block statement
-// and returns the comment (or nil)
-func extractTrailingComment(stmt Expr) *CommentBlock {
+// extractTrailingComments extracts trailing comments from a block statement
+// and returns the comments. The comments can be either CommentBlock statements
+// or After-comments for a statement of a different type.
+func extractTrailingComments(stmt Expr) []Expr {
 	body := getLastBody(stmt)
+	var comments []Expr
 	if body != nil && len(*body) > 0 {
-		lastStmt := (*body)[len(*body)-1]
-		if cb, ok := lastStmt.(*CommentBlock); ok {
-			// Remove the comment block
-			*body = (*body)[:len(*body)-1]
-			return cb
+		// Detach and return all trailing comment blocks
+		for i := len(*body) - 1; i >= 0; i-- {
+			if cb, ok := (*body)[i].(*CommentBlock); ok {
+				comments = append(comments, cb)
+				*body = (*body)[:i]
+				continue
+			}
+			break
 		}
+
 		// Detach after comments from the last statement
+		lastStmt := (*body)[len(*body)-1]
 		cb := &CommentBlock{Comments: Comments{After: lastStmt.Comment().After}}
 		if len(cb.After) > 0 {
 			lastStmt.Comment().After = []Comment{}
-			return cb
+			comments = append(comments, cb)
 		}
 	}
-	return nil
+	// The comments are collected in the reversed order, reverse them again
+	for i, j := 0, len(comments)-1; i < j; i, j = i+1, j-1 {
+		comments[i], comments[j] = comments[j], comments[i]
+	}
+	return comments
 }
 
 // getLastBody returns the last body of a block statement (the only body for For- and DefStmt
@@ -1009,9 +1020,9 @@ yydefault:
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 			yyVAL.lastStmt = yyDollar[1].expr
-			if cb := extractTrailingComment(yyDollar[1].expr); cb != nil {
-				yyVAL.exprs = append(yyVAL.exprs, cb)
-				yyVAL.lastStmt = cb
+			if cbs := extractTrailingComments(yyDollar[1].expr); len(cbs) > 0 {
+				yyVAL.exprs = append(yyVAL.exprs, cbs...)
+				yyVAL.lastStmt = cbs[len(cbs)-1]
 				if yyDollar[1].lastStmt == nil {
 					yyVAL.lastStmt = nil
 				}

--- a/build/testdata/058.golden
+++ b/build/testdata/058.golden
@@ -22,6 +22,7 @@ def f():
         return bar
 
 # 4 these comments
+
 # belong to the top level
 
 for a in b:
@@ -43,3 +44,21 @@ for a in b:
 
 # 6 these comments
 # belong to the top level
+
+def foo():
+    return
+
+# 7 these comments
+
+# belong to the
+
+# top level
+
+def foo():
+    return
+
+# 8 these comments
+
+# belong to the
+
+# top level

--- a/build/testdata/058.in
+++ b/build/testdata/058.in
@@ -20,6 +20,7 @@ def f():
   if foo:
      return bar
      # 4 these comments
+
 # belong to the top level
 
 for a in b:
@@ -39,3 +40,20 @@ for a in b:
     pass
     # 6 these comments
 # belong to the top level
+
+def foo():
+  return
+  # 7 these comments
+
+# belong to the
+
+# top level
+
+def foo():
+  return
+
+  # 8 these comments
+
+# belong to the
+
+# top level


### PR DESCRIPTION
This PR fixes the same thing as #305, but this time correclty handles the situation if an indented block has multiple comments in the end (all of them are to be not indented, not just the last one).