### PR TITLE
Fix extra escaping in indented docstrings

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -914,6 +914,9 @@ func formatDocstrings(f *File, info *RewriteInfo) {
 		updatedString := formatString(docstring.Value, oldIndentation, newIndentation)
 		if updatedString != docstring.Value {
 			docstring.Value = updatedString
+			// Apply the same transformation to Token, so that the user choice of escaped symbols is
+			// preserved.
+			docstring.Token = formatString(docstring.Token, oldIndentation, newIndentation)
 			info.FormatDocstrings++
 		}
 	})

--- a/build/testdata/059.golden
+++ b/build/testdata/059.golden
@@ -25,6 +25,7 @@ if foobar:
         """This docstring is already indented properly, therefore shouldn't be reindented,
         but the trailing spacees from this and the following lines should be removed.
 
+          “Unicode” characters aren't escaped.
         """
 
 if barfoo:
@@ -36,6 +37,8 @@ def aaa():
     """
     Docstring for top-level def statements
       are also fixed.
+
+      “Unicode” characters aren't escaped.
     """
     var = """
   This is not a docstring, 
@@ -46,6 +49,8 @@ def bbb():
     """
     Docstring for top-level def statements
 are also fixed.
+
+      “Unicode” characters aren't escaped.
     """
     var = """
         This is not a docstring, 

--- a/build/testdata/059.in
+++ b/build/testdata/059.in
@@ -25,6 +25,7 @@ if foobar:
         """This docstring is already indented properly, therefore shouldn't be reindented,
         but the trailing spacees from this and the following lines should be removed.    
         
+          “Unicode” characters aren't escaped.
         """
 
 if barfoo:
@@ -36,6 +37,8 @@ def aaa():
   """
   Docstring for top-level def statements
     are also fixed.    
+
+    “Unicode” characters aren't escaped.
   """
   var = """
   This is not a docstring, 
@@ -45,7 +48,9 @@ def aaa():
 def bbb():
         """
         Docstring for top-level def statements
- are also fixed.    
+ are also fixed.
+
+          “Unicode” characters aren't escaped.
         """
         var = """
         This is not a docstring, 


### PR DESCRIPTION
If a docstring's `Value` is changed when it's being re-indented, also change its `Token` similarly to preserve user's choice of escaping unicode symbols. The printer checks if a `Value` is equal to an unquoted `Token`, and if that's true, doesn't quote `Value` and reuses `Token`.