### PR TITLE
buildifier: migrate linkstamp to x_defs in go_binary rule

### DIFF
--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -4,7 +4,10 @@ go_binary(
     name = "buildifier",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
-    linkstamp = "main",
+    x_defs = {
+        "main.buildifierVersion": "{STABLE_buildifierVersion}",
+        "main.buildScmRevision": "{STABLE_buildScmRevision}",
+    },
 )
 
 # Test that the buildifier binary works

--- a/status.sh
+++ b/status.sh
@@ -4,7 +4,7 @@ set -e
 
 buildifier_tags=$(git describe --tags)
 IFS='-' read -a parse_tags <<< "$buildifier_tags"
-echo "buildifierVersion ${parse_tags[0]}"
+echo "STABLE_buildifierVersion ${parse_tags[0]}"
 
 buildifier_rev=$(git rev-parse HEAD)
-echo "buildScmRevision ${buildifier_rev}"
+echo "STABLE_buildScmRevision ${buildifier_rev}"


### PR DESCRIPTION
This enables use of newer versions of rules_go that only support
x_defs.

Note: the STABLE_ prefix on status script variables is required to
force a re-link when values change.

Fixes #322