### PR TITLE
Fix docstrings indentation

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -911,12 +911,14 @@ func formatDocstrings(f *File, info *RewriteInfo) {
 
 		oldIndentation := docstring.Start.LineRune - 1 // LineRune starts with 1
 		newIndentation := nestedIndentation * len(stk)
-		updatedString := formatString(docstring.Value, oldIndentation, newIndentation)
-		if updatedString != docstring.Value {
-			docstring.Value = updatedString
-			// Apply the same transformation to Token, so that the user choice of escaped symbols is
-			// preserved.
-			docstring.Token = formatString(docstring.Token, oldIndentation, newIndentation)
+
+		// Operate on Token, not Value, because their line breaks can be different if a line ends with
+		// a backslash.
+		updatedToken := formatString(docstring.Token, oldIndentation, newIndentation)
+		if updatedToken != docstring.Token {
+			docstring.Token = updatedToken
+			// Update the value to keep it consistent with Token
+			docstring.Value, _, _ = unquote(updatedToken)
 			info.FormatDocstrings++
 		}
 	})

--- a/build/testdata/059.golden
+++ b/build/testdata/059.golden
@@ -39,6 +39,9 @@ def aaa():
       are also fixed.
 
       “Unicode” characters aren't escaped.
+
+    Trailing backslashes \
+    are preserved
     """
     var = """
   This is not a docstring, 
@@ -51,6 +54,9 @@ def bbb():
 are also fixed.
 
       “Unicode” characters aren't escaped.
+
+    Trailing backslashes \
+    are preserved
     """
     var = """
         This is not a docstring, 

--- a/build/testdata/059.in
+++ b/build/testdata/059.in
@@ -39,6 +39,9 @@ def aaa():
     are also fixed.    
 
     “Unicode” characters aren't escaped.
+
+  Trailing backslashes \
+  are preserved
   """
   var = """
   This is not a docstring, 
@@ -51,6 +54,9 @@ def bbb():
  are also fixed.
 
           “Unicode” characters aren't escaped.
+
+        Trailing backslashes \
+        are preserved
         """
         var = """
         This is not a docstring, 


### PR DESCRIPTION
When a docstring is indented by buildifier, its contents is also indented. However if a line in a docstring ends with `\`, its value doesn't get a linebreak there, but this linebreak should be taken into account when the docstring is being indented, because it exists in the source file.

The indentation of a docstring should be performed over its `Token` attribute instead, and the `Value` attribute should be re-unquoted from `Token`.