### PR TITLE
Implement smarter trailing comments detection

### DIFF
--- a/build/parse.y
+++ b/build/parse.y
@@ -1110,9 +1110,14 @@ func extractTrailingComments(stmt Expr) []Expr {
 // CommentBlock statement.
 func extractDedentedComment(stmt Expr, indentation int) Expr {
 	for i, line := range stmt.Comment().After {
-		if line.Start.LineRune < indentation {
+		// line.Start.LineRune == 0 can't exist in parsed files, it indicates that the comment line
+		// has been added by an AST modification. Don't take such lines into account.
+		if line.Start.LineRune > 0 && line.Start.LineRune < indentation {
 			// This and all the following lines should be dedented
-			cb := &CommentBlock{Comments: Comments{After: stmt.Comment().After[i:]}}
+			cb := &CommentBlock{
+				Start: line.Start,
+				Comments: Comments{After: stmt.Comment().After[i:]},
+			}
 			stmt.Comment().After = stmt.Comment().After[:i]
 			return cb
 		}

--- a/build/parse.y
+++ b/build/parse.y
@@ -1062,36 +1062,62 @@ func forceMultiLineComprehension(start Position, expr Expr, clauses []Expr, end 
 	return previousEnd.Line != end.Line
 }
 
-// extractTrailingComments extracts trailing comments from a block statement
-// and returns the comments. The comments can be either CommentBlock statements
-// or After-comments for a statement of a different type.
+// extractTrailingComments extracts trailing comments of an indented block starting with the first
+// comment line with indentation less than the block indentation.
+// The comments can either belong to CommentBlock statements or to the last non-comment statement
+// as After-comments.
 func extractTrailingComments(stmt Expr) []Expr {
 	body := getLastBody(stmt)
 	var comments []Expr
 	if body != nil && len(*body) > 0 {
-		// Detach and return all trailing comment blocks
-		for i := len(*body)-1; i >= 0; i-- {
-			cb, ok := (*body)[i].(*CommentBlock)
-			if !ok {
-				break
+		// Get the current indentation level
+		start, _ := (*body)[0].Span()
+		indentation := start.LineRune
+
+		// Find the last non-comment statement
+		lastNonCommentIndex := -1
+		for i, stmt := range *body {
+			if _, ok := stmt.(*CommentBlock); !ok {
+				lastNonCommentIndex = i
 			}
-			comments = append(comments, cb)
-			*body = (*body)[:i]
+		}
+		if lastNonCommentIndex == -1 {
+			return comments
 		}
 
-		// Detach after comments from the last statement
-		lastStmt := (*body)[len(*body)-1]
-		cb := &CommentBlock{Comments: Comments{After: lastStmt.Comment().After}}
-		if len(cb.After) > 0 {
-			lastStmt.Comment().After = []Comment{}
-			comments = append(comments, cb)
+		// Iterate over the trailing comments, find the first comment line that's not indented enough,
+		// dedent it and all the following comments.
+		for i := lastNonCommentIndex; i < len(*body); i++ {
+			stmt := (*body)[i]
+			if comment := extractDedentedComment(stmt, indentation); comment != nil {
+				// This comment and all the following CommentBlock statements are to be extracted.
+				comments = append(comments, comment)
+				comments = append(comments, (*body)[i+1:]...)
+				*body = (*body)[:i+1]
+				// If the current statement is a CommentBlock statement without any comment lines
+				// it should be removed too.
+				if i > lastNonCommentIndex && len(stmt.Comment().After) == 0 {
+					*body = (*body)[:i]
+				}
+			}
+		}
+  }
+  return comments
+}
+
+// extractDedentedComment extract the first comment line from `stmt` which indentation is smaller
+// than `indentation`, and all following comment lines, and returns them in a newly created
+// CommentBlock statement.
+func extractDedentedComment(stmt Expr, indentation int) Expr {
+	for i, line := range stmt.Comment().After {
+		if line.Start.LineRune < indentation {
+			// This and all the following lines should be dedented
+			cb := &CommentBlock{Comments: Comments{After: stmt.Comment().After[i:]}}
+			stmt.Comment().After = stmt.Comment().After[:i]
+			return cb
 		}
 	}
-	// The comments are collected in the reversed order, reverse them again
-	for i, j := 0, len(comments)-1; i < j; i, j = i+1, j-1 {
- 		comments[i], comments[j] = comments[j], comments[i]
- 	}
-	return comments
+	return nil
 }
 
 // getLastBody returns the last body of a block statement (the only body for For- and DefStmt

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -316,9 +316,14 @@ func extractTrailingComments(stmt Expr) []Expr {
 // CommentBlock statement.
 func extractDedentedComment(stmt Expr, indentation int) Expr {
 	for i, line := range stmt.Comment().After {
-		if line.Start.LineRune < indentation {
+		// line.Start.LineRune == 0 can't exist in parsed files, it indicates that the comment line
+		// has been added by an AST modification. Don't take such lines into account.
+		if line.Start.LineRune > 0 && line.Start.LineRune < indentation {
 			// This and all the following lines should be dedented
-			cb := &CommentBlock{Comments: Comments{After: stmt.Comment().After[i:]}}
+			cb := &CommentBlock{
+				Start:    line.Start,
+				Comments: Comments{After: stmt.Comment().After[i:]},
+			}
 			stmt.Comment().After = stmt.Comment().After[:i]
 			return cb
 		}

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -268,36 +268,62 @@ func forceMultiLineComprehension(start Position, expr Expr, clauses []Expr, end 
 	return previousEnd.Line != end.Line
 }
 
-// extractTrailingComments extracts trailing comments from a block statement
-// and returns the comments. The comments can be either CommentBlock statements
-// or After-comments for a statement of a different type.
+// extractTrailingComments extracts trailing comments of an indented block starting with the first
+// comment line with indentation less than the block indentation.
+// The comments can either belong to CommentBlock statements or to the last non-comment statement
+// as After-comments.
 func extractTrailingComments(stmt Expr) []Expr {
 	body := getLastBody(stmt)
 	var comments []Expr
 	if body != nil && len(*body) > 0 {
-		// Detach and return all trailing comment blocks
-		for i := len(*body) - 1; i >= 0; i-- {
-			cb, ok := (*body)[i].(*CommentBlock)
-			if !ok {
-				break
+		// Get the current indentation level
+		start, _ := (*body)[0].Span()
+		indentation := start.LineRune
+
+		// Find the last non-comment statement
+		lastNonCommentIndex := -1
+		for i, stmt := range *body {
+			if _, ok := stmt.(*CommentBlock); !ok {
+				lastNonCommentIndex = i
 			}
-			comments = append(comments, cb)
-			*body = (*body)[:i]
+		}
+		if lastNonCommentIndex == -1 {
+			return comments
 		}
 
-		// Detach after comments from the last statement
-		lastStmt := (*body)[len(*body)-1]
-		cb := &CommentBlock{Comments: Comments{After: lastStmt.Comment().After}}
-		if len(cb.After) > 0 {
-			lastStmt.Comment().After = []Comment{}
-			comments = append(comments, cb)
+		// Iterate over the trailing comments, find the first comment line that's not indented enough,
+		// dedent it and all the following comments.
+		for i := lastNonCommentIndex; i < len(*body); i++ {
+			stmt := (*body)[i]
+			if comment := extractDedentedComment(stmt, indentation); comment != nil {
+				// This comment and all the following CommentBlock statements are to be extracted.
+				comments = append(comments, comment)
+				comments = append(comments, (*body)[i+1:]...)
+				*body = (*body)[:i+1]
+				// If the current statement is a CommentBlock statement without any comment lines
+				// it should be removed too.
+				if i > lastNonCommentIndex && len(stmt.Comment().After) == 0 {
+					*body = (*body)[:i]
+				}
+			}
 		}
 	}
-	// The comments are collected in the reversed order, reverse them again
-	for i, j := 0, len(comments)-1; i < j; i, j = i+1, j-1 {
-		comments[i], comments[j] = comments[j], comments[i]
-	}
 	return comments
+}
+
+// extractDedentedComment extract the first comment line from `stmt` which indentation is smaller
+// than `indentation`, and all following comment lines, and returns them in a newly created
+// CommentBlock statement.
+func extractDedentedComment(stmt Expr, indentation int) Expr {
+	for i, line := range stmt.Comment().After {
+		if line.Start.LineRune < indentation {
+			// This and all the following lines should be dedented
+			cb := &CommentBlock{Comments: Comments{After: stmt.Comment().After[i:]}}
+			stmt.Comment().After = stmt.Comment().After[:i]
+			return cb
+		}
+	}
+	return nil
 }
 
 // getLastBody returns the last body of a block statement (the only body for For- and DefStmt

--- a/build/testdata/051.in
+++ b/build/testdata/051.in
@@ -77,7 +77,7 @@ if foo:
   bar
 if foo:
   bar
-  #comment
+ #comment
 bar
 
 bar

--- a/build/testdata/058.golden
+++ b/build/testdata/058.golden
@@ -78,6 +78,7 @@ for a in b:
     # of
     # these
     # comments
+
     # are
     # aligned
     # with

--- a/build/testdata/058.golden
+++ b/build/testdata/058.golden
@@ -72,7 +72,7 @@ for a in b:
     elif bar:
         pass
     else:
-        pass
+        pass  # This comment stays here
 
     # all
     # of

--- a/build/testdata/058.golden
+++ b/build/testdata/058.golden
@@ -2,28 +2,55 @@ def f():
     if foo:
         return bar
 
-# 1 these comments
+# these comments
 # belong to the next statement
 def f():
     if foo:
         return bar
 
-# 2 these comments
+# these comments
 # belong to the top level
 
 def f():
     if foo:
         return bar
 
-# 3 these comments
-# belong to the next statement
+# these comments
+# belong to the top level
+
 def f():
     if foo:
         return bar
+        # this comment belongs to the return statement
 
-# 4 these comments
+    # these comments are aligned
+    # with the if-statement as after-comments
 
-# belong to the top level
+    # this should have the same indentation level as above
+
+# but this line belongs to the top level
+
+# and this belongs to the following for-loop
+for a in b:
+    if foo:
+        pass
+        # this comment is aligned with pass
+
+        # this comment is aligned with pass
+
+        # this comment is aligned with pass
+        pass
+    elif bar:
+        pass
+
+        # this comment is aligned with pass
+        # this comment is aligned with pass
+
+    # this comment is aligned with elif
+    # this comment is aligned with elif
+
+# this comment is aligned with for
+# this comment is aligned with for
 
 for a in b:
     if foo:
@@ -31,8 +58,13 @@ for a in b:
     elif bar:
         pass
 
-# 5 these comments
-# belong to the top level
+# all
+# of
+# these
+# comments
+# are
+# not
+# indented
 
 for a in b:
     if foo:
@@ -42,23 +74,21 @@ for a in b:
     else:
         pass
 
-# 6 these comments
-# belong to the top level
+    # all
+    # of
+    # these
+    # comments
+    # are
+    # aligned
+    # with
+    # else
 
 def foo():
     return  # This comment stays here
+    # this comment belongs to the return statement
 
-# 7 these comments
+    # this comment belongs to the function
 
-# belong to the
+# but these belong
 
-# top level
-
-def foo():
-    return  # This comment stays here
-
-# 8 these comments
-
-# belong to the
-
-# top level
+# to the top level

--- a/build/testdata/058.in
+++ b/build/testdata/058.in
@@ -67,7 +67,7 @@ for a in b:
   elif bar:
     pass
   else:
-    pass
+    pass # This comment stays here
 
   # all
    # of

--- a/build/testdata/058.in
+++ b/build/testdata/058.in
@@ -73,6 +73,7 @@ for a in b:
    # of
     # these
      # comments
+
       # are
        # aligned
         # with

--- a/build/testdata/058.in
+++ b/build/testdata/058.in
@@ -2,34 +2,64 @@ def f():
   if foo:
      return bar
 
-     # 1 these comments
+ # these comments
 # belong to the next statement
 def f():
   if foo:
      return bar
 
-     # 2 these comments
+ # these comments
 # belong to the top level
 
 def f():
   if foo:
      return bar
-     # 3 these comments
-# belong to the next statement
+ # these comments
+# belong to the top level
+
 def f():
   if foo:
      return bar
-     # 4 these comments
+        # this comment belongs to the return statement
+    # these comments are aligned
+       # with the if-statement as after-comments
 
-# belong to the top level
+    # this should have the same indentation level as above
+ # but this line belongs to the top level
+
+ # and this belongs to the following for-loop
+for a in b:
+  if foo:
+    pass
+# this comment is aligned with pass
+
+# this comment is aligned with pass
+
+# this comment is aligned with pass
+    pass
+  elif bar:
+    pass
+
+     # this comment is aligned with pass
+    # this comment is aligned with pass
+   # this comment is aligned with elif
+  # this comment is aligned with elif
+ # this comment is aligned with for
+# this comment is aligned with for
 
 for a in b:
   if foo:
     pass
   elif bar:
     pass
-    # 5 these comments
-# belong to the top level
+
+# all
+ # of
+  # these
+   # comments
+    # are
+     # not
+      # indented
 
 for a in b:
   if foo:
@@ -38,22 +68,21 @@ for a in b:
     pass
   else:
     pass
-    # 6 these comments
-# belong to the top level
+
+  # all
+   # of
+    # these
+     # comments
+      # are
+       # aligned
+        # with
+         # else
 
 def foo():
   return # This comment stays here
-  # 7 these comments
+   # this comment belongs to the return statement
 
-# belong to the
+   # this comment belongs to the function
+ # but these belong
 
-# top level
-
-def foo():
-  return # This comment stays here
-
-  # 8 these comments
-
-# belong to the
-
-# top level
+# to the top level


### PR DESCRIPTION
The current version of buildifier moves all trailing comments of an indented block to the outer block. However sometimes users expect trailing comments to belong to the indented block:

    if foo:
        pass
        # TODO: uncomment
        # return bar()

This example was previously formatted as the following (which can be considered as a bug):

    if foo:
        pass

    # TODO: uncomment
    # return bar()

However `pyformat` understands that this is not a top-level comment and doesn't dedent it.

This pull request makes the trailing comment detection smarter: if checks for the indentation level of each trailing comment line and only dedents the first comment line with indentation level less than the block indentation level, and all following comment lines.