### PR TITLE
Add support for BUCK syntax

### DIFF
--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -32,7 +32,7 @@ func TestParse(t *testing.T) {
 		if tt.out != nil {
 			name = tt.out.Path
 		}
-		p, err := Parse(name, []byte(tt.in))
+		p, err := Parse(name, 0, []byte(tt.in))
 		if err != nil {
 			t.Errorf("#%d: %v", i, err)
 			continue
@@ -62,7 +62,7 @@ func TestParseTestdata(t *testing.T) {
 			continue
 		}
 
-		_, err = Parse(filepath.Base(out), data)
+		_, err = Parse(filepath.Base(out), 0, data)
 		if err != nil {
 			t.Error(err)
 		}
@@ -134,19 +134,19 @@ var parseTests = []struct {
 `,
 		out: &File{
 			Path: "BUILD",
-			Build: true,
+			Type: 4,
 			Stmt: []Expr{
 				&CallExpr{
 					X: &Ident{
 						NamePos: Position{1, 1, 0},
-						Name: "go_binary",
+						Name:    "go_binary",
 					},
 					ListStart: Position{1, 10, 9},
 					List: []Expr{
 						&BinaryExpr{
 							X: &Ident{
 								NamePos: Position{1, 11, 10},
-								Name: "name",
+								Name:    "name",
 							},
 							OpStart: Position{1, 16, 15},
 							Op:      "=",
@@ -168,14 +168,14 @@ var parseTests = []struct {
 		in: `foo.bar.baz(name = "x")`,
 		out: &File{
 			Path: "test",
-			Build: false,
+			Type: 1,
 			Stmt: []Expr{
 				&CallExpr{
 					X: &DotExpr{
 						X: &DotExpr{
 							X: &Ident{
 								NamePos: Position{1, 1, 0},
-								Name: "foo",
+								Name:    "foo",
 							},
 							Dot:     Position{1, 4, 3},
 							NamePos: Position{1, 5, 4},
@@ -190,7 +190,7 @@ var parseTests = []struct {
 						&BinaryExpr{
 							X: &Ident{
 								NamePos: Position{1, 13, 12},
-								Name: "name",
+								Name:    "name",
 							},
 							OpStart: Position{1, 18, 17},
 							Op:      "=",

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -165,6 +165,42 @@ var parseTests = []struct {
 		},
 	},
 	{
+		in: `go_binary(name = "x"
+)
+`,
+		out: &File{
+			Path: "BUCK",
+			Type: 2,
+			Stmt: []Expr{
+				&CallExpr{
+					X: &Ident{
+						NamePos: Position{1, 1, 0},
+						Name:    "go_binary",
+					},
+					ListStart: Position{1, 10, 9},
+					List: []Expr{
+						&BinaryExpr{
+							X: &Ident{
+								NamePos: Position{1, 11, 10},
+								Name:    "name",
+							},
+							OpStart: Position{1, 16, 15},
+							Op:      "=",
+							Y: &StringExpr{
+								Start: Position{1, 18, 17},
+								Value: "x",
+								End:   Position{1, 21, 20},
+								Token: `"x"`,
+							},
+						},
+					},
+					End:            End{Pos: Position{2, 1, 21}},
+					ForceMultiLine: true,
+				},
+			},
+		},
+	},
+	{
 		in: `foo.bar.baz(name = "x")`,
 		out: &File{
 			Path: "test",

--- a/build/print.go
+++ b/build/print.go
@@ -31,19 +31,19 @@ const (
 
 // Format returns the formatted form of the given BUILD or bzl file.
 func Format(f *File) []byte {
-	pr := &printer{buildMode: f.Build}
+	pr := &printer{buildType: f.Type}
 	pr.file(f)
 	return pr.Bytes()
 }
 
 // FormatString returns the string form of the given expression.
 func FormatString(x Expr) string {
-	buildMode := true // for compatibility
+	buildType := BUILD // for compatibility
 	if file, ok := x.(*File); ok {
-		buildMode = file.Build
+		buildType = file.Type
 	}
 
-	pr := &printer{buildMode: buildMode}
+	pr := &printer{buildType: buildType}
 	switch x := x.(type) {
 	case *File:
 		pr.file(x)
@@ -55,7 +55,7 @@ func FormatString(x Expr) string {
 
 // A printer collects the state during printing of a file or expression.
 type printer struct {
-	buildMode    bool      // whether should be printed in a build mode.
+	buildType    FileType  // which output mode to use
 	bytes.Buffer           // output buffer
 	comment      []Comment // pending end-of-line comments
 	margin       int       // left margin (indent), a number of spaces
@@ -226,7 +226,7 @@ func (p *printer) compactStmt(s1, s2 Expr) bool {
 	} else if isCommentBlock(s1) || isCommentBlock(s2) {
 		// Standalone comment blocks shouldn't be attached to other statements
 		return false
-	} else if p.buildMode && p.level == 0 {
+	} else if p.buildType != Bzl && p.level == 0 {
 		// Top-level statements in a BUILD file
 		return false
 	} else if isFunctionDefinition(s1) || isFunctionDefinition(s2) {
@@ -638,14 +638,14 @@ func (p *printer) expr(v Expr, outerPrec int) {
 			p.comment = append(p.comment, block.ElsePos.Comment().Suffix...)
 			p.nestedStatements(block.False)
 		}
-		case *ForClause:
-			p.printf("for ")
-			p.expr(v.Vars, precLow)
-			p.printf(" in ")
-			p.expr(v.X, precLow)
-		case *IfClause:
-			p.printf("if ")
-			p.expr(v.Cond, precLow)
+	case *ForClause:
+		p.printf("for ")
+		p.expr(v.Vars, precLow)
+		p.printf(" in ")
+		p.expr(v.X, precLow)
+	case *IfClause:
+		p.printf("if ")
+		p.expr(v.Cond, precLow)
 	}
 
 	// Add closing parenthesis if needed.
@@ -696,7 +696,7 @@ func (p *printer) useCompactMode(start *Position, list *[]Expr, end *End, mode s
 	// In the Default printing mode try to keep the original printing style.
 	// Non-top-level statements and lists of arguments of a function definition
 	// should also keep the original style regardless of the mode.
-	if p.level != 0 || !p.buildMode || mode == modeDef {
+	if p.level != 0 || p.buildType == Bzl || mode == modeDef {
 		// If every element (including the brackets) ends on the same line where the next element starts,
 		// use the compact mode, otherwise use multiline mode
 		previousEnd := start.Line

--- a/build/print.go
+++ b/build/print.go
@@ -414,7 +414,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 			}
 		}
 
-		p.printf("%s", quote(v.Value, v.TripleQuote))
+		p.printf("%s", quote(v.Value, v.TripleQuote, p.buildType))
 
 	case *DotExpr:
 		addParen(precSuffix)

--- a/build/quote.go
+++ b/build/quote.go
@@ -190,7 +190,7 @@ const hex = "0123456789abcdef"
 
 // quote returns the quoted form of the string value "x".
 // If triple is true, quote uses the triple-quoted form """x""".
-func quote(unquoted string, triple bool) string {
+func quote(unquoted string, triple bool, fileType FileType) string {
 	q := `"`
 	if triple {
 		q = `"""`
@@ -237,7 +237,7 @@ func quote(unquoted string, triple bool) string {
 			buf.WriteByte(esc[c])
 			continue
 		}
-		if c < 0x20 || c >= 0x80 {
+		if (c < 0x20 || c >= 0x80) && fileType != BUCK {
 			// BUILD files are supposed to be Latin-1, so escape all control and high bytes.
 			// I'd prefer to use \x here, but Blaze does not implement
 			// \x in quoted strings (b/7272572).

--- a/build/quote_test.go
+++ b/build/quote_test.go
@@ -65,7 +65,7 @@ func TestQuote(t *testing.T) {
 		if !tt.std {
 			continue
 		}
-		q := quote(tt.s, strings.HasPrefix(tt.q, `"""`))
+		q := quote(tt.s, strings.HasPrefix(tt.q, `"""`), BUILD)
 		if q != tt.q {
 			t.Errorf("quote(%#q) = %s, want %s", tt.s, q, tt.q)
 		}

--- a/build/quote_test.go
+++ b/build/quote_test.go
@@ -72,6 +72,12 @@ func TestQuote(t *testing.T) {
 	}
 }
 
+func TestQuoteUnicodeIgnoredInBuck(t *testing.T) {
+	if quote("🙈", false, BUCK) != "\"🙈\"" {
+		t.Errorf("Escaping unicode in BUCK files")
+	}
+}
+
 func TestUnquote(t *testing.T) {
 	for _, tt := range quoteTests {
 		s, triple, err := unquote(tt.q)

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -18,6 +18,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 package build
 
 import (
+	"math"
 	"path"
 	"regexp"
 	"sort"
@@ -111,6 +112,7 @@ func (info *RewriteInfo) String() string {
 // rewrites is the list of all Buildifier rewrites, in the order in which they are applied.
 // The order here matters: for example, label canonicalization must happen
 // before sorting lists of strings.
+var allTypes FileType = math.MaxUint32
 var rewrites = []struct {
 	name  string
 	fn    func(*File, *RewriteInfo)
@@ -120,8 +122,8 @@ var rewrites = []struct {
 	{"label", fixLabels, BUILD},
 	{"listsort", sortStringLists, BUCK | BUILD},
 	{"multiplus", fixMultilinePlus, BUCK | BUILD},
-	{"loadsort", sortLoadArgs, All},
-	{"formatdocstrings", formatDocstrings, All},
+	{"loadsort", sortLoadArgs, allTypes},
+	{"formatdocstrings", formatDocstrings, allTypes},
 }
 
 // leaveAlone reports whether any of the nodes on the stack are marked

--- a/build/rule_test.go
+++ b/build/rule_test.go
@@ -195,7 +195,7 @@ rule()`, "foo", `Use an implicit name for one unnamed rule with load`},
 	}
 
 	for _, tst := range tests {
-		file, err := Parse(tst.path, []byte(tst.input))
+		file, err := Parse(tst.path, 0, []byte(tst.input))
 		if err != nil {
 			t.Error(tst.description, err)
 			continue

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -20,6 +20,7 @@ package build
 // Syntax data structure definitions.
 
 import (
+	"math"
 	"strings"
 	"unicode/utf8"
 )
@@ -79,10 +80,19 @@ func (c *Comments) Comment() *Comments {
 	return c
 }
 
+type FileType uint32
+
+const (
+	Bzl   FileType = 1 << iota
+	BUCK  FileType = 1 << iota
+	BUILD FileType = 1 << iota
+	All   FileType = math.MaxUint32
+)
+
 // A File represents an entire BUILD file.
 type File struct {
 	Path string // file path, relative to workspace directory
-	Build bool
+	Type FileType
 	Comments
 	Stmt []Expr
 }

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -20,7 +20,6 @@ package build
 // Syntax data structure definitions.
 
 import (
-	"math"
 	"strings"
 	"unicode/utf8"
 )
@@ -86,7 +85,6 @@ const (
 	Bzl   FileType = 1 << iota
 	BUCK  FileType = 1 << iota
 	BUILD FileType = 1 << iota
-	All   FileType = math.MaxUint32
 )
 
 // A File represents an entire BUILD file.

--- a/build/walk_test.go
+++ b/build/walk_test.go
@@ -52,7 +52,7 @@ func TestWalkOnce(t *testing.T) {
 }
 
 func TestEdit(t *testing.T) {
-	expr, _ := Parse("test", []byte("1 + 2"))
+	expr, _ := Parse("test", 0, []byte("1 + 2"))
 	compare(t, FormatString(expr), "1 + 2\n")
 	Edit(expr, func(e Expr, stk []Expr) Expr {
 		// Check if there are already parens
@@ -72,7 +72,7 @@ func TestEdit(t *testing.T) {
 }
 
 func TestRemoveParens(t *testing.T) {
-	expr, _ := Parse("test", []byte("((((1))) + 2) + (3 + 4) * 5"))
+	expr, _ := Parse("test", 0, []byte("((((1))) + 2) + (3 + 4) * 5"))
 	compare(t, FormatString(expr), "((((1))) + 2) + (3 + 4) * 5\n")
 	// Remove all ParenExpr
 	Edit(expr, func(e Expr, stk []Expr) Expr {


### PR DESCRIPTION
There are some small differences in BUCK syntax that required changes to the buildifier:

- Buck does not support the shortened name syntax of Bazel
- Buck does not handle escaped unicode in its BUCK files (unclear to me why Latin-1 is a requirement here, the skylark docs seem to mention unicode strings are fine)

This PR adds a type attribute instead of a bool to know which output type we are dealing with, and gates the `label` rewrite function as well as skips unicode escaping. Its missing some tests, but I wanted to get the PR up to get the conversation started on if this is upstreamable / acceptable style and so on. 

Thoughts etc?