### PR TITLE
Allow dot expressions to be multiline

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -419,7 +419,16 @@ func (p *printer) expr(v Expr, outerPrec int) {
 	case *DotExpr:
 		addParen(precSuffix)
 		p.expr(v.X, precSuffix)
+		_, xEnd := v.X.Span()
+		isMultiline := v.NamePos.Line > xEnd.Line
+		if isMultiline {
+			p.margin += listIndentation
+			p.breakline()
+		}
 		p.printf(".%s", v.Name)
+		if isMultiline {
+			p.margin -= listIndentation
+		}
 
 	case *IndexExpr:
 		addParen(precSuffix)

--- a/build/testdata/061.golden
+++ b/build/testdata/061.golden
@@ -11,3 +11,12 @@ object.string \
 (object.string  # 1
     .replace("foo", "bar")  # 2
     .replace("baz", "qux"))  # 3
+
+[
+    (object.string
+        .replace("foo", "bar")
+        .replace("baz", "qux")),
+    (object.string
+        .replace("foo", "bar")
+        .replace("baz", "qux")),
+]

--- a/build/testdata/061.golden
+++ b/build/testdata/061.golden
@@ -1,0 +1,13 @@
+object.string.replace("foo", "bar").replace("baz", "qux")
+
+object.string \
+    .replace("foo", "bar") \
+    .replace("baz", "qux")
+
+(object.string
+    .replace("foo", "bar")
+    .replace("baz", "qux"))
+
+(object.string  # 1
+    .replace("foo", "bar")  # 2
+    .replace("baz", "qux"))  # 3

--- a/build/testdata/061.in
+++ b/build/testdata/061.in
@@ -1,0 +1,13 @@
+object.string.replace("foo", "bar").replace("baz", "qux")
+
+object.string\
+  .replace("foo", "bar")\
+  .replace("baz", "qux")
+
+(object.string. \
+  replace("foo", "bar") \
+  .replace("baz", "qux"))
+
+(object.string. # 1
+  replace("foo", "bar") # 2
+  .replace("baz", "qux")) # 3

--- a/build/testdata/061.in
+++ b/build/testdata/061.in
@@ -11,3 +11,10 @@ object.string\
 (object.string. # 1
   replace("foo", "bar") # 2
   .replace("baz", "qux")) # 3
+
+[(object.string.
+   replace("foo", "bar")
+   .replace("baz", "qux")),
+(object.string.
+  replace("foo", "bar")
+  .replace("baz", "qux"))]

--- a/build/testdata/061.in
+++ b/build/testdata/061.in
@@ -1,7 +1,7 @@
 object.string.replace("foo", "bar").replace("baz", "qux")
 
-object.string\
-  .replace("foo", "bar")\
+object.string.\
+  replace("foo", "bar")\
   .replace("baz", "qux")
 
 (object.string. \


### PR DESCRIPTION
A long chain of dot expression can be intentionally printed in a multiline mode to avoid long lines. Buildifier doesn't try to avoid long lines on its own, therefore it should respect multiline formatting if it's enforced by the author.