### PR TITLE
Sort lists in the bzl mode

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -130,7 +130,7 @@ var rewrites = []struct {
 }{
 	{"callsort", sortCallArgs, scopeBuild},
 	{"label", fixLabels, scopeBuild},
-	{"listsort", sortStringLists, scopeBuild},
+	{"listsort", sortStringLists, scopeBoth},
 	{"multiplus", fixMultilinePlus, scopeBuild},
 	{"loadsort", sortLoadArgs, scopeBoth},
 	{"formatdocstrings", formatDocstrings, scopeBoth},
@@ -460,7 +460,7 @@ func sortStringLists(f *File, info *RewriteInfo) {
 					continue
 				}
 				context := rule + "." + key.Name
-				if !tables.IsSortableListArg[key.Name] || tables.SortableBlacklist[context] {
+				if !tables.IsSortableListArg[key.Name] || tables.SortableBlacklist[context] || !f.Build {
 					continue
 				}
 				if disabled("unsafesort") && !tables.SortableWhitelist[context] && !allowedSort(context) {
@@ -490,7 +490,7 @@ func sortStringLists(f *File, info *RewriteInfo) {
 				return
 			}
 			// "keep sorted" comment above first list element also forces sorting of list.
-			if len(v.List) > 0 && keepSorted(v.List[0]) {
+			if len(v.List) > 0 && (keepSorted(v) || keepSorted(v.List[0])) {
 				sortStringList(v, info, "?")
 			}
 		}
@@ -511,7 +511,7 @@ func sortStringList(x Expr, info *RewriteInfo, context string) {
 		return
 	}
 
-	forceSort := keepSorted(list.List[0])
+	forceSort := keepSorted(list) || keepSorted(list.List[0])
 
 	// TODO(bazel-team): Decide how to recognize lists that cannot
 	// be sorted. Avoiding all lists with comments avoids sorting

--- a/build/testdata/062.build.golden
+++ b/build/testdata/062.build.golden
@@ -1,0 +1,55 @@
+foo(
+    srcs = [
+        "list",
+        "not",
+        "sorted",
+    ],  # this should be sorted in the build mode only
+    bar = [
+        f(x)
+        for x in [
+            # please keep sorted
+            "list",
+            "not",
+            "sorted",
+        ]
+    ],
+    # keep sorted
+    foo = [
+        "list",
+        "not",
+        "sorted",
+    ],
+)
+
+# buildifier: keep sorted
+x = [
+    "list",
+    "not",
+    "sorted",
+]
+
+y = [
+    "not",
+    "sorted",
+    "list",
+]
+
+# buildifier: keep sorted
+[
+    "list",
+    "not",
+    "sorted",
+]
+
+[
+    "not",
+    "sorted",
+    "list",
+]
+
+[
+    # buildifier: keep sorted
+    "list",
+    "not",
+    "sorted",
+]

--- a/build/testdata/062.bzl.golden
+++ b/build/testdata/062.bzl.golden
@@ -1,0 +1,29 @@
+foo(
+    srcs = ["not", "sorted", "list"],  # this should be sorted in the build mode only
+    # keep sorted
+    foo = ["list", "not", "sorted"],
+    bar = [
+        f(x)
+        for x in [
+            # please keep sorted
+            "list",
+            "not",
+            "sorted",
+        ]
+    ],
+)
+
+# buildifier: keep sorted
+x = ["list", "not", "sorted"]
+y = ["not", "sorted", "list"]
+
+# buildifier: keep sorted
+["list", "not", "sorted"]
+["not", "sorted", "list"]
+
+[
+    # buildifier: keep sorted
+    "list",
+    "not",
+    "sorted",
+]

--- a/build/testdata/062.in
+++ b/build/testdata/062.in
@@ -1,0 +1,26 @@
+foo(
+  srcs = ["not", "sorted", "list"],  # this should be sorted in the build mode only
+  # keep sorted
+  foo = ["not", "sorted", "list"],
+  bar = [f(x) for x in [
+    # please keep sorted
+    "not",
+    "sorted",
+    "list"]
+  ],
+)
+
+# buildifier: keep sorted
+x = ["not", "sorted", "list"]
+y = ["not", "sorted", "list"]
+
+# buildifier: keep sorted
+["not", "sorted", "list"]
+["not", "sorted", "list"]
+
+[
+  # buildifier: keep sorted
+  "not",
+  "sorted",
+  "list"
+]


### PR DESCRIPTION
If a list is marked with a "keep sorted" comment explicitly it should be sorted in the bzl mode (as well as in the build mode).