### PR TITLE
Disable label rewrite if shortenLabelsFlag is false

### DIFF
--- a/buildozer/BUILD.bazel
+++ b/buildozer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazelbuild/buildtools/buildozer",
     visibility = ["//visibility:private"],
     deps = [
+        "//build:go_default_library",
         "//edit:go_default_library",
         "//tables:go_default_library",
     ],

--- a/buildozer/main.go
+++ b/buildozer/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/buildtools/edit"
 	"github.com/bazelbuild/buildtools/tables"
 )
@@ -75,6 +76,9 @@ func main() {
 		}
 	}
 
+	if !(*shortenLabelsFlag) {
+		build.DisableRewrites = []string{"label"}
+	}
 	edit.ShortenLabelsFlag = *shortenLabelsFlag
 	edit.DeleteWithComments = *deleteWithComments
 	opts := &edit.Options{


### PR DESCRIPTION
shortenLabelsFlas is being used in edit ShortenLabels function
but not used in rewrite ShortenLabels, which causes all the labels to be
shorten though this flag is set to false.