### PR TITLE
Support new_load /foo to=from

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -64,7 +64,7 @@ Buildozer supports the following commands(`'command args'`):
 
   * `add <attr> <value(s)>`: Adds value(s) to a list attribute of a rule. If a
     value is already present in the list, it is not added.
-  * `new_load <path> <symbol(s)>`: Add a load statement for the given path,
+  * `new_load <path> <[to=]from(s)>`: Add a load statement for the given path,
     importing the symbols. Before using this, make sure to run
     `buildozer 'fix movePackageToTop'`. Afterwards, consider running
     `buildozer 'fix unusedLoads'`.

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -253,7 +253,16 @@ func findInsertionIndex(env CmdEnvironment) (bool, int, error) {
 }
 
 func cmdNewLoad(opts *Options, env CmdEnvironment) (*build.File, error) {
-	env.File.Stmt = InsertLoad(env.File.Stmt, env.Args[0], env.Args[1:], env.Args[1:])
+	from := env.Args[1:]
+	to := append([]string{}, from...)
+	for i := range from {
+		if s := strings.SplitN(from[i], "=", 2); len(s) == 2 {
+			to[i] = s[0]
+			from[i] = s[1]
+		}
+	}
+
+	env.File.Stmt = InsertLoad(env.File.Stmt, env.Args[0], from, to)
 	return env.File, nil
 }
 
@@ -486,7 +495,7 @@ type CommandInfo struct {
 // of arguments.
 var AllCommands = map[string]CommandInfo{
 	"add":               {cmdAdd, true, 2, -1, "<attr> <value(s)>"},
-	"new_load":          {cmdNewLoad, false, 1, -1, "<path> <symbol(s)>"},
+	"new_load":          {cmdNewLoad, false, 1, -1, "<path> <[to=]from(s)>"},
 	"comment":           {cmdComment, true, 1, 3, "<attr>? <value>? <comment>"},
 	"print_comment":     {cmdPrintComment, true, 0, 2, "<attr>? <value>?"},
 	"delete":            {cmdDelete, true, 0, 0, ""},


### PR DESCRIPTION
My personal use case is something like:

```
load("@tagged_docker_push//:defaults.bzl", tagged_docker_push = "docker_push")
```