### PR TITLE
Add manual tag to the constructed buildifier target

### DIFF
--- a/buildifier/def.bzl
+++ b/buildifier/def.bzl
@@ -33,7 +33,7 @@ def _buildifier_impl(ctx):
         executable = out_file,
     )]
 
-buildifier = rule(
+_buildifier = rule(
     implementation = _buildifier_impl,
     attrs = {
         "verbose": attr.bool(
@@ -52,15 +52,23 @@ buildifier = rule(
             doc = "A list of glob patterns passed to the find command. E.g. './vendor/*' to exclude the Go vendor directory",
         ),
         "_buildifier": attr.label(
-            default = Label("@com_github_bazelbuild_buildtools//buildifier"),
+            default = "@com_github_bazelbuild_buildtools//buildifier",
             cfg = "host",
-            allow_single_file = True,
             executable = True,
         ),
         "_runner": attr.label(
-            default = Label("@com_github_bazelbuild_buildtools//buildifier:runner.bash.template"),
+            default = "@com_github_bazelbuild_buildtools//buildifier:runner.bash.template",
             allow_single_file = True,
         ),
     },
     executable = True,
 )
+
+def buildifier(**kwargs):
+    tags = kwargs.get("tags", [])
+    if "manual" not in tags:
+        tags.append("manual")
+        kwargs["tags"] = tags
+    _buildifier(
+        **kwargs
+    )


### PR DESCRIPTION
Today if the buildifier rule user runs `bazel test //...` on their project, buildifier-wrapping bash script will be built along with buildifier itself and everything it depends upon (go sdk, etc).
This change wraps the rule invocation in a macro to add the "manual" tag to it so that it is not matched by wildcard target patterns.
This is the same technic that is used in gazelle https://github.com/bazelbuild/bazel-gazelle/blob/82d15888a19178195d56d9a288a2653d16436b07/def.bzl#L116