### PR TITLE
Remove deprecated --direct_run flag

### DIFF
--- a/buildifier/README.md
+++ b/buildifier/README.md
@@ -58,5 +58,5 @@ buildifier(
 ```
 Invoke with
 ```bash
-bazel run --direct_run //:buildifier
+bazel run //:buildifier
 ```

--- a/update_generated.sh
+++ b/update_generated.sh
@@ -4,5 +4,5 @@ set -eux
 
 for r in $(bazel query 'kind(sh_binary, //...)' 2> /dev/null | grep _copy | xargs)
 do
-  bazel run --direct_run $r
+  bazel run $r
 done


### PR DESCRIPTION
When passing this to the current version of bazel (0.17.2) bazel warns
since this flag is deprecated now.