### PR TITLE
Add missing dependency on io_bazel to buildifier rule

### DIFF
--- a/buildifier/deps.bzl
+++ b/buildifier/deps.bzl
@@ -8,6 +8,16 @@ def buildifier_dependencies():
         sha256 = "57e8737fbfa2eaee76b86dd8c1184251720c840cd9abe5c3f1566d331cdf7d65",
         urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.4.0.tar.gz"],
     )
+    _maybe(
+        http_archive,
+        name = "io_bazel",
+        sha256 = "66135f877d0cc075b683474c50b1f7c3e2749bf0a40e446f20392f44494fefff",
+        strip_prefix = "bazel-0.12.0",
+        urls = [
+            "http://mirror.bazel.build/github.com/bazelbuild/bazel/archive/0.12.0.tar.gz",
+            "https://github.com/bazelbuild/bazel/archive/0.12.0.tar.gz",
+        ],
+    )
 
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():


### PR DESCRIPTION
I was trying to update dependency on this repository in one of my projects and encountered an error:
```console
# in my repository
bazel run //:buildifier
INFO: Build options have changed, discarding analysis cache.
ERROR: /private/var/tmp/_bazel_ash2k/f36748a9f0eb432c2fc5416fedbad4c7/external/com_github_bazelbuild_buildtools/build_proto/BUILD.bazel:10:1: no such package '@io_bazel//src/main/protobuf': The repository could not be resolved and referenced by '@com_github_bazelbuild_buildtools//build_proto:copy_and_fix'
ERROR: Analysis of target '//:buildifier' failed; build aborted: Analysis failed
```
This repo also has a target `//:buildifier`. Here are dependency paths for the version I use and for current master:

Hash 47728e38feb98d5f354ea1eb99e0e44f0e4d7a14
```console
bazel query 'somepath(//:buildifier, @io_bazel//src/main/protobuf:srcs)'
INFO: Empty results
```

master 86b40b7fee59cc67d3371d20f10702fe8c6dd808:
```console
bazel query 'somepath(//:buildifier, @io_bazel//src/main/protobuf:srcs)'
//:buildifier
@com_github_bazelbuild_buildtools//buildifier:buildifier
@com_github_bazelbuild_buildtools//buildifier:go_default_library
@com_github_bazelbuild_buildtools//warn:go_default_library
@com_github_bazelbuild_buildtools//edit:go_default_library
@com_github_bazelbuild_buildtools//build_proto:go_default_library
@com_github_bazelbuild_buildtools//build_proto:blaze_query_proto
@com_github_bazelbuild_buildtools//build_proto:build.proto
@com_github_bazelbuild_buildtools//build_proto:copy_and_fix
@io_bazel//src/main/protobuf:srcs
```

A dependency has been added somewhere between these two commits.