### PR TITLE
Rename unused-load to load

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -101,7 +101,7 @@ the line or at the beginning of a rule.
 
 --------------------------------------------------------------------------------
 
-## <a name="unused-load"></a>Loaded symbol is unused
+## <a name="load"></a>Loaded symbol is unused
 
 ### Background
 

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -147,7 +147,7 @@ func unusedLoadWarning(f *build.File, fix bool) []*Finding {
 				// To disable the warning, put a comment that contains '@unused'
 				start, end := to.Span()
 				findings = append(findings,
-					makeFinding(f, start, end, "unused-load",
+					makeFinding(f, start, end, "load",
 						"Loaded symbol \""+to.Name+"\" is unused. Please remove it.\n"+
 							"To disable the warning, add '@unused' in a comment.", true, nil))
 				if fix {
@@ -406,12 +406,12 @@ var FileWarningMap = map[string]func(f *build.File, fix bool) []*Finding{
 	"ctx-actions":        ctxActionsWarning,
 	"duplicated-name":    duplicatedNameWarning,
 	"integer-division":   integerDivisionWarning,
+	"load":        unusedLoadWarning,
 	"no-effect":          noEffectWarning,
 	"package-name":       packageNameWarning,
 	"package-on-top":     packageOnTopWarning,
 	"redefined-variable": redefinedVariableWarning,
 	"repository-name":    repositoryNameWarning,
-	"unused-load":        unusedLoadWarning,
 	"unused-variable":    unusedVariableWarning,
 }
 

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -188,7 +188,7 @@ php_library(name = "x")`,
 }
 
 func TestWarnUnusedLoad(t *testing.T) {
-	checkFindingsAndFix(t, "unused-load", `
+	checkFindingsAndFix(t, "load", `
 load(":f.bzl", "s1", "s2")
 load("f", "s1")
 foo(name = s1)`, `
@@ -198,7 +198,7 @@ foo(name = s1)`,
 			":2: Symbol \"s1\" has already been loaded."},
 		false)
 
-	checkFindingsAndFix(t, "unused-load", `
+	checkFindingsAndFix(t, "load", `
 load(
   ":f.bzl",
    "s1",
@@ -225,7 +225,7 @@ load(
 		[]string{":3: Loaded symbol \"s1\" is unused."},
 		false)
 
-	checkFindingsAndFix(t, "unused-load", `
+	checkFindingsAndFix(t, "load", `
 load(":f.bzl", "x")
 x = "unused"`, `
 x = "unused"`,


### PR DESCRIPTION
Although `unused-load` is more informative, there are already existing tools that expect that the category is called `load` and they were broken because of the name has been changed. This commit reverses the change.