### PR TITLE
Expand the set of file names considered to be build files.

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     size = "small",
     srcs = [
         "checkfile_test.go",
+        "lex_test.go",
         "parse_test.go",
         "print_test.go",
         "quote_test.go",
@@ -44,6 +45,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//tables:go_default_library",
         "//testutils",
     ],
 )

--- a/build/lex_test.go
+++ b/build/lex_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 Bazel contributors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package build
+
+import (
+	"testing"
+)
+
+func TestIsBuildFilename(t *testing.T) {
+	cases := map[string]bool{
+		"BUILD":           true,
+		"build":           true,
+		"bUIld":           true,
+		"BUILD.bazel":     true,
+		"build.bzl":       false,
+		"build.sky":       false,
+		"WORKSPACE":       true,
+		"external.BUILD":  true,
+		"BUILD.external":  true,
+		"aBUILD":          false,
+		"thing.sky":       false,
+		"my.WORKSPACE":    true,
+		"thing.bzl":       false,
+		"workspace.bazel": true,
+	}
+	for name, isBuild := range cases {
+		res := isBuildFilename(name)
+		if res != isBuild {
+			t.Errorf("isBuildFilename(%q) should be %v but was %v", name, isBuild, res)
+		}
+	}
+}


### PR DESCRIPTION
When using Bazel external workspaces, it's common to have files named like something.BUILD or BUILD.something, which become the BUILD file for the `@something` repository. This CL modifies build.ParseDefault so that it considers any filename with an extension or base called "BUILD" to be a BUILD file. While workspace file naming in the wild is less creative, I didn't see a reason not to extend the same rule to workspace files.

The build.BuildFilenames variable is public, so I preserved its behavior as an override. If it's not actually considered a public API, I can delete it.