### PR TITLE
Update console output for linter messages

### DIFF
--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -40,15 +40,22 @@ diff test/test.bzl.out test/test.bzl.golden
 cat > test/to_fix.bzl <<EOF
 a = b / c
 EOF
+
 cat > test/error_golden <<EOF
-test/to_fix.bzl:1: The "/" operator for integer division is deprecated in favor of "//". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)
+test/to_fix.bzl:1: integer-division: The "/" operator for integer division is deprecated in favor of "//". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)
 EOF
+
 cat > test/fixed_golden.bzl <<EOF
 a = b // c
+EOF
+
+cat > test/fix_report_golden <<EOF
+test/to_fix.bzl: applied fixes, 0 warnings left
 EOF
 
 $1 --lint=warn test/to_fix.bzl 2> test/error
 diff test/error test/error_golden
 
-$1 --lint=fix test/to_fix.bzl
+$1 --lint=fix test/to_fix.bzl 2> test/fix_report
 diff test/to_fix.bzl test/fixed_golden.bzl
+diff test/fix_report test/fix_report_golden

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -549,7 +549,7 @@ func FileWarnings(f *build.File, pkg string, enabledWarnings []string, fix bool)
 // their link in square brackets.
 func PrintWarnings(f *build.File, pkg string, enabledWarnings []string, showReplacements bool) {
 	warnings := FileWarnings(f, pkg, enabledWarnings, false)
-	sort.Slice(warnings, func(i, j int) bool {return warnings[i].Start.Line < warnings[j].Start.Line})
+	sort.Slice(warnings, func(i, j int) bool { return warnings[i].Start.Line < warnings[j].Start.Line })
 	for _, w := range warnings {
 		formatString := "%s:%d: %s: %s (%s)"
 		if !w.Actionable {

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -548,14 +548,17 @@ func FileWarnings(f *build.File, pkg string, enabledWarnings []string, fix bool)
 // Actionable warnings list their link in parens, inactionable warnings list
 // their link in square brackets.
 func PrintWarnings(f *build.File, pkg string, enabledWarnings []string, showReplacements bool) {
-	for _, w := range FileWarnings(f, pkg, enabledWarnings, false) {
-		formatString := "%s:%d: %s (%s)"
+	warnings := FileWarnings(f, pkg, enabledWarnings, false)
+	sort.Slice(warnings, func(i, j int) bool {return warnings[i].Start.Line < warnings[j].Start.Line})
+	for _, w := range warnings {
+		formatString := "%s:%d: %s: %s (%s)"
 		if !w.Actionable {
-			formatString = "%s:%d: %s [%s]"
+			formatString = "%s:%d: %s: %s [%s]"
 		}
 		fmt.Fprintf(os.Stderr, formatString,
 			w.File.Path,
 			w.Start.Line,
+			w.Category,
 			w.Message,
 			w.URL)
 		if showReplacements && w.Replacement != nil {
@@ -572,17 +575,10 @@ func PrintWarnings(f *build.File, pkg string, enabledWarnings []string, showRepl
 
 // FixWarnings fixes all warnings that can be fixed automatically.
 func FixWarnings(f *build.File, pkg string, enabledWarnings []string) {
-	for _, w := range FileWarnings(f, pkg, enabledWarnings, true) {
-		formatString := "not fixed: %s:%d: %s (%s)\n"
-		if !w.Actionable {
-			formatString = "not fixed: %s:%d: %s [%s]\n"
-		}
-		fmt.Fprintf(os.Stderr, formatString,
-			w.File.Path,
-			w.Start.Line,
-			w.Message,
-			w.URL)
-	}
+	warnings := FileWarnings(f, pkg, enabledWarnings, true)
+	fmt.Fprintf(os.Stderr, "%s: applied fixes, %d warnings left\n",
+		f.Path,
+		len(warnings))
 }
 
 func collectAllWarnings() []string {


### PR DESCRIPTION
  * `--lint=fix` now sorts warnings by line number for every file
  * `--lint=warn` doesn't show unfixed warnings (but shows their count)