### PR TITLE
Add .ijwb to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bazel-*
 *~
 .idea
+.ijwb
 *.iml


### PR DESCRIPTION
The directory is automatically created by the [Intellij with Bazel](https://plugins.jetbrains.com/plugin/8609-bazel) plugin.