### PR TITLE
Fix the type inference with the % operator

### DIFF
--- a/warn/types.go
+++ b/warn/types.go
@@ -92,6 +92,10 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 				if !ok {
 					return
 				}
+				if node.Op == "%=" && t != String {
+					// If the right hand side is not a string, the left hand side can still be a string
+					return
+				}
 				ident, ok := (node.X).(*build.Ident)
 				if !ok {
 					return
@@ -112,7 +116,12 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 				if t, ok := result[node.X]; ok {
 					nodeType = t
 				} else if t, ok := result[node.Y]; ok {
-					nodeType = t
+					if node.Op != "%" || t == String {
+						// The percent operator is special because it can be applied to to arguments of
+						// different types (`"%s\n" % foo`), and we can't assume that the expression has
+						// type X if the right-hand side has the type X.
+						nodeType = t
+					}
 				}
 			}
 		}

--- a/warn/types_test.go
+++ b/warn/types_test.go
@@ -143,4 +143,48 @@ dict:<bar + dict:<d>>
 depset:<depset:<s> | baz>
 depset:<baz | depset:<s>>
 `)
+
+	checkTypes(t, `
+n = 3
+s = "foo"
+
+foo % n
+foo % s
+foo % bar
+
+n % foo
+s % foo
+
+s %= foo
+n %= foo
+
+baz = unknown
+baz %= s
+baz
+
+boq = unknown
+boq %= n
+boq
+`, `
+n = int:<3>
+s = string:<"foo">
+
+foo % int:<n>
+string:<foo % string:<s>>
+foo % bar
+
+int:<int:<n> % foo>
+string:<string:<s> % foo>
+
+string:<s> %= foo
+int:<n> %= foo
+
+baz = unknown
+baz %= string:<s>
+string:<baz>
+
+boq = unknown
+boq %= int:<n>
+boq
+`)
 }


### PR DESCRIPTION
The `%` operator can be applied to expressions of different types. If the left side is a string, the right side
can be anything and the binary expression itself will be a string.

Therefore we can't assume that the result of `unknown % type_x` is of type X, unless it is a string, e.g. compare `10 % 3` and `"template %s" % 3`.

Likewise, the `%=` operator can also be applied to a string and a non-string.