### PR TITLE
Add dictionary handling

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -104,6 +104,11 @@ Buildozer supports the following commands(`'command args'`):
     exists in the `to_rule`, it will be overwritten.
   * `copy_no_overwrite <attr> <from_rule>`:  Copies the value of `attr` between
     rules. If it exists in the `to_rule`, no action is taken.
+  * `dict_add <attr> <(key:value)(s)>`:  Sets the value of a key for the dict
+    attribute `attr`. If the key was already present, it will be overwritten
+  * `dict_set <attr> <(key:value)(s)>`:  Sets the value of a key for the dict
+    attribute `attr`. If the key was already present, its old value is replaced.
+  * `dict_delete <attr> <key(s)>`:  Deletes the key for the dict attribute `attr`.
 
 Here, `<attr>` represents an attribute (being `add`ed/`rename`d/`delete`d etc.),
 e.g.: `srcs`, `<value(s)>` represents values of the attribute and so on.

--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -105,7 +105,7 @@ Buildozer supports the following commands(`'command args'`):
   * `copy_no_overwrite <attr> <from_rule>`:  Copies the value of `attr` between
     rules. If it exists in the `to_rule`, no action is taken.
   * `dict_add <attr> <(key:value)(s)>`:  Sets the value of a key for the dict
-    attribute `attr`. If the key was already present, it will be overwritten
+    attribute `attr`. If the key was already present, it will _not_ be overwritten
   * `dict_set <attr> <(key:value)(s)>`:  Sets the value of a key for the dict
     attribute `attr`. If the key was already present, its old value is replaced.
   * `dict_delete <attr> <key(s)>`:  Deletes the key for the dict attribute `attr`.

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -479,8 +479,8 @@ func cmdDictAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 			// Only set the value if the value is currently unset.
 			DictionarySet(dict, kv[0], &expr)
 		}
-		env.Rule.SetAttr(attr, dict)
 	}
+	env.Rule.SetAttr(attr, dict)
 	return env.File, nil
 }
 
@@ -504,8 +504,8 @@ func cmdDictSet(opts *Options, env CmdEnvironment) (*build.File, error) {
 		}
 		// Set overwrites previous values.
 		DictionarySet(dict, kv[0], &expr)
-		env.Rule.SetAttr(attr, dict)
 	}
+	env.Rule.SetAttr(attr, dict)
 	return env.File, nil
 }
 
@@ -516,19 +516,19 @@ func cmdDictRemove(opts *Options, env CmdEnvironment) (*build.File, error) {
 
 	thing := env.Rule.Attr(attr)
 	dictAttr, ok := thing.(*build.DictExpr)
-	if ok {
-		for _, x := range args {
-			// should errors here be flagged?
-			DictionaryDelete(dictAttr, x)
-			env.Rule.SetAttr(attr, dictAttr)
-		}
+	if !ok {
+		return env.File, nil
+	}
+
+	for _, x := range args {
+		// should errors here be flagged?
+		DictionaryDelete(dictAttr, x)
+		env.Rule.SetAttr(attr, dictAttr)
 	}
 
 	// If the removal results in the dict having no contents, delete the attribute (stay clean!)
 	if dictAttr == nil || len(dictAttr.List) == 0 {
-		if env.Rule.DelAttr(attr) != nil {
-			return env.File, nil
-		}
+		env.Rule.DelAttr(attr)
 	}
 
 	return env.File, nil

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -10,6 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
 // Buildozer is a tool for programmatically editing BUILD files.
 
 package edit
@@ -520,6 +521,13 @@ func cmdDictRemove(opts *Options, env CmdEnvironment) (*build.File, error) {
 			// should errors here be flagged?
 			DictionaryDelete(dictAttr, x)
 			env.Rule.SetAttr(attr, dictAttr)
+		}
+	}
+
+	// If the removal results in the dict having no contents, delete the attribute (stay clean!)
+	if dictAttr == nil || len(dictAttr.List) == 0 {
+		if env.Rule.DelAttr(attr) != nil {
+			return env.File, nil
 		}
 	}
 

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -682,6 +682,18 @@ func DictionarySet(dict *build.DictExpr, key string, value build.Expr) build.Exp
 	return nil
 }
 
+// DictionaryGet looks for the key in the dictionary expression, and returns the
+// current value. If it is unset, it returns nil.
+func DictionaryGet(dict *build.DictExpr, key string) build.Expr {
+	for _, e := range dict.List {
+		kv, _ := e.(*build.KeyValueExpr)
+		if k, ok := kv.Key.(*build.StringExpr); ok && k.Value == key {
+			return kv.Value
+		}
+	}
+	return nil
+}
+
 // DictionaryDelete looks for the key in the dictionary expression. If the key exists,
 // it removes the key-value pair and returns it. Otherwise it returns nil.
 func DictionaryDelete(dict *build.DictExpr, key string) (deleted build.Expr) {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -686,7 +686,10 @@ func DictionarySet(dict *build.DictExpr, key string, value build.Expr) build.Exp
 // current value. If it is unset, it returns nil.
 func DictionaryGet(dict *build.DictExpr, key string) build.Expr {
 	for _, e := range dict.List {
-		kv, _ := e.(*build.KeyValueExpr)
+		kv, ok := e.(*build.KeyValueExpr)
+		if !ok {
+			continue
+		}
 		if k, ok := kv.Key.(*build.StringExpr); ok && k.Value == key {
 			return kv.Value
 		}


### PR DESCRIPTION
(This supercedes #376 to deal with CLA; all credit to @PaulSonOfLars)

This address issue #126, adding dictionary manipulation tools.

Specifically, this adds the following to buildozer:

`dict_add <attr> <(key:value)(s)>` Which does not overwrite existing values.
`dict_set <attr> <(key:value)(s)>` Which overwrites existing values.
`dict_remove <attr> <key(s)>` Which removes keys from the dictionary, removing the final dictionary if it is now empty.