### PR TITLE
Document warning categories

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -38,8 +38,7 @@ the line or at the beginning of a rule.
   * Category name: `constant-glob`
   * Automatic fix: no
 
-[Glob function]
-(https://docs.bazel.build/versions/master/be/functions.html#glob)
+[Glob function](https://docs.bazel.build/versions/master/be/functions.html#glob)
 is used to get a list of files from the depot. The patterns (the first argument)
 typically include a wildcard (* character). A pattern without a wildcard is
 often useless and sometimes harmful.

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -4,6 +4,9 @@
 
 ## <a name="duplicated-name"></a>A rule with name `foo` was already found on line
 
+  * Category name: `duplicated-name`
+  * Automatic fix: no
+
 ### Background
 
 Each label in Bazel has a unique name, and Bazel doesn’t allow two rules to have
@@ -31,6 +34,9 @@ the line or at the beginning of a rule.
 --------------------------------------------------------------------------------
 
 ## <a name="constant-glob"></a>Glob pattern has no wildcard ('*')
+
+  * Category name: `constant-glob`
+  * Automatic fix: no
 
 [Glob function]
 (https://docs.bazel.build/versions/master/be/functions.html#glob)
@@ -75,6 +81,9 @@ the line or at the beginning of a rule.
 
 ## <a name="positional-args"></a>Keyword arguments should be used over positional arguments
 
+  * Category_name: `positional-args`
+  * Automatic fix: no
+
 All top level calls (except for some built-ins) should use keyword args over
 positional arguments. Positional arguments can cause subtle errors if the order
 is switched or if an argument is removed. Keyword args also greatly improve
@@ -102,6 +111,9 @@ the line or at the beginning of a rule.
 --------------------------------------------------------------------------------
 
 ## <a name="load"></a>Loaded symbol is unused
+
+  * Category_name: `load`
+  * Automatic fix: yes
 
 ### Background
 
@@ -133,6 +145,9 @@ or at the beginning of a rule.
 
 ## <a name="unused-variable"></a>Variable is unused
 
+  * Category_name: `unused-variable`
+  * Automatic fix: no
+
 This happens when a variable is set but not used in the file, e.g.
 
 ```
@@ -157,6 +172,9 @@ the line or at the beginning of a rule.
 
 ## <a name="redefined-variable"></a>Variable has already been defined
 
+  * Category_name: `redefined-variable`
+  * Automatic fix: no
+
 ### Background
 
 In .bzl files, redefining a global variable is already forbidden. This helps
@@ -178,6 +196,9 @@ the line or at the beginning of a rule.
 --------------------------------------------------------------------------------
 
 ## <a name="package-on-top"></a>Package declaration should be at the top of the file
+
+  * Category_name: `package-on-top`
+  * Automatic fix: no
 
 Here is a typical structure of a BUILD file:
 
@@ -209,6 +230,10 @@ the line or at the beginning of a rule.
 
 ## <a name="integer-division"></a>The `/` operator for integer division is deprecated
 
+  * Category_name: `integer-division`
+  * Flag in Bazel: [`--incompatible_disallow_slash_operator`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#integer-division-operator-is)
+  * Automatic fix: yes
+
 The `/` operator is deprecated in favor of `//`, please use the latter for
 integer division:
 
@@ -221,12 +246,19 @@ d //= e
 
 ## <a name="no-effect"></a>Expression result is not used
 
+  * Category_name: `no-effect`
+  * Automatic fix: no
+
 The statement has no effect. Consider removing it or storing its result in a
 variable.
 
 --------------------------------------------------------------------------------
 
 ## <a name="attr-cfg"></a>`cfg = "data"` for attr definitions has no effect
+
+  * Category_name: `attr-cfg`
+  * Flag in Bazel: [`--incompatible_disallow_data_transition`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#disallow-cfg-data)
+  * Automatic fix: yes
 
 The [Configuration](https://docs.bazel.build/versions/master/skylark/rules.html#configurations)
 `cfg = "data" is deprecated and has no effect. Consider removing it.
@@ -235,6 +267,10 @@ The [Configuration](https://docs.bazel.build/versions/master/skylark/rules.html#
 
 ## <a name="attr-non-empty"></a>`non_empty` attribute for attr definitions are deprecated
 
+  * Category_name: `attr-non-empty`
+  * Flag in Bazel: `--incompatible_disable_deprecated_attr_params`
+  * Automatic fix: yes
+
 The `non_empty` [attribute](https://docs.bazel.build/versions/master/skylark/lib/attr.html)
 for attr definitions is deprecated, please use `allow_empty` with an opposite value instead.
 
@@ -242,12 +278,20 @@ for attr definitions is deprecated, please use `allow_empty` with an opposite va
 
 ## <a name="attr-single-file"></a>`single_file` is deprecated
 
+  * Category_name: `attr-single-file`
+  * Flag in Bazel: `--incompatible_disable_deprecated_attr_params`
+  * Automatic fix: yes
+
 The `single_file` [attribute](https://docs.bazel.build/versions/master/skylark/lib/attr.html)
 is deprecated, please use `allow_single_file` instead.
 
 --------------------------------------------------------------------------------
 
 ## <a name="ctx-actions"></a>`ctx.{action_name}` is deprecated
+
+  * Category_name: `ctx-actions`
+  * Flag in Bazel: [`--incompatible_new_actions_api`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#new-actions-api)
+  * Automatic fix: yes
 
 The following [actions](https://docs.bazel.build/versions/master/skylark/lib/actions.html)
 are deprecated, please use the new API:
@@ -264,6 +308,10 @@ are deprecated, please use the new API:
 
 ## <a name="package-name"></a>Global variable `PACKAGE_NAME` is deprecated
 
+  * Category_name: `package-name`
+  * Flag in Bazel: [`--incompatible_package_name_is_a_function`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#package-name-is-a-function)
+  * Automatic fix: yes
+
 The global variable `PACKAGE_NAME` is deprecated, please use
 [`native.package_name()`](https://docs.bazel.build/versions/master/skylark/lib/native.html#package_name)
 instead.
@@ -271,6 +319,10 @@ instead.
 --------------------------------------------------------------------------------
 
 ## <a name="repository-name"></a>Global variable `REPOSITORY_NAME` is deprecated
+
+  * Category_name: `repository-name`
+  * Flag in Bazel: [`--incompatible_package_name_is_a_function`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#package-name-is-a-function)
+  * Automatic fix: yes
 
 The global variable `REPOSITORY_NAME` is deprecated, please use
 [`native.repository_name()`](https://docs.bazel.build/versions/master/skylark/lib/native.html#repository_name)
@@ -280,12 +332,20 @@ instead.
 
 ## <a name="load-on-top"></a>Load statements should be at the top of the file.
 
+  * Category_name: `load-on-top`
+  * Flag in Bazel: [`--incompatible_bzl_disallow_load_after_statement`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#load-must-appear-at-top-of-file)
+  * Automatic fix: yes
+
 Load statements should be first statements (with the exception of `WORKSPACE` files),
 they can follow only comments and docstrings.
 
 --------------------------------------------------------------------------------
 
 ## <a name="filetype"></a>The `FileType` function is deprecated
+
+  * Category_name: `filetype`
+  * Flag in Bazel: [`--incompatible_disallow_filetype`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#filetype-is-deprecated)
+  * Automatic fix: no
 
 The function `FileType` is [deprecated](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#filetype-is-deprecated).
 Instead of using it as an argument to the [`rule` function](https://docs.bazel.build/versions/master/skylark/lib/globals.html#rule)
@@ -295,12 +355,20 @@ just use a list of strings.
 
 ## <a name="output-group"></a>`ctx.attr.dep.output_group` is deprecated
 
+  * Category_name: `output-group`
+  * Flag in Bazel: [`--incompatible_no_target_output_group`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#disable-output-group-field-on-target)
+  * Automatic fix: yes
+
 The `output_group` field of a target is [deprecated](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#disable-output-group-field-on-target)
 in favor of the [`OutputGroupInfo` provider](https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html).
 
 --------------------------------------------------------------------------------
 
 ## <a name="git-repository"></a>Function `git_repository` is not global anymore
+
+  * Category_name: `git-repository`
+  * Flag in Bazel: [`--incompatible_remove_native_git_repository`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#remove-native-git-repository)
+  * Automatic fix: yes
 
 Native `git_repository` and `new_git_repository` functions are [being removed](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#remove-native-git-repository).
 Please use the Starklark versions instead:
@@ -311,6 +379,10 @@ Please use the Starklark versions instead:
 
 ## <a name="http-archive"></a>Function `http_archive` is not global anymore
 
+  * Category_name: `http-archive`
+  * Flag in Bazel: [`--incompatible_remove_native_http_archive`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#remove-native-http-archive)
+  * Automatic fix: yes
+
 Native `http_archive` function are [being removed](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#remove-native-http-archive).
 Please use the Starklark versions instead:
 
@@ -319,6 +391,10 @@ Please use the Starklark versions instead:
 --------------------------------------------------------------------------------
 
 ## <a name="dict-concatenation"></a>Dictionary concatenation is deprecated
+
+  * Category_name: `dict-concatenation`
+  * Flag in Bazel: [`--incompatible_disallow_dict_plus`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#dictionary-concatenation)
+  * Automatic fix: no
 
 The `+` operator to concatenate dicts is deprecated. The operator used to create a new dict and
 copy the data to it. There are several ways to avoid it, for example, instead of `d = d1 + d2 + d3`
@@ -344,6 +420,10 @@ you can use one of the following:
 
 ## <a name="string-iteration"></a>String iteration is deprecated
 
+  * Category_name: `string-iteration`
+  * Flag in Bazel: [`--incompatible_string_is_not_iterable`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#string-is-no-longer-iterable)
+  * Automatic fix: no
+
 Iteration over strings often leads to confusion with iteration over a sequence of strings,
 therefore strings won't be recognized as sequences of 1-element strings (like in Python).
 Use string indexing and `len` instead:
@@ -357,6 +437,10 @@ Use string indexing and `len` instead:
 
 ## <a name="depset-iteration"></a>Depset iteration is deprecated
 
+  * Category_name: `depset-iteration`
+  * Flag in Bazel: [`--incompatible_depset_is_not_iterable`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#depset-is-no-longer-iterable)
+  * Automatic fix: yes
+
 Depsets are complex structures, iterations over them and lookups require flattening them to
 a list which may be a heavy operation. To make it more obvious it's now required to call
 the `.to_list()` method on them in order to be able to iterate their items:
@@ -368,6 +452,10 @@ the `.to_list()` method on them in order to be able to iterate their items:
 --------------------------------------------------------------------------------
 
 ## <a name="depset-union"></a>Depsets should be joined using the depset constructor
+
+  * Category_name: `depset-union`
+  * Flag in Bazel: [`--incompatible_depset_union`](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#depset-union)
+  * Automatic fix: no
 
 The following ways to merge two depsets are deprecated:
 

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -296,13 +296,13 @@ is deprecated, please use `allow_single_file` instead.
 The following [actions](https://docs.bazel.build/versions/master/skylark/lib/actions.html)
 are deprecated, please use the new API:
 
-  * `ctx.new_file` -> `ctx.actions.declare_file`
-  * `ctx.experimental_new_directory` -> `ctx.actions.declare_directory`
-  * `ctx.file_action` -> `ctx.actions.write`
-  * `ctx.action(command = "...")` -> `ctx.actions.run_shell`
-  * `ctx.action(executable = "...")` -> `ctx.actions.run`
-  * `ctx.empty_action` -> `ctx.actions.do_nothing`
-  * `ctx.template_action` -> `ctx.actions.expand_template`
+  * [`ctx.new_file`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#new_file) → [`ctx.actions.declare_file`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#declare_file)
+  * `ctx.experimental_new_directory` → [`ctx.actions.declare_directory`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#declare_directory)
+  * [`ctx.file_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#file_action) → [`ctx.actions.write`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#write)
+  * [`ctx.action(command = "...")`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#action) → [`ctx.actions.run_shell`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run_shell)
+  * [`ctx.action(executable = "...")`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#action) → [`ctx.actions.run`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run)
+  * [`ctx.empty_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#empty_action) → [`ctx.actions.do_nothing`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#do_nothing)
+  * [`ctx.template_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#template_action) → [`ctx.actions.expand_template`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#expand_template)
 
 --------------------------------------------------------------------------------
 

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -116,8 +116,7 @@ the line or at the beginning of a rule.
 
 ### Background
 
-[load]
-(https://docs.bazel.build/versions/master/skylark/concepts.html#loading-an-extension)
+[load](https://docs.bazel.build/versions/master/skylark/concepts.html#loading-an-extension)
 is used to import definitions in a BUILD file. If the definition is not used in
 the file, the load can be safely removed. If a symbol is loaded two times, you
 will get a warning on the second occurrence.


### PR DESCRIPTION
For each linter category:

  * specify its name explicitly (it can be used in the command line with the `--warnings` flag
  * provide a link to the corresponding incompatible flag in Bazel if available
  * specify whether it has an automatic fix