### PR TITLE
[buildifier] Preserve symbol semantics when removing unused loads.

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -120,7 +120,10 @@ func unusedLoadWarning(f *build.File, fix bool) []*Finding {
 	loaded := make(map[string]bool)
 
 	symbols := edit.UsedSymbols(f)
-	for stmtIndex := 0; stmtIndex < len(f.Stmt); stmtIndex++ {
+	// statements are considered in reserve order to make sure that the last
+	// load wins, just like what happens during evaluation, which is very
+	// important if same symbol is loaded from different files.
+	for stmtIndex := len(f.Stmt) - 1; stmtIndex >= 0; stmtIndex-- {
 		load, ok := f.Stmt[stmtIndex].(*build.LoadStmt)
 		if !ok {
 			continue
@@ -163,7 +166,6 @@ func unusedLoadWarning(f *build.File, fix bool) []*Finding {
 		// If there are no loaded symbols left remove the entire load statement
 		if fix && len(load.To) == 0 {
 			f.Stmt = append(f.Stmt[:stmtIndex], f.Stmt[stmtIndex+1:]...)
-			stmtIndex--
 		}
 	}
 	return findings

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -206,12 +206,29 @@ php_library(name = "x")`,
 func TestWarnUnusedLoad(t *testing.T) {
 	checkFindingsAndFix(t, "load", `
 load(":f.bzl", "s1", "s2")
-load("f", "s1")
+load(":bar.bzl", "s1")
 foo(name = s1)`, `
-load(":f.bzl", "s1")
+load(":bar.bzl", "s1")
 foo(name = s1)`,
-		[]string{":1: Loaded symbol \"s2\" is unused.",
-			":2: Symbol \"s1\" has already been loaded."},
+		[]string{
+			":1: Symbol \"s1\" has already been loaded.",
+			":1: Loaded symbol \"s2\" is unused."},
+		scopeEverywhere)
+
+	checkFindingsAndFix(t, "load", `
+load("foo", "a", "b", "c")
+load("bar", "a", "d", "e")
+
+z = a + b + d`, `
+load("foo", "b")
+load("bar", "a", "d")
+
+z = a + b + d`,
+		[]string{
+			":2: Loaded symbol \"e\" is unused.",
+			":1: Symbol \"a\" has already been loaded.",
+			":1: Loaded symbol \"c\" is unused.",
+		},
 		scopeEverywhere)
 
 	checkFindingsAndFix(t, "load", `


### PR DESCRIPTION
When the same symbol is loaded multiple times, during evalution the
last symbol wins and all previous loads are ignored, but `buildifier`
would preserve the first instance and remove all other usages
which breaks semantics unless all loads are from the same file.

In other words

```
load(":defs1.bzl", "s1")
load(":defs2.bzl", "s1")
```

is equivalent to

```
load(":defs2.bzl", "s1")
```

but `buildifier` would produce

```
load(":defs1.bzl", "s1")
```

To address this, all statements are analyzed in a reverse order, so the very
last (in terms of line numbers) is preserved and all preceding loads are
removed. This also slightly simplifies `load` removal logic, since we no longer
need to adjust index.