### PR TITLE
Only print lint fixes with verbose mode

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -311,7 +311,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 	case "warn":
 		warn.PrintWarnings(f, pkg, warningsList, false)
 	case "fix":
-		warn.FixWarnings(f, pkg, warningsList)
+		warn.FixWarnings(f, pkg, warningsList, *vflag)
 	}
 
 	if *filePath != "" {

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -51,11 +51,12 @@ EOF
 
 cat > test/fix_report_golden <<EOF
 test/to_fix.bzl: applied fixes, 0 warnings left
+fixed test/to_fix.bzl
 EOF
 
 $1 --lint=warn test/to_fix.bzl 2> test/error
 diff test/error test/error_golden
 
-$1 --lint=fix test/to_fix.bzl 2> test/fix_report
+$1 --lint=fix -v test/to_fix.bzl 2> test/fix_report
 diff test/to_fix.bzl test/fixed_golden.bzl
 diff test/fix_report test/fix_report_golden

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -992,11 +992,13 @@ func PrintWarnings(f *build.File, pkg string, enabledWarnings []string, showRepl
 }
 
 // FixWarnings fixes all warnings that can be fixed automatically.
-func FixWarnings(f *build.File, pkg string, enabledWarnings []string) {
+func FixWarnings(f *build.File, pkg string, enabledWarnings []string, verbose bool) {
 	warnings := FileWarnings(f, pkg, enabledWarnings, true)
-	fmt.Fprintf(os.Stderr, "%s: applied fixes, %d warnings left\n",
-		f.Path,
-		len(warnings))
+	if verbose {
+		fmt.Fprintf(os.Stderr, "%s: applied fixes, %d warnings left\n",
+			f.Path,
+			len(warnings))
+	}
 }
 
 func collectAllWarnings() []string {

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -81,7 +81,7 @@ func checkFix(t *testing.T, category, input, expected string, scope, fileType bu
 		panic(fmt.Sprintf("%v", err))
 	}
 
-	FixWarnings(buildFile, "the_package", []string{category})
+	FixWarnings(buildFile, "the_package", []string{category}, false)
 	have := build.Format(buildFile)
 	want := build.Format(goldenFile)
 	if !bytes.Equal(have, want) {


### PR DESCRIPTION
Previously every file that was processed by the buildifier -lint=fix
command would produce output, even if there weren't any fixes. To make
this more like the buildifier fix formatting mode, this wraps that print
in the `-v` flag.