### PR TITLE
Support WORKSPACE files

### DIFF
--- a/build/lex_test.go
+++ b/build/lex_test.go
@@ -21,26 +21,27 @@ import (
 )
 
 func TestIsBuildFilename(t *testing.T) {
-	cases := map[string]bool{
-		"BUILD":           true,
-		"build":           true,
-		"bUIld":           true,
-		"BUILD.bazel":     true,
-		"build.bzl":       false,
-		"build.sky":       false,
-		"WORKSPACE":       true,
-		"external.BUILD":  true,
-		"BUILD.external":  true,
-		"aBUILD":          false,
-		"thing.sky":       false,
-		"my.WORKSPACE":    true,
-		"thing.bzl":       false,
-		"workspace.bazel": true,
+	cases := map[string]FileType{
+		"BUILD":           TypeBuild,
+		"build":           TypeBuild,
+		"bUIld":           TypeBuild,
+		"BUILD.bazel":     TypeBuild,
+		"build.bzl":       TypeDefault,
+		"build.sky":       TypeDefault,
+		"WORKSPACE":       TypeWorkspace,
+		"external.BUILD":  TypeBuild,
+		"BUILD.external":  TypeBuild,
+		"aBUILD":          TypeDefault,
+		"thing.sky":       TypeDefault,
+		"my.WORKSPACE":    TypeWorkspace,
+		"thing.bzl":       TypeDefault,
+		"workspace.bazel": TypeWorkspace,
+		"workspace.bzl":   TypeDefault,
 	}
-	for name, isBuild := range cases {
-		res := isBuildFilename(name)
-		if res != isBuild {
-			t.Errorf("isBuildFilename(%q) should be %v but was %v", name, isBuild, res)
+	for name, fileType := range cases {
+		res := getFileType(name)
+		if res != fileType {
+			t.Errorf("isBuildFilename(%q) should be %v but was %v", name, fileType, res)
 		}
 	}
 }

--- a/build/lex_test.go
+++ b/build/lex_test.go
@@ -37,6 +37,7 @@ func TestIsBuildFilename(t *testing.T) {
 		"thing.bzl":       TypeDefault,
 		"workspace.bazel": TypeWorkspace,
 		"workspace.bzl":   TypeDefault,
+		"foo.bar":         TypeDefault,
 	}
 	for name, fileType := range cases {
 		res := getFileType(name)

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -96,8 +96,8 @@ var parseTests = []struct {
 )
 `,
 		out: &File{
-			Path:  "BUILD",
-			Build: true,
+			Path: "BUILD",
+			Type: TypeBuild,
 			Stmt: []Expr{
 				&CallExpr{
 					X: &Ident{
@@ -130,8 +130,8 @@ var parseTests = []struct {
 	{
 		in: `foo.bar.baz(name = "x")`,
 		out: &File{
-			Path:  "test",
-			Build: false,
+			Path: "test",
+			Type: TypeDefault,
 			Stmt: []Expr{
 				&CallExpr{
 					X: &DotExpr{
@@ -192,8 +192,8 @@ var parseTests = []struct {
 		in: `load(":foo.bzl", "foo", """bar""", baz="foo", foo="""baz""")
 `,
 		out: &File{
-			Path:  "BUILD",
-			Build: true,
+			Path: "BUILD",
+			Type: TypeBuild,
 			Stmt: []Expr{
 				&LoadStmt{
 					Load: Position{1, 1, 0},

--- a/build/print.go
+++ b/build/print.go
@@ -31,19 +31,19 @@ const (
 
 // Format returns the formatted form of the given BUILD or bzl file.
 func Format(f *File) []byte {
-	pr := &printer{buildMode: f.Build}
+	pr := &printer{fileType: f.Type}
 	pr.file(f)
 	return pr.Bytes()
 }
 
 // FormatString returns the string form of the given expression.
 func FormatString(x Expr) string {
-	buildMode := true // for compatibility
+	buildMode := TypeBuild // for compatibility
 	if file, ok := x.(*File); ok {
-		buildMode = file.Build
+		buildMode = file.Type
 	}
 
-	pr := &printer{buildMode: buildMode}
+	pr := &printer{fileType: buildMode}
 	switch x := x.(type) {
 	case *File:
 		pr.file(x)
@@ -55,7 +55,7 @@ func FormatString(x Expr) string {
 
 // A printer collects the state during printing of a file or expression.
 type printer struct {
-	buildMode    bool      // whether should be printed in a build mode.
+	fileType     FileType  // different rules can be applied to different file types.
 	bytes.Buffer           // output buffer
 	comment      []Comment // pending end-of-line comments
 	margin       int       // left margin (indent), a number of spaces
@@ -226,8 +226,8 @@ func (p *printer) compactStmt(s1, s2 Expr) bool {
 	} else if isCommentBlock(s1) || isCommentBlock(s2) {
 		// Standalone comment blocks shouldn't be attached to other statements
 		return false
-	} else if p.buildMode && p.level == 0 {
-		// Top-level statements in a BUILD file
+	} else if p.fileType != TypeDefault && p.level == 0 {
+		// Top-level statements in a BUILD or WORKSPACE file
 		return false
 	} else if isFunctionDefinition(s1) || isFunctionDefinition(s2) {
 		// On of the statements is a function definition
@@ -697,7 +697,7 @@ func (p *printer) useCompactMode(start *Position, list *[]Expr, end *End, mode s
 	// In the Default printing mode try to keep the original printing style.
 	// Non-top-level statements and lists of arguments of a function definition
 	// should also keep the original style regardless of the mode.
-	if p.level != 0 || !p.buildMode || mode == modeDef {
+	if p.level != 0 || p.fileType == TypeDefault || mode == modeDef {
 		// If every element (including the brackets) ends on the same line where the next element starts,
 		// use the compact mode, otherwise use multiline mode.
 		// If an node's line number is 0, it means it doesn't appear in the original file,

--- a/build/print.go
+++ b/build/print.go
@@ -38,12 +38,12 @@ func Format(f *File) []byte {
 
 // FormatString returns the string form of the given expression.
 func FormatString(x Expr) string {
-	buildMode := TypeBuild // for compatibility
+	fileType := TypeBuild // for compatibility
 	if file, ok := x.(*File); ok {
-		buildMode = file.Type
+		fileType = file.Type
 	}
 
-	pr := &printer{fileType: buildMode}
+	pr := &printer{fileType: fileType}
 	switch x := x.(type) {
 	case *File:
 		pr.file(x)

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -81,8 +81,8 @@ func (c *Comments) Comment() *Comments {
 
 // A File represents an entire BUILD file.
 type File struct {
-	Path  string // file path, relative to workspace directory
-	Build bool
+	Path string // file path, relative to workspace directory
+	Type FileType
 	Comments
 	Stmt []Expr
 }

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -51,7 +51,7 @@ var (
 	tablesPath    = flag.String("tables", "", "path to JSON file with custom table definitions which will replace the built-in tables")
 	addTablesPath = flag.String("add_tables", "", "path to JSON file with custom table definitions which will be merged with the built-in tables")
 	version       = flag.Bool("version", false, "Print the version of buildifier")
-	inputType     = flag.String("type", "auto", "Input file type: build (for BUILD files), bzl (for .bzl files) or auto (default, based on the filename)")
+	inputType     = flag.String("type", "auto", "Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), or auto (default, based on the filename)")
 
 	// Debug flags passed through to rewrite.go
 	allowSort = stringList("allowsort", "additional sort contexts to treat as safe")
@@ -110,11 +110,11 @@ func main() {
 
 	// Check input type.
 	switch *inputType {
-	case "build", "bzl", "auto":
+	case "build", "bzl", "workspace", "auto":
 		// ok
 
 	default:
-		fmt.Fprintf(os.Stderr, "buildifier: unrecognized input type %s; valid types are build, bzl, auto\n", *inputType)
+		fmt.Fprintf(os.Stderr, "buildifier: unrecognized input type %s; valid types are build, bzl, workspace, auto\n", *inputType)
 		os.Exit(2)
 	}
 
@@ -419,6 +419,8 @@ func getParser(inputType string) func(filename string, data []byte) (*build.File
 		return build.ParseBuild
 	case "auto":
 		return build.Parse
+	case "workspace":
+		return build.ParseWorkspace
 	default:
 		return build.ParseDefault
 	}

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -20,6 +20,7 @@ func ConvFile(f *syntax.File) *build.File {
 	}
 
 	return &build.File{
+		Type:     build.TypeDefault,
 		Stmt:     stmts,
 		Comments: convComments(f.Comments()),
 	}

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -230,7 +230,7 @@ func RemoveEmptyPackage(f *build.File) *build.File {
 		}
 		all = append(all, stmt)
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Type: build.TypeBuild}
 }
 
 // InsertAfter inserts an expression after index i.
@@ -339,7 +339,7 @@ func DeleteRule(f *build.File, rule *build.Rule) *build.File {
 		}
 		all = append(all, stmt)
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Type: build.TypeBuild}
 }
 
 // DeleteRuleByName returns the AST without the rules that have the
@@ -357,7 +357,7 @@ func DeleteRuleByName(f *build.File, name string) *build.File {
 			all = append(all, stmt)
 		}
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Type: build.TypeBuild}
 }
 
 // DeleteRuleByKind removes the rules of the specified kind from the AST.
@@ -375,7 +375,7 @@ func DeleteRuleByKind(f *build.File, kind string) *build.File {
 			all = append(all, stmt)
 		}
 	}
-	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Build: true}
+	return &build.File{Path: f.Path, Comments: f.Comments, Stmt: all, Type: build.TypeBuild}
 }
 
 // AllLists returns all the lists concatenated in an expression.

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -235,8 +235,8 @@ func unusedVariableWarning(f *build.File, fix bool) []*Finding {
 
 func duplicatedNameWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
-	if !f.Build {
-		// Not applicable to non-BUILD files.
+	if f.Type == build.TypeDefault {
+		// Not applicable to .bzl files.
 		return findings
 	}
 	names := make(map[string]int) // map from name to line number
@@ -293,7 +293,7 @@ func packageOnTopWarning(f *build.File, fix bool) []*Finding {
 func loadOnTopWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 
-	if f.Build {
+	if f.Type != build.TypeDefault {
 		// Not applicable for BUILD or WORKSPACE files
 		return findings
 	}
@@ -452,8 +452,8 @@ func noEffectStatementsCheck(f *build.File, body []build.Expr, isTopLevel, isFun
 // unusedVariableCheck checks for unused variables inside a given node `stmt` (either *build.File or
 // *build.DefStmt) and reports unused and already defined variables.
 func unusedVariableCheck(f *build.File, stmts []build.Expr, findings []*Finding) []*Finding {
-	if !f.Build {
-		// Not applicable to non-BUILD files, unused symbols may be loaded and used in other files.
+	if f.Type == build.TypeDefault {
+		// Not applicable to .bzl files, unused symbols may be loaded and used in other files.
 		return findings
 	}
 	usedSymbols := make(map[string]bool)
@@ -769,7 +769,7 @@ func argumentsOrderWarning(f *build.File, fix bool) []*Finding {
 func nativeInBuildFilesWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 
-	if !f.Build {
+	if f.Type != build.TypeBuild {
 		return findings
 	}
 
@@ -804,7 +804,7 @@ func nativeInBuildFilesWarning(f *build.File, fix bool) []*Finding {
 func nativePackageWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 
-	if f.Build {
+	if f.Type != build.TypeDefault {
 		return findings
 	}
 
@@ -941,7 +941,7 @@ func FileWarnings(f *build.File, pkg string, enabledWarnings []string, fix bool)
 			if fn == nil {
 				log.Fatalf("unexpected warning %q", warn)
 			}
-			if !f.Build {
+			if f.Type == build.TypeDefault {
 				continue
 			}
 			for _, stmt := range f.Stmt {


### PR DESCRIPTION
Currently, a boolean flag is used to distinguish between .bzl and BUILD files, and WORKSPACE have been treated like BUILD files. However there are differences, certain refactoring tools (such as moving all load statements on the top) shouldn't be apllied to WORKSPACE files, but can be applied to BUILD files.

This PR creates a new type FileType to represent multiple file types (currently there are three types available).

Also the `--type` flag now accepts a new value (`workspace`).