### PR TITLE
Fix scopes for warnings

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -20,10 +20,10 @@
   * [integer-division](#integer-division)
   * [load](#load)
   * [load-on-top](#load-on-top)
-  * [load-out-of-order](#load-out-of-order)
   * [native-build](#native-build)
   * [native-package](#native-package)
   * [no-effect](#no-effect)
+  * [out-of-order-load](#out-of-order-load)
   * [output-group](#output-group)
   * [package-name](#package-name)
   * [package-on-top](#package-on-top)
@@ -375,21 +375,6 @@ they can follow only comments and docstrings.
 
 --------------------------------------------------------------------------------
 
-## <a name="load-out-of-order"></a>Load statements should be ordered by their labels.
-
-  * Category_name: `load-out-of-order`
-  * Automatic fix: yes
-
-Load statements should be ordered by their first argument - extension file label.
-This makes it easier to developers to locate loads of interest and reduces chances
-for conflicts when performing large-scale automated refactoring.
-
-When applying automated fixes, it's highly recommended to also use
-[`load-on-top`](#load-on-top) fixes, since otherwise the relative order
-of a symbol load and its usage can change resulting in runtime error.
-
---------------------------------------------------------------------------------
-
 ## <a name="native-build"></a>The `native` module shouldn't be used in BUILD files
 
   * Category_name: `native-build`
@@ -417,6 +402,21 @@ modify the semantics of a BUILD file and makes it hard to maintain.
 
 The statement has no effect. Consider removing it or storing its result in a
 variable.
+
+--------------------------------------------------------------------------------
+
+## <a name="out-of-order-load"></a>Load statements should be ordered by their labels.
+
+  * Category_name: `out-of-order-load`
+  * Automatic fix: yes
+
+Load statements should be ordered by their first argument - extension file label.
+This makes it easier to developers to locate loads of interest and reduces chances
+for conflicts when performing large-scale automated refactoring.
+
+When applying automated fixes, it's highly recommended to also use
+[`load-on-top`](#load-on-top) fixes, since otherwise the relative order
+of a symbol load and its usage can change resulting in runtime error.
 
 --------------------------------------------------------------------------------
 

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -140,7 +140,7 @@ func unusedLoadWarning(f *build.File, fix bool) []*Finding {
 				} else {
 					start, end := to.Span()
 					findings = append(findings,
-						makeFinding(f, start, end, "usused-load",
+						makeFinding(f, start, end, "load",
 							"Symbol \""+to.Name+"\" has already been loaded. Please remove it.", true, nil))
 				}
 				continue
@@ -293,8 +293,8 @@ func packageOnTopWarning(f *build.File, fix bool) []*Finding {
 func loadOnTopWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 
-	if f.Type != build.TypeDefault {
-		// Not applicable for BUILD or WORKSPACE files
+	if f.Type == build.TypeWorkspace {
+		// Not applicable for WORKSPACE files
 		return findings
 	}
 
@@ -335,6 +335,12 @@ func loadOnTopWarning(f *build.File, fix bool) []*Finding {
 
 func outOfOrderLoadWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
+
+	if f.Type == build.TypeWorkspace {
+		// Not applicable for WORKSPACE files
+		return findings
+	}
+
 	sortedLoads := []*build.LoadStmt{}
 	for i := 0; i < len(f.Stmt); i++ {
 		load, ok := f.Stmt[i].(*build.LoadStmt)


### PR DESCRIPTION
With the support of WORKSPACE files it's now possible to include or exclude them from the scope of various lint warnings.

This CL excludes WORKSPACE from the `out-of-order-load` and `load-on-top` warnings, as load statements may appear anywhere in any order in WORKSPACE files.

Fixes #449