### PR TITLE
Align version of bazel and rules_go in buildifier/ as well

### DIFF
--- a/buildifier/README.md
+++ b/buildifier/README.md
@@ -61,8 +61,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "c1f52b8789218bb1542ed362c4f7de7052abcf254d865d96fb7ba6d44bc15ee3",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.0/rules_go-0.12.0.tar.gz",
+    sha256 = "f87fa87475ea107b3c69196f39c82b7bbf58fe27c62a338684c20ca17d1d8613",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.2/rules_go-0.16.2.tar.gz",
 )
 
 http_archive(

--- a/buildifier/deps.bzl
+++ b/buildifier/deps.bzl
@@ -4,18 +4,18 @@ def buildifier_dependencies():
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        strip_prefix = "bazel-skylib-0.4.0",
-        sha256 = "57e8737fbfa2eaee76b86dd8c1184251720c840cd9abe5c3f1566d331cdf7d65",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.4.0.tar.gz"],
+        sha256 = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f",
+        strip_prefix = "bazel-skylib-0.5.0",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz"],
     )
     _maybe(
         http_archive,
         name = "io_bazel",
-        sha256 = "66135f877d0cc075b683474c50b1f7c3e2749bf0a40e446f20392f44494fefff",
-        strip_prefix = "bazel-0.12.0",
+        sha256 = "dd07fb88a3f4c9bb68416eb277bfbea20c982a9f4bd6525368d4e4beea55cb57",
+        strip_prefix = "bazel-0.19.2",
         urls = [
-            "http://mirror.bazel.build/github.com/bazelbuild/bazel/archive/0.12.0.tar.gz",
-            "https://github.com/bazelbuild/bazel/archive/0.12.0.tar.gz",
+            "http://mirror.bazel.build/github.com/bazelbuild/bazel/archive/0.19.2.tar.gz",
+            "https://github.com/bazelbuild/bazel/archive/0.19.2.tar.gz",
         ],
     )
 


### PR DESCRIPTION
5816db19ef74 updated WORKSPACE, but did not update buildifier's deps.bzl
and README.md files.