### PR TITLE
[buildifier] Do not warn about positional args used for register_toolchains.

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -33,11 +33,12 @@ type Replacement struct {
 }
 
 var functionsWithPositionalArguments = map[string]bool{
-	"distribs":      true,
-	"exports_files": true,
-	"licenses":      true,
-	"print":         true,
-	"vardef":        true,
+	"distribs":            true,
+	"exports_files":       true,
+	"licenses":            true,
+	"print":               true,
+	"register_toolchains": true,
+	"vardef":              true,
 }
 
 func docURL(cat string) string {

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -516,6 +516,14 @@ my_macro(foo = "bar")
 my_macro("foo", "bar")`,
 		[]string{":2: All calls to rules or macros should pass arguments by keyword (arg_name=value) syntax."},
 		scopeBuild|scopeWorkspace)
+
+	checkFindings(t, "positional-args", `
+register_toolchains(
+	"//foo",
+	"//bar",
+)`,
+		[]string{},
+		scopeBuild|scopeWorkspace)
 }
 
 func TestIntegerDivision(t *testing.T) {


### PR DESCRIPTION
`register_toolchains` accepts a sequence of strings instead of
keyword arguments.

Fixes #454