### PR TITLE
[buildifier] Fix load order comparison warning.

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -381,7 +381,7 @@ func outOfOrderLoadWarning(f *build.File, fix bool) []*Finding {
 	}
 
 	for i := 1; i < len(sortedLoads); i++ {
-		if !compareLoadLabels(sortedLoads[i-1].Module.Value, sortedLoads[i].Module.Value) {
+		if compareLoadLabels(sortedLoads[i].Module.Value, sortedLoads[i-1].Module.Value) {
 			start, end := sortedLoads[i].Span()
 			findings = append(findings, makeFinding(f, start, end, "out-of-order-load",
 				"Load statement is out of its lexicographical order.", true, nil))

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -508,6 +508,14 @@ load(":b.bzl", "b")
 			":3: Load statement is out of its lexicographical order.",
 			":6: Load statement is out of its lexicographical order.",
 		}, scopeBuild|scopeBzl)
+
+	checkFindingsAndFix(t, "out-of-order-load", `
+load(":a.bzl", "a")
+load(":a.bzl", "a")
+`, `
+load(":a.bzl", "a")
+load(":a.bzl", "a")`,
+		[]string{}, scopeBuild|scopeBzl)
 }
 
 func TestPositionalArguments(t *testing.T) {


### PR DESCRIPTION
Currently the warning would be printed in case two identical labels
are compared, which cannot be fixed, since reordering the same load
would not change the comparison result.

This change makes the warning flag only instances where `i`th label
is "less than" the `i-1`th label.