### PR TITLE
[buildifier] Take name priority into account when ordering dictionary items.

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -430,6 +430,9 @@ Dictionary items should be sorted lexicagraphically by their keys. This makes
 it easier to find the item of interest and reduces chances of conflicts when
 performing large-scale automated refactoring.
 
+The order is affected by `NamePriority` dictionary passed using `-tables` or
+`-add_tables` flags.
+
 If you want to preserve the original dictionary items order, you can disable
 the warning by adding a comment `# @unsorted-dict-items` to the dictionary
 expression or any of its enclosing expressins (binary, if etc). For example,

--- a/warn/BUILD.bazel
+++ b/warn/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//build:go_default_library",
         "//bzlenv:go_default_library",
         "//edit:go_default_library",
+        "//tables:go_default_library",
     ],
 )
 

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/buildtools/edit"
+	"github.com/bazelbuild/buildtools/tables"
 )
 
 // A Finding is a warning reported by the analyzer. It may contain an optional suggested fix.
@@ -417,9 +418,14 @@ func unsortedDictItemsWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 
 	compareItems := func(item1, item2 *build.KeyValueExpr) bool {
-		key1 := item1.Key.(*build.StringExpr)
-		key2 := item2.Key.(*build.StringExpr)
-		return key1.Value < key2.Value
+		key1 := item1.Key.(*build.StringExpr).Value
+		key2 := item2.Key.(*build.StringExpr).Value
+		key1Priority := tables.NamePriority[key1]
+		key2Priority := tables.NamePriority[key2]
+		if key1Priority != key2Priority {
+			return key1Priority < key2Priority
+		}
+		return key1 < key2
 	}
 
 	build.Walk(f, func(expr build.Expr, stack []build.Expr) {

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -601,6 +601,18 @@ d = {
 		[]string{"4: Dictionary items are out of their lexicographical order."},
 		scopeEverywhere)
 
+	checkFindingsAndFix(t, "unsorted-dict-items", `
+d = {
+	"deps": [],
+	"srcs": ["foo.go"],
+}`, `
+d = {
+	"srcs": ["foo.go"],
+	"deps": [],
+}`,
+		[]string{"3: Dictionary items are out of their lexicographical order."},
+		scopeEverywhere)
+
 	checkFindings(t, "unsorted-dict-items", `
 # @unsorted-dict-items
 d = {


### PR DESCRIPTION
Since it's common to use dictionaries for passing `**kwargs` to rules, their
ordering should match the ordering used rule attributes in build files.

Build files rely on `NamePriority` `tables` dictionary to adjust priorities
according to common or project-specific guidelines and now the same rules
apply to ordering dictionary items.