### PR TITLE
[buildifier] Sort private symbols after public.

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -420,6 +420,13 @@ func unsortedDictItemsWarning(f *build.File, fix bool) []*Finding {
 	compareItems := func(item1, item2 *build.KeyValueExpr) bool {
 		key1 := item1.Key.(*build.StringExpr).Value
 		key2 := item2.Key.(*build.StringExpr).Value
+		// regular keys should preceed private ones (start with "_")
+		if strings.HasPrefix(key1, "_") {
+			return strings.HasPrefix(key2, "_") && key1 < key2
+		}
+		if strings.HasPrefix(key2, "_") {
+			return true
+		}
 		key1Priority := tables.NamePriority[key1]
 		key2Priority := tables.NamePriority[key2]
 		if key1Priority != key2Priority {

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -613,6 +613,32 @@ d = {
 		[]string{"3: Dictionary items are out of their lexicographical order."},
 		scopeEverywhere)
 
+	checkFindingsAndFix(t, "unsorted-dict-items", `
+foo_binary = rule(
+	implementation = _foo_binary_impl,
+	attrs = {
+		"_foocc": attr.label(
+			default = Label("//depsets:foocc"),
+		),
+		"srcs": attr.label_list(allow_files = True),
+		"deps": attr.label_list(),
+	},
+	outputs = {"out": "%{name}.out"},
+)`, `
+foo_binary = rule(
+	implementation = _foo_binary_impl,
+	attrs = {
+		"srcs": attr.label_list(allow_files = True),
+		"deps": attr.label_list(),
+		"_foocc": attr.label(
+			default = Label("//depsets:foocc"),
+		),
+	},
+	outputs = {"out": "%{name}.out"},
+)`,
+		[]string{"7: Dictionary items are out of their lexicographical order."},
+		scopeEverywhere)
+
 	checkFindings(t, "unsorted-dict-items", `
 # @unsorted-dict-items
 d = {


### PR DESCRIPTION
Symbols that start with `_` are private and should follow public
symbols to make user experience better.