### PR TITLE
[buildifier] Refactor warn.PrintWarnings function.

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -317,8 +317,10 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 	pkg := getPackageName(filename)
 	switch lint {
 	case "warn":
-		hasWarnings := warn.PrintWarnings(f, pkg, warningsList, false)
-		if hasWarnings == true {
+		warnings := warn.FileWarnings(f, pkg, warningsList, false)
+		warn.PrintWarnings(f, warnings, false)
+		hasWarnings := len(warnings) > 0
+		if hasWarnings {
 			exitCode = 4
 		}
 	case "fix":

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -1058,8 +1058,7 @@ func FileWarnings(f *build.File, pkg string, enabledWarnings []string, fix bool)
 // PrintWarnings prints the list of warnings returned from calling FileWarnings.
 // Actionable warnings list their link in parens, inactionable warnings list
 // their link in square brackets.
-func PrintWarnings(f *build.File, pkg string, enabledWarnings []string, showReplacements bool) bool {
-	warnings := FileWarnings(f, pkg, enabledWarnings, false)
+func PrintWarnings(f *build.File, warnings []*Finding, showReplacements bool) {
 	sort.Slice(warnings, func(i, j int) bool { return warnings[i].Start.Line < warnings[j].Start.Line })
 	for _, w := range warnings {
 		formatString := "%s:%d: %s: %s (%s)"
@@ -1082,8 +1081,6 @@ func PrintWarnings(f *build.File, pkg string, enabledWarnings []string, showRepl
 			fmt.Fprintf(os.Stderr, "\n")
 		}
 	}
-
-	return len(warnings) > 0
 }
 
 // FixWarnings fixes all warnings that can be fixed automatically.


### PR DESCRIPTION
PrintWarnings functions handles the logic of warning presentation and
as such should not be responsible for anything else. It was also
accepting unnecessarily many arguments, making it harder to use.

The comment was also not explaining what a returning value meant.