### PR TITLE
[buildifier] Fail when fixing with warnings

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -373,7 +373,10 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 			exitCode = 4
 		}
 	case "fix":
-		warn.FixWarnings(f, pkg, warningsList, *vflag)
+		hasWarnings := warn.FixWarnings(f, pkg, warningsList, *vflag)
+		if hasWarnings == true {
+			exitCode = 4
+		}
 	}
 
 	if *filePath != "" {

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -228,13 +228,15 @@ func PrintWarnings(f *build.File, warnings []*Finding, showReplacements bool) {
 }
 
 // FixWarnings fixes all warnings that can be fixed automatically.
-func FixWarnings(f *build.File, pkg string, enabledWarnings []string, verbose bool) {
+func FixWarnings(f *build.File, pkg string, enabledWarnings []string, verbose bool) bool {
 	warnings := FileWarnings(f, pkg, enabledWarnings, true)
 	if verbose {
 		fmt.Fprintf(os.Stderr, "%s: applied fixes, %d warnings left\n",
 			f.DisplayPath(),
 			len(warnings))
 	}
+
+	return len(warnings) > 0
 }
 
 func collectAllWarnings() []string {


### PR DESCRIPTION
Since some warnings cannot be automatically fixed, this change makes
buildifier exit with a non zero status code in that case. That way if
you're running this on CI, you know you there are still warnings that
need to be resolved.