### PR TITLE
[buildifier] Include all flags in usage info.

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -94,7 +94,10 @@ to the workspace directory. Normally buildifier deduces that path from the
 file names given, but the path can be given explicitly with the -path
 argument. This is especially useful when reformatting standard input,
 or in scripts that reformat a temporary copy of a file.
+
+Full list of flags with their defaults:
 `)
+	flag.PrintDefaults()
 	os.Exit(2)
 }
 


### PR DESCRIPTION
This extends usage information with all existing flags and their
defaults:

```
...
Buildifier's reformatting depends in part on the path to the file relative
to the workspace directory. Normally buildifier deduces that path from the
file names given, but the path can be given explicitly with the -path
argument. This is especially useful when reformatting standard input,
or in scripts that reformat a temporary copy of a file.

Full list of flags with their defaults:
  -add_tables string
    	path to JSON file with custom table definitions which will be merged with the built-in tables
  -allowsort string
    	additional sort contexts to treat as safe
  -buildifier_disable string
    	list of buildifier rewrites to disable
  -d	alias for -mode=diff
  -lint string
    	lint mode: off, warn, or fix (default off)
  -mode string
    	formatting mode: check, diff, or fix (default fix)
  -path string
    	assume BUILD file has this path relative to the workspace directory
  -showlog
    	show log in check mode
  -tables string
    	path to JSON file with custom table definitions which will replace the built-in tables
  -type string
    	Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), or auto (default, based on the filename) (default "auto")
  -v	print verbose information on standard error
  -version
    	Print the version of buildifier
  -warnings string
    	comma-separated warnings used in the lint mode or "all" (default all) (default "all")
exit status 2
```