### PR TITLE
Display the filenames for --mode=diff

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -376,7 +376,9 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 			return
 		}
 		infile := filename
+		displayFilename := ""
 		if filename == "" {
+			displayFilename = "<stdin>"
 			// data was read from standard filename.
 			// Write it to a temporary file so diff can read it.
 			infile, err = writeTemp(data)
@@ -385,7 +387,10 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 				exitCode = 3
 				return
 			}
+		} else {
+			displayFilename = filename
 		}
+		fmt.Fprintf(os.Stderr, "%v:\n", displayFilename)
 		if err := diff.Show(infile, outfile); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			exitCode = 4


### PR DESCRIPTION
Previously, only the lines were output, which makes tracking down the
changes a bit hard.

I’m assuming the `--mode=diff` output is not intended to be parse-able by e.g. `patch`, but I might be wrong.