### PR TITLE
Remove skylib and io_bazel dependencies from WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,13 +17,6 @@ http_archive(
     url = "https://github.com/bazelbuild/bazel-gazelle/archive/44ce230b3399a5d4472198740358fcd825b0c3c9.tar.gz",  # 2018-12-10
 )
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "7363ae6721c1648017e23a200013510c9e71ca69f398d52886ee6af7f26af436",
-    strip_prefix = "bazel-skylib-c00ef493869e2966d47508e8625aae723a4a3054",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz",  # 2018-12-06
-)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
@@ -35,17 +28,6 @@ go_rules_dependencies()
 go_register_toolchains()
 
 buildifier_dependencies()
-
-# used for build.proto
-http_archive(
-    name = "io_bazel",
-    sha256 = "f59608e56b0b68fe9b18661ae3d10f6a61aaa5f70ed11f2db52e7bc6db516454",
-    strip_prefix = "bazel-0.20.0",
-    urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/bazel/archive/0.20.0.tar.gz",
-        "https://github.com/bazelbuild/bazel/archive/0.20.0.tar.gz",
-    ],
-)
 
 go_repository(
     name = "skylark_syntax",

--- a/buildifier/deps.bzl
+++ b/buildifier/deps.bzl
@@ -4,9 +4,9 @@ def buildifier_dependencies():
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "3b61715da37bc552cba875351e0c79ae150450d4cf3844b54b8c03cd2d0f481b",
-        strip_prefix = "bazel-skylib-d7c5518fa061ae18a20d00b14082705d3d2d885d",
-        url = "https://github.com/bazelbuild/bazel-skylib/archive/d7c5518fa061ae18a20d00b14082705d3d2d885d.tar.gz",  # 2018-11-21
+        sha256 = "7363ae6721c1648017e23a200013510c9e71ca69f398d52886ee6af7f26af436",
+        strip_prefix = "bazel-skylib-c00ef493869e2966d47508e8625aae723a4a3054",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz",  # 2018-12-06
     )
     _maybe(
         http_archive,


### PR DESCRIPTION
Seeing as these are already imported via buildifier_dependencies they are redundant.

In response to a [comment](https://github.com/bazelbuild/buildtools/pull/478#issuecomment-446767227) on an earlier PR, and I figured this would make updating versions easier. 

There is a bit of a nasty catch however, in our setup we noticed that the loading of the dependencies isn't entirely deterministic when using the _maybe rules (different target run calls may load different versions of the same dependency).
So if you intended it this way, feel free to disregard the PR.