### PR TITLE
Disable load-on-top warnings for BUILD files

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -295,8 +295,8 @@ func packageOnTopWarning(f *build.File, fix bool) []*Finding {
 func loadOnTopWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 
-	if f.Type == build.TypeWorkspace {
-		// Not applicable for WORKSPACE files
+	if f.Type != build.TypeDefault {
+		// Only applicable to .bzl files
 		return findings
 	}
 

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -415,7 +415,7 @@ load(":f.bzl", "x")
 foo()
 
 x()`,
-		[]string{":2: Load statements should be at the top of the file."}, scopeBuild|scopeBzl)
+		[]string{":2: Load statements should be at the top of the file."}, scopeBzl)
 
 	checkFindingsAndFix(t, "load-on-top", `
 """Docstring"""
@@ -451,7 +451,7 @@ bar()`,
 		[]string{
 			":9: Load statements should be at the top of the file.",
 			":15: Load statements should be at the top of the file.",
-		}, scopeBuild|scopeBzl)
+		}, scopeBzl)
 }
 
 func TestOutOfOrderLoad(t *testing.T) {


### PR DESCRIPTION
Check for load statements being not on the top is essential for .bzl files because it's going to be an error in Bazel to do so.

However despite it's also consistent to have load statements on top for BUILD files as well, that doesn't work well with existing BUILD files generators that often put load statements right before they are needed.