### PR TITLE
Don't use the name 'stdin' for standard input

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -85,11 +85,11 @@ func ParseDefault(filename string, data []byte) (*File, error) {
 	return f, err
 }
 
-func getFileType(basename string) FileType {
-	basename = strings.ToLower(basename)
-	if basename == "stdin" {
+func getFileType(filename string) FileType {
+	if filename == "" { // stdin
 		return TypeBuild // For compatibility
 	}
+	basename := strings.ToLower(filepath.Base(filename))
 	ext := filepath.Ext(basename)
 	if ext == ".bzl" || ext == ".sky" {
 		return TypeDefault
@@ -109,8 +109,7 @@ func getFileType(basename string) FileType {
 // Uses the filename to detect the formatting type (build, workspace, or default) and calls
 // ParseBuild, ParseWorkspace, or ParseDefault correspondingly.
 func Parse(filename string, data []byte) (*File, error) {
-	basename := filepath.Base(filename)
-	switch getFileType(basename) {
+	switch getFileType(filename) {
 	case TypeBuild:
 		return ParseBuild(filename, data)
 	case TypeWorkspace:
@@ -128,7 +127,11 @@ type ParseError struct {
 
 // Error returns a string representation of the parse error.
 func (e ParseError) Error() string {
-	return fmt.Sprintf("%s:%d:%d: %v", e.Filename, e.Pos.Line, e.Pos.LineRune, e.Message)
+	filename := e.Filename
+	if filename == "" {
+		filename = "<stdin>"
+	}
+	return fmt.Sprintf("%s:%d:%d: %v", filename, e.Pos.Line, e.Pos.LineRune, e.Message)
 }
 
 // An input represents a single input file being parsed.

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -87,6 +87,14 @@ type File struct {
 	Stmt []Expr
 }
 
+// DisplayPath returns the filename if it's not empty, "<stdin>" otherwise
+func (f *File) DisplayPath() string {
+	if f.Path == "" {
+		return "<stdin>"
+	}
+	return f.Path
+}
+
 func (f *File) Span() (start, end Position) {
 	if len(f.Stmt) == 0 {
 		return

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -211,7 +211,7 @@ func main() {
 		if *mode == "fix" {
 			*mode = "pipe"
 		}
-		processFile("stdin", data, *inputType, *lint, warningsList, false)
+		processFile("", data, *inputType, *lint, warningsList, false)
 	} else {
 		processFiles(args, *inputType, *lint, warningsList)
 	}

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -1066,7 +1066,7 @@ func PrintWarnings(f *build.File, warnings []*Finding, showReplacements bool) {
 			formatString = "%s:%d: %s: %s [%s]"
 		}
 		fmt.Fprintf(os.Stderr, formatString,
-			w.File.Path,
+			w.File.DisplayPath(),
 			w.Start.Line,
 			w.Category,
 			w.Message,
@@ -1088,7 +1088,7 @@ func FixWarnings(f *build.File, pkg string, enabledWarnings []string, verbose bo
 	warnings := FileWarnings(f, pkg, enabledWarnings, true)
 	if verbose {
 		fmt.Fprintf(os.Stderr, "%s: applied fixes, %d warnings left\n",
-			f.Path,
+			f.DisplayPath(),
 			len(warnings))
 	}
 }


### PR DESCRIPTION
Currently if the file is read from stdin its filename is stored as "stdin", which is used not only for printing but also for some internal logic (e.g. when `--mode=diff` is used and the file comes from stdin it should be saved to a temporary file for comparison).

It's more clear and less error-prone if such files have no filename (`""`) and the word "stdin" is used only for representation.