### PR TITLE
Provide a flexible way of enabling disabling warnings

### DIFF
--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -1,13 +1,21 @@
 set -e
 
+die () {
+  echo "$1" 1>&2
+  exit 1
+}
+
+buildifier=$1
+buildifier2=$2
+
 mkdir test
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
 echo -e "$INPUT" > test/build  # case doesn't matter
 echo -e "$INPUT" > test/test.bzl
 
-$1 < test/build > stdout
-$1 test/*
-$2 test/test.bzl > test/test.bzl.out
+"$buildifier" < test/build > stdout
+"$buildifier" test/*
+"$buildifier2" test/test.bzl > test/test.bzl.out
 
 cat > test/BUILD.golden <<EOF
 load(":foo.bzl", "foo")
@@ -39,33 +47,63 @@ diff test/test.bzl.out test/test.bzl.golden
 
 cat > test/to_fix.bzl <<EOF
 a = b / c
-EOF
-
-cat > test/error_golden <<EOF
-test/to_fix.bzl:1: integer-division: The "/" operator for integer division is deprecated in favor of "//". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)
+d = {"b": 2, "a": 1}
+foo(**kwargs, *args)
 EOF
 
 cat > test/fixed_golden.bzl <<EOF
 a = b // c
+d = {"b": 2, "a": 1}
+foo(*args, **kwargs)
+EOF
+
+cat > test/fixed_golden_all.bzl <<EOF
+a = b // c
+d = {"a": 1, "b": 2}
+foo(*args, **kwargs)
+EOF
+
+cat > test/fixed_golden_dict_order.bzl <<EOF
+a = b / c
+d = {"a": 1, "b": 2}
+foo(*args, **kwargs)
+EOF
+
+cat > test/fixed_golden_order.bzl <<EOF
+a = b / c
+d = {"b": 2, "a": 1}
+foo(*args, **kwargs)
 EOF
 
 cat > test/fix_report_golden <<EOF
-test/to_fix.bzl: applied fixes, 0 warnings left
-fixed test/to_fix.bzl
+test/to_fix_tmp.bzl: applied fixes, 0 warnings left
+fixed test/to_fix_tmp.bzl
 EOF
 
-ret=0
-$1 --lint=warn test/to_fix.bzl 2> test/error || ret=$?
-if [[ $ret -ne 4 ]]; then
-  echo "Expected buildifier to exit with 4" >&2
-  exit 1
-fi
-diff test/error test/error_golden
+error_integer="test/to_fix_tmp.bzl:1: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
+error_dict="test/to_fix_tmp.bzl:2: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
+error_order="test/to_fix_tmp.bzl:3: args-order: Function call arguments should be in the following order: positional, keyword, *args, **kwargs. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#args-order)"
 
-$1 --lint=fix -v test/to_fix.bzl 2> test/fix_report || ret=$?
-if [[ $ret -ne 4 ]]; then
-  echo "Expected buildifier to exit with 4" >&2
-  exit 1
-fi
-diff test/to_fix.bzl test/fixed_golden.bzl
-diff test/fix_report test/fix_report_golden
+test_lint () {
+  ret=0
+  cp test/to_fix.bzl test/to_fix_tmp.bzl
+  echo "$4" > test/error_golden
+
+  $buildifier --lint=warn $2 test/to_fix_tmp.bzl 2> test/error || ret=$?
+  if [[ $ret -ne 4 ]]; then
+    die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
+  fi
+  diff test/error test/error_golden || die "$1: wrong console output for --lint=warn"
+
+  $buildifier --lint=fix $2 -v test/to_fix_tmp.bzl 2> test/fix_report || ret=$?
+  if [[ $ret -ne 4 ]]; then
+    die "$1: fix: Expected buildifier to exit with 4, actual: $ret"
+  fi
+  diff test/to_fix_tmp.bzl $3 || die "$1: wrong file output for --lint=fix"
+  diff test/fix_report test/fix_report_golden || die "$1: wrong console output for --lint=fix"
+}
+
+test_lint "default" "" "test/fixed_golden.bzl" "$error_integer"$'\n'"$error_order"
+test_lint "all" "--warnings=all" "test/fixed_golden_all.bzl" "$error_integer"$'\n'"$error_dict"$'\n'"$error_order"
+test_lint "order" "--warnings=args-order" "test/fixed_golden_order.bzl" "$error_order"
+test_lint "custom" "--warnings=-integer-division,+unsorted-dict-items" "test/fixed_golden_dict_order.bzl" "$error_dict"$'\n'"$error_order"

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -13,13 +13,6 @@ import (
 	"github.com/bazelbuild/buildtools/tables"
 )
 
-// nonDefaultWarnings contains warnings that are enabled by default because they're not applicable
-// for all files and cause too much diff noise when applied.
-var nonDefaultWarnings = map[string]bool{
-	"out-of-order-load":   true, // load statements should be sorted by their labels
-	"unsorted-dict-items": true, // dict items should be sorted
-}
-
 // A Finding is a warning reported by the analyzer. It may contain an optional suggested fix.
 type Finding struct {
 	File        *build.File
@@ -976,6 +969,13 @@ var FileWarningMap = map[string]func(f *build.File, fix bool) []*Finding{
 	"string-iteration":    stringIterationWarning,
 	"unsorted-dict-items": unsortedDictItemsWarning,
 	"unused-variable":     unusedVariableWarning,
+}
+
+// nonDefaultWarnings contains warnings that are enabled by default because they're not applicable
+// for all files and cause too much diff noise when applied.
+var nonDefaultWarnings = map[string]bool{
+	"out-of-order-load":   true, // load statements should be sorted by their labels
+	"unsorted-dict-items": true, // dict items should be sorted
 }
 
 // DisabledWarning checks if the warning was disabled by a comment.

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -13,6 +13,13 @@ import (
 	"github.com/bazelbuild/buildtools/tables"
 )
 
+// nonDefaultWarnings contains warnings that are enabled by default because they're not applicable
+// for all files and cause too much diff noise when applied.
+var nonDefaultWarnings = map[string]bool{
+	"out-of-order-load":   true, // load statements should be sorted by their labels
+	"unsorted-dict-items": true, // dict items should be sorted
+}
+
 // A Finding is a warning reported by the analyzer. It may contain an optional suggested fix.
 type Finding struct {
 	File        *build.File
@@ -1108,3 +1115,16 @@ func collectAllWarnings() []string {
 
 // AllWarnings is the list of all available warnings.
 var AllWarnings = collectAllWarnings()
+
+func collectDefaultWarnings() []string {
+	warnings := []string{}
+	for _, warning := range AllWarnings {
+		if !nonDefaultWarnings[warning] {
+			warnings = append(warnings, warning)
+		}
+	}
+	return warnings
+}
+
+// DefaultWarnings is the list of all warnings that should be used inside google3
+var DefaultWarnings = collectDefaultWarnings()


### PR DESCRIPTION
  * Mark certain warnings as non-default (currently `out-of-order-load` and `unsorted-dict-items`), they won't be applied unless explicitly added (or with `--warnings=all`)
  * Allow users to provide `+` and `-` modifiers to the warnings list. E.g `--warnings=-foo,+bar` means all default warnings except "foo" but with "bar" (which is assumed to be non-default).

Fixes #493