### PR TITLE
[warn] Sort loads by package and file name separately.

### DIFF
--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -516,6 +516,30 @@ load(":a.bzl", "a")
 load(":a.bzl", "a")
 load(":a.bzl", "a")`,
 		[]string{}, scopeBuild|scopeBzl)
+
+	checkFindingsAndFix(t, "out-of-order-load", `
+load("//foo:xyz.bzl", "xyz")
+load("//foo/bar:mno.bzl", "mno")
+`, `
+load("//foo:xyz.bzl", "xyz")
+load("//foo/bar:mno.bzl", "mno")`,
+		[]string{}, scopeBuild|scopeBzl)
+
+	checkFindingsAndFix(t, "out-of-order-load", `
+load("//foo:xyz.bzl", "xyz")
+load("//foo2:mno.bzl", "mno")
+`, `
+load("//foo:xyz.bzl", "xyz")
+load("//foo2:mno.bzl", "mno")`,
+		[]string{}, scopeBuild|scopeBzl)
+
+	checkFindingsAndFix(t, "out-of-order-load", `
+load("//foo:b.bzl", "b")
+load("//foo:a.bzl", "a")
+`, `
+load("//foo:a.bzl", "a")
+load("//foo:b.bzl", "b")`,
+		[]string{":2: Load statement is out of its lexicographical order."}, scopeBuild|scopeBzl)
 }
 
 func TestUnsortedDictItems(t *testing.T) {


### PR DESCRIPTION
Previously, the sorting was performed based on the entire module string
lexicographically, which would result in somewhat suboptimal ordering of
things like
```
load("//foo2:mno.bzl", "mno")
load("//foo:xyz.bzl", "xyz")
```
and
```
load("//foo/bar:mno.bzl", "mno")
load("//foo:xyz.bzl", "xyz")
```

This change makes it so the ordering logic first tries to compare loads
by package alone and break ties using file names.

Fixes #501