### PR TITLE
Add `print_if_changed` as a mode in the buildifier rule

### DIFF
--- a/buildifier/def.bzl
+++ b/buildifier/def.bzl
@@ -48,7 +48,7 @@ _buildifier = rule(
         "mode": attr.string(
             default = "fix",
             doc = "Formatting mode",
-            values = ["check", "diff", "fix"],
+            values = ["check", "diff", "fix", "print_if_changed"],
         ),
         "lint_mode": attr.string(
             doc = "Linting mode",


### PR DESCRIPTION
This mode was added a year ago but was never added as an option to the
buildifier rule which makes it inaccessible to those that use buildifier
through the rule