### PR TITLE
Add a check for missing return values

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -30,6 +30,7 @@
   * [positional-args](#positional-args)
   * [redefined-variable](#redefined-variable)
   * [repository-name](#repository-name)
+  * [return-value](#return-value)
   * [same-origin-load](#same-origin-load)
   * [string-iteration](#string-iteration)
   * [unsorted-dict-items](#unsorted-dict-items)
@@ -569,6 +570,19 @@ the line or at the beginning of a rule.
 The global variable `REPOSITORY_NAME` is deprecated, please use
 [`native.repository_name()`](https://docs.bazel.build/versions/master/skylark/lib/native.html#repository_name)
 instead.
+
+--------------------------------------------------------------------------------
+
+## <a name="return-value"></a>Some but not all execution paths of a function return a value
+
+  * Category_name: `return-value`
+  * Automatic fix: no
+
+Some but not all execution paths of a function return a value. Either there's
+an explicit empty `return` statement, or an implcit return in the end of a
+function. If it is intentional, make it explicit using `return None`. If you
+know certain parts of the code cannot be reached, add the statement
+`fail("unreachable")` to them.
 
 --------------------------------------------------------------------------------
 

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -1107,3 +1107,131 @@ native.cc_library(name = "lib")
 		`:1: "native.package()" shouldn't be used in .bzl files.`,
 	}, scopeBzl)
 }
+
+func TestMissingReturnValueWarning(t *testing.T) {
+	// empty return
+	checkFindings(t, "return-value", `
+def foo():
+  if x:
+    return x
+  else:
+    return
+`, []string{
+		`:5: Some but not all execution paths of "foo" return a value.`,
+	}, scopeEverywhere)
+
+	// empty return; implicit return in the end
+	checkFindings(t, "return-value", `
+def bar():
+  if x:
+    pass
+  elif y:
+    return y
+  else:
+    return
+`, []string{
+		`:1: Some but not all execution paths of "bar" return a value.
+The function may terminate by an implicit return in the end.`,
+		`:7: Some but not all execution paths of "bar" return a value.`,
+	}, scopeEverywhere)
+
+	// implicit return in the end
+	checkFindings(t, "return-value", `
+def foo():
+  if x:
+    return x
+  else:
+    bar()
+`, []string{
+		`:1: Some but not all execution paths of "foo" return a value.
+The function may terminate by an implicit return in the end.`,
+	}, scopeEverywhere)
+
+	// implicit return in the end
+	checkFindings(t, "return-value", `
+def bar():
+  if x:
+    return x
+  elif y:
+    return y
+  else:
+    foo
+    if z:
+      return z
+
+  if foo:
+     return not foo
+`, []string{
+		`:1: Some but not all execution paths of "bar" return a value.
+The function may terminate by an implicit return in the end.`,
+	}, scopeEverywhere)
+
+	// only returned values and fail() statements, ok
+	checkFindings(t, "return-value", `
+def bar():
+  if x:
+    return x
+  elif y:
+    return y
+  else:
+    foo
+    if z:
+      return z
+
+  if foo:
+     return not foo
+  else:
+     fail("unreachable")
+`, []string{}, scopeEverywhere)
+
+	// implicit return in the end because fail() is not a statement
+	checkFindings(t, "return-value", `
+def bar():
+  if x:
+    return x
+  elif y:
+    return y
+  else:
+    foo
+    if z:
+      return z
+
+  if foo:
+     return not foo
+  else:
+     foo() or fail("unreachable")
+`, []string{
+		`:1: Some but not all execution paths of "bar" return a value.
+The function may terminate by an implicit return in the end.`,
+	}, scopeEverywhere)
+
+	// only empty returns, ok
+	checkFindings(t, "return-value", `
+def bar():
+  if x:
+    x()
+  elif y:
+    return
+  else:
+    foo
+    if z:
+      fail()
+
+  if foo:
+     return
+`, []string{}, scopeEverywhere)
+
+	// no returns, ok
+	checkFindings(t, "return-value", `
+def foobar():
+  pass
+`, []string{}, scopeEverywhere)
+
+	// only fails, ok
+	checkFindings(t, "return-value", `
+def foobar():
+  if foo:
+    fail()
+`, []string{}, scopeEverywhere)
+
+}


### PR DESCRIPTION
Warn if a function explicitly returns values somewhere, but not everywhere where it can terminate.