### PR TITLE
Fix Windows-specific incompatibilities

### DIFF
--- a/build/print_test.go
+++ b/build/print_test.go
@@ -42,7 +42,7 @@ func setFlags(file string) func() {
 		tables.StripLabelLeadingSlashes = true
 	}
 	// Test file 050 tests the ShortenAbsoluteLabelsToRelative behavior, all other tests assume that ShortenAbsoluteLabelsToRelative is false.
-	if strings.Contains(file, "/050.") {
+	if strings.Contains(file, string(os.PathSeparator)+"050.") {
 		tables.ShortenAbsoluteLabelsToRelative = true
 	}
 	return func() {


### PR DESCRIPTION
  * `filepath.Dir` and `os.PathSeparator` (or `filepath.Separator`) should be used instead of `path.Dir` and `'/'` while working with actual filenames.
  * When paths are converted to labels, `filepath.Separator` should be replaced with `'/'` explicitly.

This commit should fix tests that are currently failing at #522.