### PR TITLE
Warnings for variable names

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -23,6 +23,7 @@ Warning categories supported by buildifier's linter:
   * [load](#load)
   * [load-on-top](#load-on-top)
   * [module-docstring](#module-docstring)
+  * [name-conventions](#name-conventions)
   * [native-build](#native-build)
   * [native-package](#native-package)
   * [no-effect](#no-effect)
@@ -418,6 +419,16 @@ they can follow only comments and docstrings.
 
 `.bzl` files should have docstrings on top of them. A docstring is a string statement
 which should be the first statement of the file (it may follow comment lines). 
+
+--------------------------------------------------------------------------------
+
+## <a name="name-conventions"></a>Name conventions
+
+  * Category_name: `name-conventions`
+  * Automatic fix: yes
+
+By convention, all variables should be lower_snake_case, constant should be
+UPPER_SNAKE_CASE, and providers should be UpperCamelCase ending with `Info`.
 
 --------------------------------------------------------------------------------
 

--- a/build/walk.go
+++ b/build/walk.go
@@ -184,3 +184,47 @@ func WalkOnce(v Expr, f func(x *Expr)) {
 		}
 	}
 }
+
+// walkStatements is a helper function for WalkStatements
+func walkStatements(v Expr, stack *[]Expr, f func(x Expr, stk []Expr)) {
+	if v == nil {
+		return
+	}
+
+	f(v, *stack)
+	*stack = append(*stack, v)
+
+	traverse := func(x Expr) {
+		walkStatements(x, stack, f)
+	}
+
+	switch expr := v.(type) {
+	case *File:
+		for _, s := range expr.Stmt {
+			traverse(s)
+		}
+	case *DefStmt:
+		for _, s := range expr.Body {
+			traverse(s)
+		}
+	case *IfStmt:
+		for _, s := range expr.True {
+			traverse(s)
+		}
+		for _, s := range expr.False {
+			traverse(s)
+		}
+	case *ForStmt:
+		for _, s := range expr.Body {
+			traverse(s)
+		}
+	}
+
+	*stack = (*stack)[:len(*stack)-1]
+}
+
+// WalkStatements traverses sub statements (not all nodes)
+func WalkStatements(v Expr, f func(x Expr, stk []Expr)) {
+	var stack []Expr
+	walkStatements(v, &stack, f)
+}

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -89,6 +89,7 @@ var FileWarningMap = map[string]func(f *build.File, fix bool) []*Finding{
 	"load-on-top":         loadOnTopWarning,
 	"return-value":        missingReturnValueWarning,
 	"module-docstring":    moduleDocstringWarning,
+	"name-conventions":    nameConventionsWarning,
 	"native-build":        nativeInBuildFilesWarning,
 	"native-package":      nativePackageWarning,
 	"no-effect":           noEffectWarning,

--- a/warn/warn_naming_test.go
+++ b/warn/warn_naming_test.go
@@ -79,48 +79,6 @@ def f(x):
 		}, scopeEverywhere)
 }
 
-func TestProviderNames(t *testing.T) {
-	checkFindings(t, "name-conventions", `
-foo = not_provider()
-foo = provider
-foo = provider(args)
-fooInfo = provider()
-FooInfoProvider = provider()
-FooInfo = provider()
-_FooInfo = provider()
-_Foo_Info = provider()
-_ = provider()
-`,
-		[]string{
-			`:3: Provider name "foo" should be UpperCamelCase and should end with 'Info'.`,
-			`:4: Provider name "fooInfo" should be UpperCamelCase and should end with 'Info'.`,
-			`:5: Provider name "FooInfoProvider" should be UpperCamelCase and should end with 'Info'.`,
-			`:8: Provider name "_Foo_Info" should be UpperCamelCase and should end with 'Info'.`,
-			`:9: Provider name "_" should be UpperCamelCase and should end with 'Info'.`,
-		}, scopeEverywhere)
-
-	checkFindings(t, "name-conventions", `
-def f(arg = provider()):
-  foo = not_provider()
-  foo = provider
-  foo = provider()
-  fooInfo = provider()
-  FooInfoProvider = provider()
-  FooInfo = provider()
-  _FooInfo = provider()
-  _Foo_Info = provider()
-  _ = provider()
-`,
-		[]string{
-			`:4: Provider name "foo" should be UpperCamelCase and should end with 'Info'.`,
-			`:5: Provider name "fooInfo" should be UpperCamelCase and should end with 'Info'.`,
-			`:6: Provider name "FooInfoProvider" should be UpperCamelCase and should end with 'Info'.`,
-			`:9: Provider name "_Foo_Info" should be UpperCamelCase and should end with 'Info'.`,
-			`:10: Provider name "_" should be UpperCamelCase and should end with 'Info'.`,
-		}, scopeEverywhere)
-
-}
-
 func TestVariableNames(t *testing.T) {
 	checkFindings(t, "name-conventions", `
 _ = 0
@@ -128,12 +86,20 @@ foo = 1
 FOO = 2
 Foo = 3
 foo, Bar, BazInfo = 4, 5, 6
-foo, (BAR, _) = 7, (8, 9) 
+foo, (BAR, _) = 7, (8, 9)
+fOO = 10
+FooInfo = 11
+_FooInfo = 12
+_BAR = 13
+_baz = 14
+_Foo_bar, foo_Baz = 15, 16
 `,
 		[]string{
-			`:4: Variable name "Foo" should be lower_snake_case or UPPER_SNAKE_CASE (for constants).`,
-			`:5: Variable name "Bar" should be lower_snake_case or UPPER_SNAKE_CASE (for constants).`,
-			`:5: Variable name "BazInfo" should be lower_snake_case or UPPER_SNAKE_CASE (for constants).`,
+			`:4: Variable name "Foo" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:5: Variable name "Bar" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:7: Variable name "fOO" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:12: Variable name "_Foo_bar" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:12: Variable name "foo_Baz" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
 		}, scopeEverywhere)
 
 	checkFindings(t, "name-conventions", `
@@ -143,12 +109,20 @@ def f(x, _, Arg = None):
   FOO = 2
   Foo = 3
   foo, Bar, BazInfo = 4, 5, 6
-  foo, (BAR, _) = 7, (8, 9) 
+  foo, (BAR, _) = 7, (8, 9)
+  fOO = 10
+  FooInfo = 11
+  _FooInfo = 12
+  _BAR = 13
+  _baz = 14
+  _Foo_bar, foo_Baz = 15, 16
 `,
 		[]string{
-			`:5: Variable name "Foo" should be lower_snake_case or UPPER_SNAKE_CASE (for constants).`,
-			`:6: Variable name "Bar" should be lower_snake_case or UPPER_SNAKE_CASE (for constants).`,
-			`:6: Variable name "BazInfo" should be lower_snake_case or UPPER_SNAKE_CASE (for constants).`,
+			`:5: Variable name "Foo" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:6: Variable name "Bar" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:8: Variable name "fOO" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:13: Variable name "_Foo_bar" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
+			`:13: Variable name "foo_Baz" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`,
 		}, scopeEverywhere)
 
 	checkFindings(t, "name-conventions", `


### PR DESCRIPTION
All variables should be lower_snake_case, constant should be UPPER_SNAKE_CASE, and providers should be UpperCamelCase ending with `Info`.