### PR TITLE
Compress multiple 'not documented' warnings into one warning

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -2,9 +2,10 @@ package warn
 
 import (
 	"fmt"
-	"github.com/bazelbuild/buildtools/build"
 	"regexp"
 	"strings"
+
+	"github.com/bazelbuild/buildtools/build"
 )
 
 // FunctionLengthDocstringThreshold is a limit for a function size (in statements), above which
@@ -244,14 +245,26 @@ func functionDocstringWarning(f *build.File, fix bool) []*Finding {
 		if isDocstringRequired || len(info.args) > 0 {
 
 			// Check whether all arguments are documented.
+			notDocumentedArguments := []string{}
 			paramNames := make(map[string]bool)
 			for _, param := range def.Params {
 				name := getParamName(param)
 				paramNames[name] = true
 				if _, ok := info.args[name]; !ok {
-					findings = append(findings, makeFinding(f, start, end, "function-docstring",
-						fmt.Sprintf(`Argument "%s" is not documented.`, name), true, nil))
+					notDocumentedArguments = append(notDocumentedArguments, name)
 				}
+			}
+			if len(notDocumentedArguments) > 0 {
+				s := "s"
+				if len(notDocumentedArguments) == 1 {
+					s = ""
+				}
+				findings = append(findings, makeFinding(f, start, end, "function-docstring",
+					fmt.Sprintf(
+						`Argument%s "%s" is not documented.`,
+							s,
+							strings.Join(notDocumentedArguments, `", "`),
+						), true, nil))
 			}
 
 			// Check whether all documented arguments actually exist in the function signature.

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -255,19 +255,16 @@ func functionDocstringWarning(f *build.File, fix bool) []*Finding {
 				}
 			}
 			if len(notDocumentedArguments) > 0 {
-				s := "s"
-				are := "are"
 				if len(notDocumentedArguments) == 1 {
-					s = ""
-					are = "is"
-				}
-				findings = append(findings, makeFinding(f, start, end, "function-docstring",
-					fmt.Sprintf(
-						`Argument%s "%s" %s not documented.`,
-							s,
+					findings = append(findings, makeFinding(f, start, end, "function-docstring",
+						fmt.Sprintf(`Argument "%s" is not documented.`, notDocumentedArguments[0]), true, nil))
+				} else {
+					findings = append(findings, makeFinding(f, start, end, "function-docstring",
+						fmt.Sprintf(
+							`Arguments "%s" are not documented.`,
 							strings.Join(notDocumentedArguments, `", "`),
-							are,
 						), true, nil))
+				}
 			}
 
 			// Check whether all documented arguments actually exist in the function signature.

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -256,14 +256,17 @@ func functionDocstringWarning(f *build.File, fix bool) []*Finding {
 			}
 			if len(notDocumentedArguments) > 0 {
 				s := "s"
+				are := "are"
 				if len(notDocumentedArguments) == 1 {
 					s = ""
+					are = "is"
 				}
 				findings = append(findings, makeFinding(f, start, end, "function-docstring",
 					fmt.Sprintf(
-						`Argument%s "%s" is not documented.`,
+						`Argument%s "%s" %s not documented.`,
 							s,
 							strings.Join(notDocumentedArguments, `", "`),
+							are,
 						), true, nil))
 			}
 

--- a/warn/warn_docstring_test.go
+++ b/warn/warn_docstring_test.go
@@ -259,11 +259,7 @@ def f(x, y, z = None, *args, **kwargs):
    pass
 `,
 		[]string{
-			`2: Argument "x" is not documented.`,
-			`2: Argument "y" is not documented.`,
-			`2: Argument "z" is not documented.`,
-			`2: Argument "*args" is not documented.`,
-			`2: Argument "**kwargs" is not documented.`,
+			`2: Arguments "x", "y", "z", "*args", "**kwargs" is not documented.`,
 		},
 		scopeEverywhere)
 

--- a/warn/warn_docstring_test.go
+++ b/warn/warn_docstring_test.go
@@ -259,7 +259,7 @@ def f(x, y, z = None, *args, **kwargs):
    pass
 `,
 		[]string{
-			`2: Arguments "x", "y", "z", "*args", "**kwargs" is not documented.`,
+			`2: Arguments "x", "y", "z", "*args", "**kwargs" are not documented.`,
 		},
 		scopeEverywhere)
 


### PR DESCRIPTION
It's common that a function has many arguments and a docstring that doesn't document them.

In this case instead of generating multiple warnings (one for missing documentation) buildifier should generate one cumulative warning to reduce the warning noise.