### PR TITLE
Fix duplicated names warning with implicit names

### DIFF
--- a/build/rule.go
+++ b/build/rule.go
@@ -184,10 +184,15 @@ func (r *Rule) SetKind(kind string) {
 	r.Call.X = expr
 }
 
+// ExplicitName returns the rule's target name if it's explicitly provided as a string value, "" otherwise.
+func (r *Rule) ExplicitName() string {
+	return r.AttrString("name")
+}
+
 // Name returns the rule's target name.
 // If the rule has no explicit target name, Name returns the implicit name if there is one, else the empty string.
 func (r *Rule) Name() string {
-	explicitName := r.AttrString("name")
+	explicitName := r.ExplicitName()
 	if explicitName == "" && r.Kind() != "package" {
 		return r.ImplicitName
 	}

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -110,12 +110,12 @@ func duplicatedNameWarning(f *build.File, fix bool) []*Finding {
 		return findings
 	}
 	names := make(map[string]int) // map from name to line number
-	msg := "A rule with name `%s' was already found on line %d. " +
-		"Even if it's valid for Blaze, this may confuse other tools. " +
-		"Please rename it and use different names."
+	msg := `A rule with name "%s" was already found on line %d. ` +
+		`Even if it's valid for Blaze, this may confuse other tools. ` +
+		`Please rename it and use different names.`
 
 	for _, rule := range f.Rules("") {
-		name := rule.Name()
+		name := rule.ExplicitName()
 		if name == "" {
 			continue
 		}

--- a/warn/warn_bazel_test.go
+++ b/warn/warn_bazel_test.go
@@ -49,8 +49,16 @@ cc_library(name = "y")
 py_library(name = "x")
 py_library(name = "z")
 php_library(name = "x")`,
-		[]string{":3: A rule with name `x' was already found on line 1",
-			":5: A rule with name `x' was already found on line 1"},
+		[]string{
+			`:3: A rule with name "x" was already found on line 1`,
+			`:5: A rule with name "x" was already found on line 1`,
+		}, scopeBuild|scopeWorkspace)
+
+	checkFindings(t, "duplicated-name", `
+exports_files(["foo.txt"])
+[macro(name = "bar_%s" % i) for i in ii]
+`,
+		[]string{},
 		scopeBuild|scopeWorkspace)
 }
 

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -20,11 +20,11 @@ const (
 func getFilename(fileType build.FileType) string {
 	switch fileType {
 	case build.TypeBuild:
-		return "BUILD"
+		return "package/BUILD"
 	case build.TypeWorkspace:
-		return "WORKSPACE"
+		return "package/WORKSPACE"
 	default:
-		return "test_file.bzl"
+		return "package/test_file.bzl"
 	}
 }
 


### PR DESCRIPTION
Implicit names shouldn't be taken into account when checking for duplicated rule names.

Fixes #553 