### PR TITLE
Fix ctx-actions automatic fix

### DIFF
--- a/warn/warn_bazel_api.go
+++ b/warn/warn_bazel_api.go
@@ -167,7 +167,7 @@ func notLoadedFunctionUsageCheck(f *build.File, category string, globals []strin
 
 // makePositional makes the function argument positional (removes the keyword if it exists)
 func makePositional(argument build.Expr) build.Expr {
-	if binary, ok := argument.(*build.BinaryExpr); ok {
+	if binary, ok := argument.(*build.BinaryExpr); ok && binary.Op == "=" {
 		return binary.Y
 	}
 	return argument

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -89,7 +89,7 @@ func TestCtxActionsWarning(t *testing.T) {
 	checkFindingsAndFix(t, "ctx-actions", `
 def impl(ctx):
   ctx.new_file(foo)
-  ctx.new_file(foo, bar)
+  ctx.new_file(foo, "foo %s " % bar)
   ctx.new_file(foo, bar, baz)
   ctx.experimental_new_directory(foo, bar)
   ctx.file_action(foo, bar)
@@ -103,7 +103,7 @@ def impl(ctx):
 `, `
 def impl(ctx):
   ctx.actions.declare_file(foo)
-  ctx.actions.declare_file(bar, sibling = foo)
+  ctx.actions.declare_file("foo %s " % bar, sibling = foo)
   ctx.new_file(foo, bar, baz)
   ctx.actions.declare_directory(foo, bar)
   ctx.actions.write(foo, bar)

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -90,6 +90,7 @@ func TestCtxActionsWarning(t *testing.T) {
 def impl(ctx):
   ctx.new_file(foo)
   ctx.new_file(foo, "foo %s " % bar)
+  ctx.new_file(foo, name = bar)
   ctx.new_file(foo, bar, baz)
   ctx.experimental_new_directory(foo, bar)
   ctx.file_action(foo, bar)
@@ -104,6 +105,7 @@ def impl(ctx):
 def impl(ctx):
   ctx.actions.declare_file(foo)
   ctx.actions.declare_file("foo %s " % bar, sibling = foo)
+  ctx.actions.declare_file(bar, sibling = foo)
   ctx.new_file(foo, bar, baz)
   ctx.actions.declare_directory(foo, bar)
   ctx.actions.write(foo, bar)
@@ -119,14 +121,15 @@ def impl(ctx):
 			`:2: "ctx.new_file" is deprecated.`,
 			`:3: "ctx.new_file" is deprecated.`,
 			`:4: "ctx.new_file" is deprecated.`,
-			`:5: "ctx.experimental_new_directory" is deprecated.`,
-			`:6: "ctx.file_action" is deprecated.`,
+			`:5: "ctx.new_file" is deprecated.`,
+			`:6: "ctx.experimental_new_directory" is deprecated.`,
 			`:7: "ctx.file_action" is deprecated.`,
-			`:8: "ctx.action" is deprecated.`,
+			`:8: "ctx.file_action" is deprecated.`,
 			`:9: "ctx.action" is deprecated.`,
-			`:10: "ctx.empty_action" is deprecated.`,
-			`:11: "ctx.template_action" is deprecated.`,
+			`:10: "ctx.action" is deprecated.`,
+			`:11: "ctx.empty_action" is deprecated.`,
 			`:12: "ctx.template_action" is deprecated.`,
+			`:13: "ctx.template_action" is deprecated.`,
 		},
 		scopeEverywhere)
 


### PR DESCRIPTION
If a positional argument is a binary expression but not with `=` as an operator, `MakePositional` should leave it as it is.