### PR TITLE
Fix for legacy named arguments

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -407,7 +407,7 @@ or at the beginning of a rule.
   * Category_name: `keyword-parameters`
   * Automatic fix: yes
 
-Some parameters for builtin functions in Skyalrk are keyword for legacy reasons,
+Some parameters for builtin functions in Starlark are keyword for legacy reasons,
 their names are not meaningful (e.g. `x`), making them positional will improve
 the readability.
 

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -407,8 +407,8 @@ or at the beginning of a rule.
   * Category_name: `keyword-parameters`
   * Automatic fix: yes
 
-Some parameters for builtin functions in Starlark are keyword for legacy reasons,
-their names are not meaningful (e.g. `x`), making them positional will improve
+Some parameters for builtin functions in Starlark are keyword for legacy reasons;
+their names are not meaningful (e.g. `x`). Making them positional will improve
 the readability.
 
 --------------------------------------------------------------------------------

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -20,6 +20,7 @@ Warning categories supported by buildifier's linter:
   * [git-repository](#git-repository)
   * [http-archive](#http-archive)
   * [integer-division](#integer-division)
+  * [keyword-parameters](#keyword-parameters)
   * [load](#load)
   * [load-on-top](#load-on-top)
   * [module-docstring](#module-docstring)
@@ -398,6 +399,17 @@ If you want to keep the load, you can disable the warning by adding a comment
 
 You can disable this warning by adding `# buildozer: disable=load` on the line
 or at the beginning of a rule.
+
+--------------------------------------------------------------------------------
+
+## <a name="keyword-parameters"></a>Keyword parameter should be positional
+
+  * Category_name: `keyword-parameters`
+  * Automatic fix: yes
+
+Some parameters for builtin functions in Skyalrk are keyword for legacy reasons,
+their names are not meaningful (e.g. `x`), making them positional will improve
+the readability.
 
 --------------------------------------------------------------------------------
 

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -85,6 +85,7 @@ var FileWarningMap = map[string]func(f *build.File, fix bool) []*Finding{
 	"git-repository":      nativeGitRepositoryWarning,
 	"http-archive":        nativeHTTPArchiveWarning,
 	"integer-division":    integerDivisionWarning,
+	"keyword-parameters":  keywordParametersWarning,
 	"load":                unusedLoadWarning,
 	"load-on-top":         loadOnTopWarning,
 	"return-value":        missingReturnValueWarning,

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -457,3 +457,54 @@ rule()  # no parameters
 rule(foo = bar)  # no matching parameters
 `, []string{}, scopeEverywhere)
 }
+
+func TestKeywordParameters(t *testing.T) {
+	checkFindingsAndFix(t, "keyword-parameters", `
+foo(key = value)
+all(elements = [True, False])
+any(elements = [True, False])
+tuple(x = [1, 2, 3])
+list(x = [1, 2, 3])
+len(x = [1, 2, 3])
+str(x = foo)
+repr(x = foo)
+bool(x = 3)
+int(x = "3")
+dir(x = foo)
+type(x = foo)
+hasattr(x = foo, name = "bar")
+getattr(x = foo, name = "bar", default = "baz")
+select(x = {})
+`, `
+foo(key = value)
+all([True, False])
+any([True, False])
+tuple([1, 2, 3])
+list([1, 2, 3])
+len([1, 2, 3])
+str(foo)
+repr(foo)
+bool(3)
+int("3")
+dir(foo)
+type(foo)
+hasattr(foo, name = "bar")
+getattr(foo, name = "bar", default = "baz")
+select({})
+`, []string{
+		`:2: Keyword parameter "elements" for "all" should be positional.`,
+		`:3: Keyword parameter "elements" for "any" should be positional.`,
+		`:4: Keyword parameter "x" for "tuple" should be positional.`,
+		`:5: Keyword parameter "x" for "list" should be positional.`,
+		`:6: Keyword parameter "x" for "len" should be positional.`,
+		`:7: Keyword parameter "x" for "str" should be positional.`,
+		`:8: Keyword parameter "x" for "repr" should be positional.`,
+		`:9: Keyword parameter "x" for "bool" should be positional.`,
+		`:10: Keyword parameter "x" for "int" should be positional.`,
+		`:11: Keyword parameter "x" for "dir" should be positional.`,
+		`:12: Keyword parameter "x" for "type" should be positional.`,
+		`:13: Keyword parameter "x" for "hasattr" should be positional.`,
+		`:14: Keyword parameter "x" for "getattr" should be positional.`,
+		`:15: Keyword parameter "x" for "select" should be positional.`,
+	}, scopeEverywhere)
+}


### PR DESCRIPTION
Replaces legacy keyword arguments with positional arguments in some builtin functions, e.g. `bool(x = foo)` -> `bool(foo)`.

Fixes https://github.com/bazelbuild/bazel/issues/5010