### PR TITLE
Introduce an AssignmentExpr node

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -716,6 +716,9 @@ func (in *input) order(v Expr) {
 	case *BinaryExpr:
 		in.order(v.X)
 		in.order(v.Y)
+	case *AssignmentExpr:
+		in.order(v.X)
+		in.order(v.Y)
 	case *ConditionalExpr:
 		in.order(v.Then)
 		in.order(v.Test)

--- a/build/lex.go
+++ b/build/lex.go
@@ -716,9 +716,9 @@ func (in *input) order(v Expr) {
 	case *BinaryExpr:
 		in.order(v.X)
 		in.order(v.Y)
-	case *AssignmentExpr:
-		in.order(v.X)
-		in.order(v.Y)
+	case *AssignExpr:
+		in.order(v.LHS)
+		in.order(v.RHS)
 	case *ConditionalExpr:
 		in.order(v.Then)
 		in.order(v.Test)

--- a/build/parse.y
+++ b/build/parse.y
@@ -972,6 +972,16 @@ func unary(pos Position, op string, x Expr) Expr {
 func binary(x Expr, pos Position, op string, y Expr) Expr {
 	_, xend := x.Span()
 	ystart, _ := y.Span()
+
+	if op == "=" {
+		return &AssignmentExpr{
+			X:       x,
+			OpStart: pos,
+			LineBreak: xend.Line < ystart.Line,
+			Y:       y,
+		}
+	}
+
 	return &BinaryExpr{
 		X:       x,
 		OpStart: pos,

--- a/build/parse.y
+++ b/build/parse.y
@@ -975,21 +975,21 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 
 	switch op {
 	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "|=":
-		return &AssignmentExpr{
-			X:       x,
-			OpStart: pos,
-			Op:      op,
+		return &AssignExpr{
+			LHS:       x,
+			OpPos:     pos,
+			Op:        op,
 			LineBreak: xend.Line < ystart.Line,
-			Y:       y,
+			RHS:       y,
 		}
 	}
 
 	return &BinaryExpr{
-		X:       x,
-		OpStart: pos,
-		Op:      op,
+		X:         x,
+		OpStart:   pos,
+		Op:        op,
 		LineBreak: xend.Line < ystart.Line,
-		Y:       y,
+		Y:         y,
 	}
 }
 

--- a/build/parse.y
+++ b/build/parse.y
@@ -973,10 +973,12 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 	_, xend := x.Span()
 	ystart, _ := y.Span()
 
-	if op == "=" {
+	switch op {
+	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "|=":
 		return &AssignmentExpr{
 			X:       x,
 			OpStart: pos,
+			Op:      op,
 			LineBreak: xend.Line < ystart.Line,
 			Y:       y,
 		}

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -152,12 +152,12 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 
 	switch op {
 	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "|=":
-		return &AssignmentExpr{
-			X:         x,
-			OpStart:   pos,
+		return &AssignExpr{
+			LHS:       x,
+			OpPos:     pos,
 			Op:        op,
 			LineBreak: xend.Line < ystart.Line,
-			Y:         y,
+			RHS:       y,
 		}
 	}
 

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -149,6 +149,16 @@ func unary(pos Position, op string, x Expr) Expr {
 func binary(x Expr, pos Position, op string, y Expr) Expr {
 	_, xend := x.Span()
 	ystart, _ := y.Span()
+
+	if op == "=" {
+		return &AssignmentExpr{
+			X:         x,
+			OpStart:   pos,
+			LineBreak: xend.Line < ystart.Line,
+			Y:         y,
+		}
+	}
+
 	return &BinaryExpr{
 		X:         x,
 		OpStart:   pos,

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -150,10 +150,12 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 	_, xend := x.Span()
 	ystart, _ := y.Span()
 
-	if op == "=" {
+	switch op {
+	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "|=":
 		return &AssignmentExpr{
 			X:         x,
 			OpStart:   pos,
+			Op:        op,
 			LineBreak: xend.Line < ystart.Line,
 			Y:         y,
 		}

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -106,13 +106,12 @@ var parseTests = []struct {
 					},
 					ListStart: Position{1, 10, 9},
 					List: []Expr{
-						&BinaryExpr{
+						&AssignmentExpr{
 							X: &Ident{
 								NamePos: Position{1, 11, 10},
 								Name:    "name",
 							},
 							OpStart: Position{1, 16, 15},
-							Op:      "=",
 							Y: &StringExpr{
 								Start: Position{1, 18, 17},
 								Value: "x",
@@ -150,13 +149,12 @@ var parseTests = []struct {
 					},
 					ListStart: Position{1, 12, 11},
 					List: []Expr{
-						&BinaryExpr{
+						&AssignmentExpr{
 							X: &Ident{
 								NamePos: Position{1, 13, 12},
 								Name:    "name",
 							},
 							OpStart: Position{1, 18, 17},
-							Op:      "=",
 							Y: &StringExpr{
 								Start: Position{1, 20, 19},
 								Value: "x",

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -112,6 +112,7 @@ var parseTests = []struct {
 								Name:    "name",
 							},
 							OpStart: Position{1, 16, 15},
+							Op: "=",
 							Y: &StringExpr{
 								Start: Position{1, 18, 17},
 								Value: "x",
@@ -155,6 +156,7 @@ var parseTests = []struct {
 								Name:    "name",
 							},
 							OpStart: Position{1, 18, 17},
+							Op: "=",
 							Y: &StringExpr{
 								Start: Position{1, 20, 19},
 								Value: "x",

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -106,14 +106,14 @@ var parseTests = []struct {
 					},
 					ListStart: Position{1, 10, 9},
 					List: []Expr{
-						&AssignmentExpr{
-							X: &Ident{
+						&AssignExpr{
+							LHS: &Ident{
 								NamePos: Position{1, 11, 10},
 								Name:    "name",
 							},
-							OpStart: Position{1, 16, 15},
-							Op: "=",
-							Y: &StringExpr{
+							OpPos: Position{1, 16, 15},
+							Op:    "=",
+							RHS: &StringExpr{
 								Start: Position{1, 18, 17},
 								Value: "x",
 								End:   Position{1, 21, 20},
@@ -150,14 +150,14 @@ var parseTests = []struct {
 					},
 					ListStart: Position{1, 12, 11},
 					List: []Expr{
-						&AssignmentExpr{
-							X: &Ident{
+						&AssignExpr{
+							LHS: &Ident{
 								NamePos: Position{1, 13, 12},
 								Name:    "name",
 							},
-							OpStart: Position{1, 18, 17},
-							Op: "=",
-							Y: &StringExpr{
+							OpPos: Position{1, 18, 17},
+							Op:    "=",
+							RHS: &StringExpr{
 								Start: Position{1, 20, 19},
 								Value: "x",
 								End:   Position{1, 23, 22},

--- a/build/print.go
+++ b/build/print.go
@@ -503,21 +503,21 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.expr(v.Y, prec+1)
 		p.margin = m
 
-	case *AssignmentExpr:
+	case *AssignExpr:
 		addParen(precAssign)
 		m := p.margin
 		if v.LineBreak {
 			p.margin = p.indent() + listIndentation
 		}
 
-		p.expr(v.X, precAssign)
+		p.expr(v.LHS, precAssign)
 		p.printf(" %s", v.Op)
 		if v.LineBreak {
 			p.breakline()
 		} else {
 			p.printf(" ")
 		}
-		p.expr(v.Y, precAssign+1)
+		p.expr(v.RHS, precAssign+1)
 		p.margin = m
 
 	case *ParenExpr:
@@ -543,10 +543,10 @@ func (p *printer) expr(v Expr, outerPrec int) {
 				arg = from.asString()
 				arg.Comment().Before = to.Comment().Before
 			} else {
-				arg = &AssignmentExpr{
-					X:  to,
-					Op: "=",
-					Y:  from.asString(),
+				arg = &AssignExpr{
+					LHS: to,
+					Op:  "=",
+					RHS: from.asString(),
 				}
 			}
 			args = append(args, arg)

--- a/build/print.go
+++ b/build/print.go
@@ -517,7 +517,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		}
 
 		p.expr(v.X, precAssign)
-		p.printf(" =")
+		p.printf(" %s", v.Op)
 		if v.LineBreak {
 			p.breakline()
 		} else {
@@ -551,6 +551,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 			} else {
 				arg = &AssignmentExpr{
 					X:  to,
+					Op: "=",
 					Y:  from.asString(),
 				}
 			}

--- a/build/print.go
+++ b/build/print.go
@@ -307,12 +307,6 @@ const (
 
 // opPrec gives the precedence for operators found in a BinaryExpr.
 var opPrec = map[string]int{
-	"+=":     precAssign,
-	"-=":     precAssign,
-	"*=":     precAssign,
-	"/=":     precAssign,
-	"//=":    precAssign,
-	"%=":     precAssign,
 	"or":     precOr,
 	"and":    precAnd,
 	"in":     precCmp,

--- a/build/print.go
+++ b/build/print.go
@@ -307,7 +307,6 @@ const (
 
 // opPrec gives the precedence for operators found in a BinaryExpr.
 var opPrec = map[string]int{
-	"=":      precAssign,
 	"+=":     precAssign,
 	"-=":     precAssign,
 	"*=":     precAssign,
@@ -498,9 +497,6 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		m := p.margin
 		if v.LineBreak {
 			p.margin = p.indent()
-			if v.Op == "=" {
-				p.margin += listIndentation
-			}
 		}
 
 		p.expr(v.X, prec)
@@ -511,6 +507,23 @@ func (p *printer) expr(v Expr, outerPrec int) {
 			p.printf(" ")
 		}
 		p.expr(v.Y, prec+1)
+		p.margin = m
+
+	case *AssignmentExpr:
+		addParen(precAssign)
+		m := p.margin
+		if v.LineBreak {
+			p.margin = p.indent() + listIndentation
+		}
+
+		p.expr(v.X, precAssign)
+		p.printf(" =")
+		if v.LineBreak {
+			p.breakline()
+		} else {
+			p.printf(" ")
+		}
+		p.expr(v.Y, precAssign+1)
 		p.margin = m
 
 	case *ParenExpr:
@@ -536,9 +549,8 @@ func (p *printer) expr(v Expr, outerPrec int) {
 				arg = from.asString()
 				arg.Comment().Before = to.Comment().Before
 			} else {
-				arg = &BinaryExpr{
+				arg = &AssignmentExpr{
 					X:  to,
-					Op: "=",
 					Y:  from.asString(),
 				}
 			}

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -299,8 +299,8 @@ func fixLabels(f *File, info *RewriteInfo) {
 				if leaveAlone1(v.List[i]) {
 					continue
 				}
-				as, ok := v.List[i].(*BinaryExpr)
-				if !ok || as.Op != "=" {
+				as, ok := v.List[i].(*AssignmentExpr)
+				if !ok {
 					continue
 				}
 				key, ok := as.X.(*Ident)
@@ -412,7 +412,7 @@ func ruleNamePriority(rule, arg string) int {
 // If x is of the form key=value, argName returns the string key.
 // Otherwise argName returns "".
 func argName(x Expr) string {
-	if as, ok := x.(*BinaryExpr); ok && as.Op == "=" {
+	if as, ok := x.(*AssignmentExpr); ok {
 		if id, ok := as.X.(*Ident); ok {
 			return id.Name
 		}
@@ -460,8 +460,8 @@ func sortStringLists(f *File, info *RewriteInfo) {
 				if leaveAlone1(arg) {
 					continue
 				}
-				as, ok := arg.(*BinaryExpr)
-				if !ok || as.Op != "=" || leaveAlone1(as) || doNotSort(as) {
+				as, ok := arg.(*AssignmentExpr)
+				if !ok || leaveAlone1(as) || doNotSort(as) {
 					continue
 				}
 				key, ok := as.X.(*Ident)
@@ -477,13 +477,13 @@ func sortStringLists(f *File, info *RewriteInfo) {
 				}
 				sortStringList(as.Y, info, context)
 			}
-		case *BinaryExpr:
+		case *AssignmentExpr:
 			if disabled("unsafesort") {
 				return
 			}
 			// "keep sorted" comment on x = list forces sorting of list.
 			as := v
-			if as.Op == "=" && keepSorted(as) {
+			if keepSorted(as) {
 				sortStringList(as.Y, info, "?")
 			}
 		case *KeyValueExpr:
@@ -974,10 +974,8 @@ func argumentType(expr Expr) int {
 		case "*":
 			return 3
 		}
-	case *BinaryExpr:
-		if expr.Op == "=" {
-			return 2
-		}
+	case *AssignmentExpr:
+		return 2
 	}
 	return 1
 }

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -299,18 +299,18 @@ func fixLabels(f *File, info *RewriteInfo) {
 				if leaveAlone1(v.List[i]) {
 					continue
 				}
-				as, ok := v.List[i].(*AssignmentExpr)
+				as, ok := v.List[i].(*AssignExpr)
 				if !ok {
 					continue
 				}
-				key, ok := as.X.(*Ident)
+				key, ok := as.LHS.(*Ident)
 				if !ok || !tables.IsLabelArg[key.Name] || tables.LabelBlacklist[callName(v)+"."+key.Name] {
 					continue
 				}
-				if leaveAlone1(as.Y) {
+				if leaveAlone1(as.RHS) {
 					continue
 				}
-				if list, ok := as.Y.(*ListExpr); ok {
+				if list, ok := as.RHS.(*ListExpr); ok {
 					for i := range list.List {
 						if leaveAlone1(list.List[i]) {
 							continue
@@ -319,7 +319,7 @@ func fixLabels(f *File, info *RewriteInfo) {
 						shortenLabel(list.List[i])
 					}
 				}
-				if set, ok := as.Y.(*SetExpr); ok {
+				if set, ok := as.RHS.(*SetExpr); ok {
 					for i := range set.List {
 						if leaveAlone1(set.List[i]) {
 							continue
@@ -328,8 +328,8 @@ func fixLabels(f *File, info *RewriteInfo) {
 						shortenLabel(set.List[i])
 					}
 				} else {
-					joinLabel(&as.Y)
-					shortenLabel(as.Y)
+					joinLabel(&as.RHS)
+					shortenLabel(as.RHS)
 				}
 			}
 		}
@@ -412,8 +412,8 @@ func ruleNamePriority(rule, arg string) int {
 // If x is of the form key=value, argName returns the string key.
 // Otherwise argName returns "".
 func argName(x Expr) string {
-	if as, ok := x.(*AssignmentExpr); ok {
-		if id, ok := as.X.(*Ident); ok {
+	if as, ok := x.(*AssignExpr); ok {
+		if id, ok := as.LHS.(*Ident); ok {
 			return id.Name
 		}
 	}
@@ -460,11 +460,11 @@ func sortStringLists(f *File, info *RewriteInfo) {
 				if leaveAlone1(arg) {
 					continue
 				}
-				as, ok := arg.(*AssignmentExpr)
+				as, ok := arg.(*AssignExpr)
 				if !ok || leaveAlone1(as) || doNotSort(as) {
 					continue
 				}
-				key, ok := as.X.(*Ident)
+				key, ok := as.LHS.(*Ident)
 				if !ok {
 					continue
 				}
@@ -475,16 +475,16 @@ func sortStringLists(f *File, info *RewriteInfo) {
 				if disabled("unsafesort") && !tables.SortableWhitelist[context] && !allowedSort(context) {
 					continue
 				}
-				sortStringList(as.Y, info, context)
+				sortStringList(as.RHS, info, context)
 			}
-		case *AssignmentExpr:
+		case *AssignExpr:
 			if disabled("unsafesort") {
 				return
 			}
 			// "keep sorted" comment on x = list forces sorting of list.
 			as := v
 			if keepSorted(as) {
-				sortStringList(as.Y, info, "?")
+				sortStringList(as.RHS, info, "?")
 			}
 		case *KeyValueExpr:
 			if disabled("unsafesort") {
@@ -974,7 +974,7 @@ func argumentType(expr Expr) int {
 		case "*":
 			return 3
 		}
-	case *AssignmentExpr:
+	case *AssignExpr:
 		return 2
 	}
 	return 1

--- a/build/rule.go
+++ b/build/rule.go
@@ -203,8 +203,8 @@ func (r *Rule) Name() string {
 func (r *Rule) AttrKeys() []string {
 	var keys []string
 	for _, expr := range r.Call.List {
-		if binExpr, ok := expr.(*BinaryExpr); ok && binExpr.Op == "=" {
-			if keyExpr, ok := binExpr.X.(*Ident); ok {
+		if as, ok := expr.(*AssignmentExpr); ok {
+			if keyExpr, ok := as.X.(*Ident); ok {
 				keys = append(keys, keyExpr.Name)
 			}
 		}
@@ -212,13 +212,12 @@ func (r *Rule) AttrKeys() []string {
 	return keys
 }
 
-// AttrDefn returns the BinaryExpr defining the rule's attribute with the given key.
-// That is, the result is a *BinaryExpr with Op == "=".
+// AttrDefn returns the AssignmentExpr defining the rule's attribute with the given key.
 // If the rule has no such attribute, AttrDefn returns nil.
-func (r *Rule) AttrDefn(key string) *BinaryExpr {
+func (r *Rule) AttrDefn(key string) *AssignmentExpr {
 	for _, kv := range r.Call.List {
-		as, ok := kv.(*BinaryExpr)
-		if !ok || as.Op != "=" {
+		as, ok := kv.(*AssignmentExpr)
+		if !ok {
 			continue
 		}
 		k, ok := as.X.(*Ident)
@@ -246,8 +245,8 @@ func (r *Rule) Attr(key string) Expr {
 func (r *Rule) DelAttr(key string) Expr {
 	list := r.Call.List
 	for i, kv := range list {
-		as, ok := kv.(*BinaryExpr)
-		if !ok || as.Op != "=" {
+		as, ok := kv.(*AssignmentExpr)
+		if !ok {
 			continue
 		}
 		k, ok := as.X.(*Ident)
@@ -272,9 +271,8 @@ func (r *Rule) SetAttr(key string, val Expr) {
 	}
 
 	r.Call.List = append(r.Call.List,
-		&BinaryExpr{
+		&AssignmentExpr{
 			X:  &Ident{Name: key},
-			Op: "=",
 			Y:  val,
 		},
 	)

--- a/build/rule.go
+++ b/build/rule.go
@@ -273,6 +273,7 @@ func (r *Rule) SetAttr(key string, val Expr) {
 	r.Call.List = append(r.Call.List,
 		&AssignmentExpr{
 			X:  &Ident{Name: key},
+			Op: "=",
 			Y:  val,
 		},
 	)

--- a/build/rule.go
+++ b/build/rule.go
@@ -203,8 +203,8 @@ func (r *Rule) Name() string {
 func (r *Rule) AttrKeys() []string {
 	var keys []string
 	for _, expr := range r.Call.List {
-		if as, ok := expr.(*AssignmentExpr); ok {
-			if keyExpr, ok := as.X.(*Ident); ok {
+		if as, ok := expr.(*AssignExpr); ok {
+			if keyExpr, ok := as.LHS.(*Ident); ok {
 				keys = append(keys, keyExpr.Name)
 			}
 		}
@@ -212,15 +212,15 @@ func (r *Rule) AttrKeys() []string {
 	return keys
 }
 
-// AttrDefn returns the AssignmentExpr defining the rule's attribute with the given key.
+// AttrDefn returns the AssignExpr defining the rule's attribute with the given key.
 // If the rule has no such attribute, AttrDefn returns nil.
-func (r *Rule) AttrDefn(key string) *AssignmentExpr {
+func (r *Rule) AttrDefn(key string) *AssignExpr {
 	for _, kv := range r.Call.List {
-		as, ok := kv.(*AssignmentExpr)
+		as, ok := kv.(*AssignExpr)
 		if !ok {
 			continue
 		}
-		k, ok := as.X.(*Ident)
+		k, ok := as.LHS.(*Ident)
 		if !ok || k.Name != key {
 			continue
 		}
@@ -237,7 +237,7 @@ func (r *Rule) Attr(key string) Expr {
 	if as == nil {
 		return nil
 	}
-	return as.Y
+	return as.RHS
 }
 
 // DelAttr deletes the rule's attribute with the named key.
@@ -245,17 +245,17 @@ func (r *Rule) Attr(key string) Expr {
 func (r *Rule) DelAttr(key string) Expr {
 	list := r.Call.List
 	for i, kv := range list {
-		as, ok := kv.(*AssignmentExpr)
+		as, ok := kv.(*AssignExpr)
 		if !ok {
 			continue
 		}
-		k, ok := as.X.(*Ident)
+		k, ok := as.LHS.(*Ident)
 		if !ok || k.Name != key {
 			continue
 		}
 		copy(list[i:], list[i+1:])
 		r.Call.List = list[:len(list)-1]
-		return as.Y
+		return as.RHS
 	}
 	return nil
 }
@@ -266,15 +266,15 @@ func (r *Rule) DelAttr(key string) Expr {
 func (r *Rule) SetAttr(key string, val Expr) {
 	as := r.AttrDefn(key)
 	if as != nil {
-		as.Y = val
+		as.RHS = val
 		return
 	}
 
 	r.Call.List = append(r.Call.List,
-		&AssignmentExpr{
-			X:  &Ident{Name: key},
-			Op: "=",
-			Y:  val,
+		&AssignExpr{
+			LHS: &Ident{Name: key},
+			Op:  "=",
+			RHS: val,
 		},
 	)
 }

--- a/build/rule_test.go
+++ b/build/rule_test.go
@@ -22,11 +22,10 @@ var simpleCall *CallExpr = &CallExpr{
 		Name: "java_library",
 	},
 	List: []Expr{
-		&BinaryExpr{
+		&AssignmentExpr{
 			X: &Ident{
 				Name: "name",
 			},
-			Op: "=",
 			Y: &StringExpr{
 				Value: "x",
 			},
@@ -47,11 +46,10 @@ var structCall *CallExpr = &CallExpr{
 		Name: "baz",
 	},
 	List: []Expr{
-		&BinaryExpr{
+		&AssignmentExpr{
 			X: &Ident{
 				Name: "name",
 			},
-			Op: "=",
 			Y: &StringExpr{
 				Value: "x",
 			},
@@ -77,11 +75,10 @@ func TestSetKind(t *testing.T) {
 				Name: "java_library",
 			},
 			List: []Expr{
-				&BinaryExpr{
+				&AssignmentExpr{
 					X: &Ident{
 						Name: "name",
 					},
-					Op: "=",
 					Y: &StringExpr{
 						Value: "x",
 					},
@@ -144,11 +141,10 @@ func TestRulesDoubleNested(t *testing.T) {
 			Name: "java_library",
 		},
 		List: []Expr{
-			&BinaryExpr{
+			&AssignmentExpr{
 				X: &Ident{
 					Name: "name",
 				},
-				Op: "=",
 				Y: &CallExpr{
 					X:    &Ident{Name: "varref"},
 					List: []Expr{&StringExpr{Value: "x"}},

--- a/build/rule_test.go
+++ b/build/rule_test.go
@@ -26,6 +26,7 @@ var simpleCall *CallExpr = &CallExpr{
 			X: &Ident{
 				Name: "name",
 			},
+			Op: "=",
 			Y: &StringExpr{
 				Value: "x",
 			},
@@ -50,6 +51,7 @@ var structCall *CallExpr = &CallExpr{
 			X: &Ident{
 				Name: "name",
 			},
+			Op: "=",
 			Y: &StringExpr{
 				Value: "x",
 			},
@@ -79,6 +81,7 @@ func TestSetKind(t *testing.T) {
 					X: &Ident{
 						Name: "name",
 					},
+					Op: "=",
 					Y: &StringExpr{
 						Value: "x",
 					},
@@ -145,6 +148,7 @@ func TestRulesDoubleNested(t *testing.T) {
 				X: &Ident{
 					Name: "name",
 				},
+				Op: "=",
 				Y: &CallExpr{
 					X:    &Ident{Name: "varref"},
 					List: []Expr{&StringExpr{Value: "x"}},

--- a/build/rule_test.go
+++ b/build/rule_test.go
@@ -22,12 +22,12 @@ var simpleCall *CallExpr = &CallExpr{
 		Name: "java_library",
 	},
 	List: []Expr{
-		&AssignmentExpr{
-			X: &Ident{
+		&AssignExpr{
+			LHS: &Ident{
 				Name: "name",
 			},
 			Op: "=",
-			Y: &StringExpr{
+			RHS: &StringExpr{
 				Value: "x",
 			},
 		},
@@ -47,12 +47,12 @@ var structCall *CallExpr = &CallExpr{
 		Name: "baz",
 	},
 	List: []Expr{
-		&AssignmentExpr{
-			X: &Ident{
+		&AssignExpr{
+			LHS: &Ident{
 				Name: "name",
 			},
 			Op: "=",
-			Y: &StringExpr{
+			RHS: &StringExpr{
 				Value: "x",
 			},
 		},
@@ -77,12 +77,12 @@ func TestSetKind(t *testing.T) {
 				Name: "java_library",
 			},
 			List: []Expr{
-				&AssignmentExpr{
-					X: &Ident{
+				&AssignExpr{
+					LHS: &Ident{
 						Name: "name",
 					},
 					Op: "=",
-					Y: &StringExpr{
+					RHS: &StringExpr{
 						Value: "x",
 					},
 				},
@@ -144,12 +144,12 @@ func TestRulesDoubleNested(t *testing.T) {
 			Name: "java_library",
 		},
 		List: []Expr{
-			&AssignmentExpr{
-				X: &Ident{
+			&AssignExpr{
+				LHS: &Ident{
 					Name: "name",
 				},
 				Op: "=",
-				Y: &CallExpr{
+				RHS: &CallExpr{
 					X:    &Ident{Name: "varref"},
 					List: []Expr{&StringExpr{Value: "x"}},
 				},

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -366,6 +366,7 @@ type AssignmentExpr struct {
 	Comments
 	X         Expr
 	OpStart   Position
+	Op        string
 	LineBreak bool // insert line break between Op and Y
 	Y         Expr
 }

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -361,6 +361,21 @@ func (x *BinaryExpr) Span() (start, end Position) {
 	return start, end
 }
 
+// An AssignmentExpr represents a binary expression with `=`: X = Y.
+type AssignmentExpr struct {
+	Comments
+	X         Expr
+	OpStart   Position
+	LineBreak bool // insert line break between Op and Y
+	Y         Expr
+}
+
+func (x *AssignmentExpr) Span() (start, end Position) {
+	start, _ = x.X.Span()
+	_, end = x.Y.Span()
+	return start, end
+}
+
 // A ParenExpr represents a parenthesized expression: (X).
 type ParenExpr struct {
 	Comments

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -361,19 +361,19 @@ func (x *BinaryExpr) Span() (start, end Position) {
 	return start, end
 }
 
-// An AssignmentExpr represents a binary expression with `=`: X = Y.
-type AssignmentExpr struct {
+// An AssignExpr represents a binary expression with `=`: LHS = RHS.
+type AssignExpr struct {
 	Comments
-	X         Expr
-	OpStart   Position
+	LHS       Expr
+	OpPos     Position
 	Op        string
-	LineBreak bool // insert line break between Op and Y
-	Y         Expr
+	LineBreak bool // insert line break between Op and RHS
+	RHS       Expr
 }
 
-func (x *AssignmentExpr) Span() (start, end Position) {
-	start, _ = x.X.Span()
-	_, end = x.Y.Span()
+func (x *AssignExpr) Span() (start, end Position) {
+	start, _ = x.LHS.Span()
+	_, end = x.RHS.Span()
 	return start, end
 }
 

--- a/build/walk.go
+++ b/build/walk.go
@@ -103,9 +103,9 @@ func WalkOnce(v Expr, f func(x *Expr)) {
 	case *BinaryExpr:
 		f(&v.X)
 		f(&v.Y)
-	case *AssignmentExpr:
-		f(&v.X)
-		f(&v.Y)
+	case *AssignExpr:
+		f(&v.LHS)
+		f(&v.RHS)
 	case *LambdaExpr:
 		for i := range v.Params {
 			f(&v.Params[i])

--- a/build/walk.go
+++ b/build/walk.go
@@ -103,6 +103,9 @@ func WalkOnce(v Expr, f func(x *Expr)) {
 	case *BinaryExpr:
 		f(&v.X)
 		f(&v.Y)
+	case *AssignmentExpr:
+		f(&v.X)
+		f(&v.Y)
 	case *LambdaExpr:
 		for i := range v.Params {
 			f(&v.Params[i])

--- a/build/walk_test.go
+++ b/build/walk_test.go
@@ -6,7 +6,7 @@ func nodeToString(e Expr) string {
 	if bin, ok := e.(*BinaryExpr); ok {
 		return bin.Op
 	}
-	if assign, ok := e.(*AssignmentExpr); ok {
+	if assign, ok := e.(*AssignExpr); ok {
 		return assign.Op
 	}
 	if lit, ok := e.(*LiteralExpr); ok {

--- a/build/walk_test.go
+++ b/build/walk_test.go
@@ -6,8 +6,8 @@ func nodeToString(e Expr) string {
 	if bin, ok := e.(*BinaryExpr); ok {
 		return bin.Op
 	}
-	if _, ok := e.(*AssignmentExpr); ok {
-		return "="
+	if assign, ok := e.(*AssignmentExpr); ok {
+		return assign.Op
 	}
 	if lit, ok := e.(*LiteralExpr); ok {
 		return lit.Token

--- a/build/walk_test.go
+++ b/build/walk_test.go
@@ -6,6 +6,9 @@ func nodeToString(e Expr) string {
 	if bin, ok := e.(*BinaryExpr); ok {
 		return bin.Op
 	}
+	if _, ok := e.(*AssignmentExpr); ok {
+		return "="
+	}
 	if lit, ok := e.(*LiteralExpr); ok {
 		return lit.Token
 	}

--- a/bzlenv/bzlenv.go
+++ b/bzlenv/bzlenv.go
@@ -107,15 +107,13 @@ func declareGlobals(stmts []build.Expr, env *Environment) {
 			for _, ident := range node.To {
 				env.declare(ident.Name, Imported, ident)
 			}
-		case *build.BinaryExpr:
-			if node.Op == "=" {
-				kind := Local
-				if env.Function == nil {
-					kind = Global
-				}
-				for _, id := range CollectLValues(node.X) {
-					env.declare(id.Name, kind, node)
-				}
+		case *build.AssignmentExpr:
+			kind := Local
+			if env.Function == nil {
+				kind = Global
+			}
+			for _, id := range CollectLValues(node.X) {
+				env.declare(id.Name, kind, node)
 			}
 		case *build.DefStmt:
 			env.declare(node.Name, Function, node)
@@ -148,7 +146,7 @@ func declareParams(fct *build.DefStmt, env *Environment) {
 			if ident, ok := node.X.(*build.Ident); ok {
 				env.declare(ident.Name, Parameter, node)
 			}
-		case *build.BinaryExpr:
+		case *build.AssignmentExpr:
 			// x = value
 			if ident, ok := node.X.(*build.Ident); ok {
 				env.declare(ident.Name, Parameter, node)
@@ -160,15 +158,13 @@ func declareParams(fct *build.DefStmt, env *Environment) {
 func declareLocalVariables(stmts []build.Expr, env *Environment) {
 	for _, stmt := range stmts {
 		switch node := stmt.(type) {
-		case *build.BinaryExpr:
-			if node.Op == "=" {
-				kind := Local
-				if env.Function == nil {
-					kind = Global
-				}
-				for _, id := range CollectLValues(node.X) {
-					env.declare(id.Name, kind, node)
-				}
+		case *build.AssignmentExpr:
+			kind := Local
+			if env.Function == nil {
+				kind = Global
+			}
+			for _, id := range CollectLValues(node.X) {
+				env.declare(id.Name, kind, node)
 			}
 		case *build.IfStmt:
 			declareLocalVariables(node.True, env)

--- a/bzlenv/bzlenv.go
+++ b/bzlenv/bzlenv.go
@@ -107,12 +107,12 @@ func declareGlobals(stmts []build.Expr, env *Environment) {
 			for _, ident := range node.To {
 				env.declare(ident.Name, Imported, ident)
 			}
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			kind := Local
 			if env.Function == nil {
 				kind = Global
 			}
-			for _, id := range CollectLValues(node.X) {
+			for _, id := range CollectLValues(node.LHS) {
 				env.declare(id.Name, kind, node)
 			}
 		case *build.DefStmt:
@@ -146,9 +146,9 @@ func declareParams(fct *build.DefStmt, env *Environment) {
 			if ident, ok := node.X.(*build.Ident); ok {
 				env.declare(ident.Name, Parameter, node)
 			}
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			// x = value
-			if ident, ok := node.X.(*build.Ident); ok {
+			if ident, ok := node.LHS.(*build.Ident); ok {
 				env.declare(ident.Name, Parameter, node)
 			}
 		}
@@ -158,12 +158,12 @@ func declareParams(fct *build.DefStmt, env *Environment) {
 func declareLocalVariables(stmts []build.Expr, env *Environment) {
 	for _, stmt := range stmts {
 		switch node := stmt.(type) {
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			kind := Local
 			if env.Function == nil {
 				kind = Global
 			}
-			for _, id := range CollectLValues(node.X) {
+			for _, id := range CollectLValues(node.LHS) {
 				env.declare(id.Name, kind, node)
 			}
 		case *build.IfStmt:

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -50,10 +50,10 @@ func convStmt(stmt syntax.Stmt) build.Expr {
 		}
 		return load
 	case *syntax.AssignStmt:
-		return &build.AssignmentExpr{
+		return &build.AssignExpr{
 			Op:       stmt.Op.String(),
-			X:        convExpr(stmt.LHS),
-			Y:        convExpr(stmt.RHS),
+			LHS:      convExpr(stmt.LHS),
+			RHS:      convExpr(stmt.RHS),
 			Comments: convComments(stmt.Comments()),
 		}
 	case *syntax.IfStmt:
@@ -172,9 +172,9 @@ func convExpr(e syntax.Expr) build.Expr {
 		_, lhsEnd := e.X.Span()
 		rhsBegin, _ := e.Y.Span()
 		if e.Op.String() == "=" {
-			return &build.AssignmentExpr{
-				X:         convExpr(e.X),
-				Y:         convExpr(e.Y),
+			return &build.AssignExpr{
+				LHS:       convExpr(e.X),
+				RHS:       convExpr(e.Y),
 				Op:        e.Op.String(),
 				LineBreak: lhsEnd.Line != rhsBegin.Line,
 				Comments:  convComments(e.Comments())}

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -171,6 +171,14 @@ func convExpr(e syntax.Expr) build.Expr {
 	case *syntax.BinaryExpr:
 		_, lhsEnd := e.X.Span()
 		rhsBegin, _ := e.Y.Span()
+		if e.Op.String() == "=" {
+			return &build.AssignmentExpr{
+				X:         convExpr(e.X),
+				Y:         convExpr(e.Y),
+				Op:        e.Op.String(),
+				LineBreak: lhsEnd.Line != rhsBegin.Line,
+				Comments:  convComments(e.Comments())}
+		}
 		return &build.BinaryExpr{
 			X:         convExpr(e.X),
 			Y:         convExpr(e.Y),

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -50,7 +50,7 @@ func convStmt(stmt syntax.Stmt) build.Expr {
 		}
 		return load
 	case *syntax.AssignStmt:
-		return &build.BinaryExpr{
+		return &build.AssignmentExpr{
 			Op:       stmt.Op.String(),
 			X:        convExpr(stmt.LHS),
 			Y:        convExpr(stmt.RHS),

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -68,12 +68,12 @@ const stdinPackageName = "-" // the special package name to represent stdin
 
 // CmdEnvironment stores the information the commands below have access to.
 type CmdEnvironment struct {
-	File   *build.File                  // the AST
-	Rule   *build.Rule                  // the rule to modify
+	File   *build.File                      // the AST
+	Rule   *build.Rule                      // the rule to modify
 	Vars   map[string]*build.AssignmentExpr // global variables set in the build file
-	Pkg    string                       // the full package name
-	Args   []string                     // the command-line arguments
-	output *apipb.Output_Record         // output proto, stores whatever a command wants to print
+	Pkg    string                           // the full package name
+	Args   []string                         // the command-line arguments
+	output *apipb.Output_Record             // output proto, stores whatever a command wants to print
 }
 
 // The cmdXXX functions implement the various commands.

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -723,7 +723,7 @@ type rewriteResult struct {
 // getGlobalVariables returns the global variable assignments in the provided list of expressions.
 // That is, for each variable assignment of the form
 //   a = v
-// vars["a"] will contain the BinaryExpr whose Y value is the assignment "a = v".
+// vars["a"] will contain the AssignmentExpr whose Y value is the assignment "a = v".
 func getGlobalVariables(exprs []build.Expr) (vars map[string]*build.AssignmentExpr) {
 	vars = make(map[string]*build.AssignmentExpr)
 	for _, expr := range exprs {

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -68,12 +68,12 @@ const stdinPackageName = "-" // the special package name to represent stdin
 
 // CmdEnvironment stores the information the commands below have access to.
 type CmdEnvironment struct {
-	File   *build.File                      // the AST
-	Rule   *build.Rule                      // the rule to modify
-	Vars   map[string]*build.AssignmentExpr // global variables set in the build file
-	Pkg    string                           // the full package name
-	Args   []string                         // the command-line arguments
-	output *apipb.Output_Record             // output proto, stores whatever a command wants to print
+	File   *build.File                  // the AST
+	Rule   *build.Rule                  // the rule to modify
+	Vars   map[string]*build.AssignExpr // global variables set in the build file
+	Pkg    string                       // the full package name
+	Args   []string                     // the command-line arguments
+	output *apipb.Output_Record         // output proto, stores whatever a command wants to print
 }
 
 // The cmdXXX functions implement the various commands.
@@ -110,9 +110,9 @@ func cmdComment(opts *Options, env CmdEnvironment) (*build.File, error) {
 	case 2: // Attach to an attribute
 		if attr := env.Rule.AttrDefn(env.Args[0]); attr != nil {
 			if fullLine {
-				attr.X.Comment().Before = comment
+				attr.LHS.Comment().Before = comment
 			} else {
-				attr.Y.Comment().Suffix = comment
+				attr.RHS.Comment().Suffix = comment
 			}
 		}
 	case 3: // Attach to a specific value in a list
@@ -723,12 +723,12 @@ type rewriteResult struct {
 // getGlobalVariables returns the global variable assignments in the provided list of expressions.
 // That is, for each variable assignment of the form
 //   a = v
-// vars["a"] will contain the AssignmentExpr whose Y value is the assignment "a = v".
-func getGlobalVariables(exprs []build.Expr) (vars map[string]*build.AssignmentExpr) {
-	vars = make(map[string]*build.AssignmentExpr)
+// vars["a"] will contain the AssignExpr whose RHS value is the assignment "a = v".
+func getGlobalVariables(exprs []build.Expr) (vars map[string]*build.AssignExpr) {
+	vars = make(map[string]*build.AssignExpr)
 	for _, expr := range exprs {
-		if as, ok := expr.(*build.AssignmentExpr); ok {
-			if lhs, ok := as.X.(*build.Ident); ok {
+		if as, ok := expr.(*build.AssignExpr); ok {
+			if lhs, ok := as.LHS.(*build.Ident); ok {
 				vars[lhs.Name] = as
 			}
 		}
@@ -790,7 +790,7 @@ func rewrite(opts *Options, commandsForFile commandsForFile) *rewriteResult {
 		return &rewriteResult{file: name, errs: []error{err}}
 	}
 
-	vars := map[string]*build.AssignmentExpr{}
+	vars := map[string]*build.AssignExpr{}
 	if opts.EditVariables {
 		vars = getGlobalVariables(f.Stmt)
 	}

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -592,7 +592,7 @@ func attributeMustNotBeSorted(rule, attr string) bool {
 
 // getVariable returns the binary expression that assignes a variable to expr, if expr is
 // an identifier of a variable that vars contains a mapping for.
-func getVariable(expr build.Expr, vars *map[string]*build.AssignmentExpr) (varAssignment *build.AssignmentExpr) {
+func getVariable(expr build.Expr, vars *map[string]*build.AssignExpr) (varAssignment *build.AssignExpr) {
 	if vars == nil {
 		return nil
 	}
@@ -633,11 +633,11 @@ func AddValueToList(oldList build.Expr, pkg string, item build.Expr, sorted bool
 }
 
 // AddValueToListAttribute adds the given item to the list attribute identified by name and pkg.
-func AddValueToListAttribute(r *build.Rule, name string, pkg string, item build.Expr, vars *map[string]*build.AssignmentExpr) {
+func AddValueToListAttribute(r *build.Rule, name string, pkg string, item build.Expr, vars *map[string]*build.AssignExpr) {
 	old := r.Attr(name)
 	sorted := !attributeMustNotBeSorted(r.Kind(), name)
 	if varAssignment := getVariable(old, vars); varAssignment != nil {
-		varAssignment.Y = AddValueToList(varAssignment.Y, pkg, item, sorted)
+		varAssignment.RHS = AddValueToList(varAssignment.RHS, pkg, item, sorted)
 	} else {
 		r.SetAttr(name, AddValueToList(old, pkg, item, sorted))
 	}
@@ -645,7 +645,7 @@ func AddValueToListAttribute(r *build.Rule, name string, pkg string, item build.
 
 // MoveAllListAttributeValues moves all values from list attribute oldAttr to newAttr,
 // and deletes oldAttr.
-func MoveAllListAttributeValues(rule *build.Rule, oldAttr, newAttr, pkg string, vars *map[string]*build.AssignmentExpr) error {
+func MoveAllListAttributeValues(rule *build.Rule, oldAttr, newAttr, pkg string, vars *map[string]*build.AssignExpr) error {
 	if rule.Attr(oldAttr) == nil {
 		return fmt.Errorf("no attribute %s found in %s", oldAttr, rule.Name())
 	}
@@ -722,11 +722,11 @@ func RenameAttribute(r *build.Rule, oldName, newName string) error {
 		return fmt.Errorf("attribute %s already exists in rule %s", newName, r.Name())
 	}
 	for _, kv := range r.Call.List {
-		as, ok := kv.(*build.AssignmentExpr)
+		as, ok := kv.(*build.AssignExpr)
 		if !ok {
 			continue
 		}
-		k, ok := as.X.(*build.Ident)
+		k, ok := as.LHS.(*build.Ident)
 		if !ok || k.Name != oldName {
 			continue
 		}
@@ -769,8 +769,8 @@ func UsedSymbols(stmt build.Expr) map[string]bool {
 		}
 		// Check if we are on the left-side of an assignment
 		for _, e := range stack {
-			if as, ok := e.(*build.AssignmentExpr); ok {
-				if as.X == expr {
+			if as, ok := e.(*build.AssignExpr); ok {
+				if as.LHS == expr {
 					return
 				}
 			}

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -592,7 +592,7 @@ func attributeMustNotBeSorted(rule, attr string) bool {
 
 // getVariable returns the binary expression that assignes a variable to expr, if expr is
 // an identifier of a variable that vars contains a mapping for.
-func getVariable(expr build.Expr, vars *map[string]*build.BinaryExpr) (varAssignment *build.BinaryExpr) {
+func getVariable(expr build.Expr, vars *map[string]*build.AssignmentExpr) (varAssignment *build.AssignmentExpr) {
 	if vars == nil {
 		return nil
 	}
@@ -633,7 +633,7 @@ func AddValueToList(oldList build.Expr, pkg string, item build.Expr, sorted bool
 }
 
 // AddValueToListAttribute adds the given item to the list attribute identified by name and pkg.
-func AddValueToListAttribute(r *build.Rule, name string, pkg string, item build.Expr, vars *map[string]*build.BinaryExpr) {
+func AddValueToListAttribute(r *build.Rule, name string, pkg string, item build.Expr, vars *map[string]*build.AssignmentExpr) {
 	old := r.Attr(name)
 	sorted := !attributeMustNotBeSorted(r.Kind(), name)
 	if varAssignment := getVariable(old, vars); varAssignment != nil {
@@ -645,7 +645,7 @@ func AddValueToListAttribute(r *build.Rule, name string, pkg string, item build.
 
 // MoveAllListAttributeValues moves all values from list attribute oldAttr to newAttr,
 // and deletes oldAttr.
-func MoveAllListAttributeValues(rule *build.Rule, oldAttr, newAttr, pkg string, vars *map[string]*build.BinaryExpr) error {
+func MoveAllListAttributeValues(rule *build.Rule, oldAttr, newAttr, pkg string, vars *map[string]*build.AssignmentExpr) error {
 	if rule.Attr(oldAttr) == nil {
 		return fmt.Errorf("no attribute %s found in %s", oldAttr, rule.Name())
 	}
@@ -722,8 +722,8 @@ func RenameAttribute(r *build.Rule, oldName, newName string) error {
 		return fmt.Errorf("attribute %s already exists in rule %s", newName, r.Name())
 	}
 	for _, kv := range r.Call.List {
-		as, ok := kv.(*build.BinaryExpr)
-		if !ok || as.Op != "=" {
+		as, ok := kv.(*build.AssignmentExpr)
+		if !ok {
 			continue
 		}
 		k, ok := as.X.(*build.Ident)
@@ -769,8 +769,8 @@ func UsedSymbols(stmt build.Expr) map[string]bool {
 		}
 		// Check if we are on the left-side of an assignment
 		for _, e := range stack {
-			if as, ok := e.(*build.BinaryExpr); ok {
-				if as.Op == "=" && as.X == expr {
+			if as, ok := e.(*build.AssignmentExpr); ok {
+				if as.X == expr {
 					return
 				}
 			}

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -288,7 +288,7 @@ func TestDictionaryDelete(t *testing.T) {
 			continue
 		}
 		rule := bld.RuleAt(1)
-		dict := rule.Call.List[0].(*build.BinaryExpr).Y.(*build.DictExpr)
+		dict := rule.Call.List[0].(*build.AssignmentExpr).Y.(*build.DictExpr)
 		returnVal := DictionaryDelete(dict, "deletekey")
 		got := strings.TrimSpace(string(build.Format(bld)))
 		wantBld, err := build.Parse("BUILD", []byte(tst.expected))

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -288,7 +288,7 @@ func TestDictionaryDelete(t *testing.T) {
 			continue
 		}
 		rule := bld.RuleAt(1)
-		dict := rule.Call.List[0].(*build.AssignmentExpr).Y.(*build.DictExpr)
+		dict := rule.Call.List[0].(*build.AssignExpr).RHS.(*build.DictExpr)
 		returnVal := DictionaryDelete(dict, "deletekey")
 		got := strings.TrimSpace(string(build.Format(bld)))
 		wantBld, err := build.Parse("BUILD", []byte(tst.expected))

--- a/edit/fix.go
+++ b/edit/fix.go
@@ -320,12 +320,12 @@ func usePlusEqual(f *build.File) bool {
 			continue
 		}
 
-		var fix *build.AssignmentExpr
+		var fix *build.AssignExpr
 		if dot.Name == "extend" {
-			fix = &build.AssignmentExpr{X: obj, Op: "+=", Y: call.List[0]}
+			fix = &build.AssignExpr{LHS: obj, Op: "+=", RHS: call.List[0]}
 		} else if dot.Name == "append" {
 			list := &build.ListExpr{List: []build.Expr{call.List[0]}}
-			fix = &build.AssignmentExpr{X: obj, Op: "+=", Y: list}
+			fix = &build.AssignExpr{LHS: obj, Op: "+=", RHS: list}
 		} else {
 			continue
 		}
@@ -409,7 +409,7 @@ func movePackageDeclarationToTheTop(f *build.File) bool {
 	inserted := false // true when the package declaration has been inserted
 	for _, stmt := range f.Stmt {
 		_, isComment := stmt.(*build.CommentBlock)
-		_, isAssignExpr := stmt.(*build.AssignmentExpr) // e.g. variable declaration
+		_, isAssignExpr := stmt.(*build.AssignExpr) // e.g. variable declaration
 		_, isLoad := stmt.(*build.LoadStmt)
 		if isComment || isAssignExpr || isLoad {
 			all = append(all, stmt)

--- a/edit/fix.go
+++ b/edit/fix.go
@@ -320,12 +320,12 @@ func usePlusEqual(f *build.File) bool {
 			continue
 		}
 
-		var fix *build.BinaryExpr
+		var fix *build.AssignmentExpr
 		if dot.Name == "extend" {
-			fix = &build.BinaryExpr{X: obj, Op: "+=", Y: call.List[0]}
+			fix = &build.AssignmentExpr{X: obj, Op: "+=", Y: call.List[0]}
 		} else if dot.Name == "append" {
 			list := &build.ListExpr{List: []build.Expr{call.List[0]}}
-			fix = &build.BinaryExpr{X: obj, Op: "+=", Y: list}
+			fix = &build.AssignmentExpr{X: obj, Op: "+=", Y: list}
 		} else {
 			continue
 		}
@@ -409,9 +409,9 @@ func movePackageDeclarationToTheTop(f *build.File) bool {
 	inserted := false // true when the package declaration has been inserted
 	for _, stmt := range f.Stmt {
 		_, isComment := stmt.(*build.CommentBlock)
-		_, isBinaryExpr := stmt.(*build.BinaryExpr) // e.g. variable declaration
+		_, isAssignExpr := stmt.(*build.AssignmentExpr) // e.g. variable declaration
 		_, isLoad := stmt.(*build.LoadStmt)
-		if isComment || isBinaryExpr || isLoad {
+		if isComment || isAssignExpr || isLoad {
 			all = append(all, stmt)
 			continue
 		}

--- a/warn/types.go
+++ b/warn/types.go
@@ -106,26 +106,6 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 			}
 		case *build.BinaryExpr:
 			switch node.Op {
-			case "+=", "-=", "*=", "/=", "//=", "%=", "|=":
-				// Assignments
-				t, ok := result[node.Y]
-				if !ok {
-					return
-				}
-				if node.Op == "%=" && t != String {
-					// If the right hand side is not a string, the left hand side can still be a string
-					return
-				}
-				ident, ok := (node.X).(*build.Ident)
-				if !ok {
-					return
-				}
-				binding := env.Get(ident.Name)
-				if binding == nil {
-					return
-				}
-				variables[binding.ID] = t
-
 			case ">", ">=", "<", "<=", "==", "!=", "in", "not in":
 				// Boolean
 				nodeType = Bool
@@ -147,6 +127,10 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 		case *build.AssignmentExpr:
 			t, ok := result[node.Y]
 			if !ok {
+				return
+			}
+			if node.Op == "%=" && t != String {
+				// If the right hand side is not a string, the left hand side can still be a string
 				return
 			}
 			ident, ok := (node.X).(*build.Ident)

--- a/warn/types.go
+++ b/warn/types.go
@@ -124,8 +124,8 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 					}
 				}
 			}
-		case *build.AssignmentExpr:
-			t, ok := result[node.Y]
+		case *build.AssignExpr:
+			t, ok := result[node.RHS]
 			if !ok {
 				return
 			}
@@ -133,7 +133,7 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 				// If the right hand side is not a string, the left hand side can still be a string
 				return
 			}
-			ident, ok := (node.X).(*build.Ident)
+			ident, ok := (node.LHS).(*build.Ident)
 			if !ok {
 				return
 			}
@@ -162,8 +162,8 @@ func walkOnce(node build.Expr, env *bzlenv.Environment, fct func(e *build.Expr, 
 	case *build.CallExpr:
 		fct(&expr.X, env)
 		for _, param := range expr.List {
-			if as, ok := param.(*build.AssignmentExpr); ok {
-				fct(&as.Y, env)
+			if as, ok := param.(*build.AssignExpr); ok {
+				fct(&as.RHS, env)
 			} else {
 				fct(&param, env)
 			}

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -149,7 +149,7 @@ func positionalArgumentsWarning(f *build.File, pkg string, stmt build.Expr) *Fin
 		return nil
 	}
 	for _, arg := range call.List {
-		if _, ok := arg.(*build.AssignmentExpr); ok {
+		if _, ok := arg.(*build.AssignExpr); ok {
 			continue
 		}
 		start, end := arg.Span()

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -149,7 +149,7 @@ func positionalArgumentsWarning(f *build.File, pkg string, stmt build.Expr) *Fin
 		return nil
 	}
 	for _, arg := range call.List {
-		if op, ok := arg.(*build.BinaryExpr); ok && op.Op == "=" {
+		if _, ok := arg.(*build.AssignmentExpr); ok {
 			continue
 		}
 		start, end := arg.Span()

--- a/warn/warn_bazel_api.go
+++ b/warn/warn_bazel_api.go
@@ -184,18 +184,18 @@ func makePositional(argument build.Expr) build.Expr {
 
 // makeKeyword makes the function argument keyword (adds or edits the keyword name)
 func makeKeyword(argument build.Expr, name string) build.Expr {
-	binary, ok := argument.(*build.BinaryExpr)
+	assign, ok := argument.(*build.AssignmentExpr)
 	if !ok {
-		return &build.BinaryExpr{
+		return &build.AssignmentExpr{
 			X:  &build.Ident{Name: name},
 			Op: "=",
 			Y:  argument,
 		}
 	}
-	ident, ok := binary.X.(*build.Ident)
+	ident, ok := assign.X.(*build.Ident)
 	if !ok {
-		binary.X = &build.Ident{Name: name}
-		return binary
+		assign.X = &build.Ident{Name: name}
+		return assign
 	}
 	ident.Name = name
 	return argument

--- a/warn/warn_bazel_api.go
+++ b/warn/warn_bazel_api.go
@@ -56,13 +56,13 @@ func negateExpression(expr build.Expr) build.Expr {
 
 // getParam search for a param with a given name in a given list of function arguments
 // and returns it with its index
-func getParam(attrs []build.Expr, paramName string) (int, *build.Ident, *build.AssignmentExpr) {
+func getParam(attrs []build.Expr, paramName string) (int, *build.Ident, *build.AssignExpr) {
 	for i, attr := range attrs {
-		as, ok := attr.(*build.AssignmentExpr)
+		as, ok := attr.(*build.AssignExpr)
 		if !ok {
 			continue
 		}
-		name, ok := (as.X).(*build.Ident)
+		name, ok := (as.LHS).(*build.Ident)
 		if !ok || name.Name != paramName {
 			continue
 		}
@@ -176,25 +176,25 @@ func notLoadedFunctionUsageCheck(f *build.File, category string, globals []strin
 
 // makePositional makes the function argument positional (removes the keyword if it exists)
 func makePositional(argument build.Expr) build.Expr {
-	if binary, ok := argument.(*build.AssignmentExpr); ok {
-		return binary.Y
+	if binary, ok := argument.(*build.AssignExpr); ok {
+		return binary.RHS
 	}
 	return argument
 }
 
 // makeKeyword makes the function argument keyword (adds or edits the keyword name)
 func makeKeyword(argument build.Expr, name string) build.Expr {
-	assign, ok := argument.(*build.AssignmentExpr)
+	assign, ok := argument.(*build.AssignExpr)
 	if !ok {
-		return &build.AssignmentExpr{
-			X:  &build.Ident{Name: name},
-			Op: "=",
-			Y:  argument,
+		return &build.AssignExpr{
+			LHS: &build.Ident{Name: name},
+			Op:  "=",
+			RHS: argument,
 		}
 	}
-	ident, ok := assign.X.(*build.Ident)
+	ident, ok := assign.LHS.(*build.Ident)
 	if !ok {
-		assign.X = &build.Ident{Name: name}
+		assign.LHS = &build.Ident{Name: name}
 		return assign
 	}
 	ident.Name = name
@@ -226,7 +226,7 @@ func attrConfigurationWarning(f *build.File, fix bool) []*Finding {
 		if param == nil {
 			return
 		}
-		value, ok := (param.Y).(*build.StringExpr)
+		value, ok := (param.RHS).(*build.StringExpr)
 		if !ok || value.Value != "data" {
 			return
 		}
@@ -269,7 +269,7 @@ func attrNonEmptyWarning(f *build.File, fix bool) []*Finding {
 		}
 		if fix {
 			name.Name = "allow_empty"
-			param.Y = negateExpression(param.Y)
+			param.RHS = negateExpression(param.RHS)
 		} else {
 			start, end := param.Span()
 			findings = append(findings,
@@ -312,7 +312,7 @@ func attrSingleFileWarning(f *build.File, fix bool) []*Finding {
 					"single_file is deprecated in favor of allow_single_file.", true, nil))
 			return
 		}
-		value := singleFileParam.Y
+		value := singleFileParam.RHS
 		if boolean, ok := value.(*build.Ident); ok && boolean.Name == "False" {
 			// if the value is `False`, just remove the whole parameter
 			call.List = append(call.List[:i], call.List[i+1:]...)
@@ -320,10 +320,10 @@ func attrSingleFileWarning(f *build.File, fix bool) []*Finding {
 			// search for `allow_files` parameter in the same attr definition and remove it
 			j, _, allowFilesParam := getParam(call.List, "allow_files")
 			if allowFilesParam != nil {
-				value = allowFilesParam.Y
+				value = allowFilesParam.RHS
 				call.List = append(call.List[:j], call.List[j+1:]...)
 			}
-			singleFileParam.Y = value
+			singleFileParam.RHS = value
 			name.Name = "allow_single_file"
 		}
 	})
@@ -536,8 +536,8 @@ func contextArgsAPIWarning(f *build.File, fix bool) []*Finding {
 				// `add_joined` doesn't have a `before_each` parameter, replace it with `format_each`:
 				// `before_each = foo` -> `format_each = foo + "%s"`
 				beforeEachKw.Name = "format_each"
-				beforeEach.Y = &build.BinaryExpr{
-					X:  beforeEach.Y,
+				beforeEach.RHS = &build.BinaryExpr{
+					X:  beforeEach.RHS,
 					Op: "+",
 					Y:  &build.StringExpr{Value: "%s"},
 				}
@@ -632,7 +632,7 @@ func ruleImplReturnWarning(f *build.File, fix bool) []*Finding {
 		var impl build.Expr
 		_, _, param := getParam(call.List, "implementation")
 		if param != nil {
-			impl = param.Y
+			impl = param.RHS
 		} else if len(call.List) > 0 {
 			impl = call.List[0]
 		}

--- a/warn/warn_bazel_api.go
+++ b/warn/warn_bazel_api.go
@@ -56,17 +56,17 @@ func negateExpression(expr build.Expr) build.Expr {
 
 // getParam search for a param with a given name in a given list of function arguments
 // and returns it with its index
-func getParam(attrs []build.Expr, paramName string) (int, *build.Ident, *build.BinaryExpr) {
+func getParam(attrs []build.Expr, paramName string) (int, *build.Ident, *build.AssignmentExpr) {
 	for i, attr := range attrs {
-		binary, ok := attr.(*build.BinaryExpr)
-		if !ok || binary.Op != "=" {
+		as, ok := attr.(*build.AssignmentExpr)
+		if !ok {
 			continue
 		}
-		name, ok := (binary.X).(*build.Ident)
+		name, ok := (as.X).(*build.Ident)
 		if !ok || name.Name != paramName {
 			continue
 		}
-		return i, name, binary
+		return i, name, as
 	}
 	return -1, nil, nil
 }
@@ -176,7 +176,7 @@ func notLoadedFunctionUsageCheck(f *build.File, category string, globals []strin
 
 // makePositional makes the function argument positional (removes the keyword if it exists)
 func makePositional(argument build.Expr) build.Expr {
-	if binary, ok := argument.(*build.BinaryExpr); ok && binary.Op == "=" {
+	if binary, ok := argument.(*build.AssignmentExpr); ok {
 		return binary.Y
 	}
 	return argument

--- a/warn/warn_bazel_operation.go
+++ b/warn/warn_bazel_operation.go
@@ -25,9 +25,9 @@ func depsetUnionWarning(f *build.File, fix bool) []*Finding {
 			case "+", "|":
 				addWarning(expr)
 			}
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			// `depset1 += depset2` or `depset1 |= depset2`
-			if types[expr.X] != Depset && types[expr.Y] != Depset {
+			if types[expr.LHS] != Depset && types[expr.RHS] != Depset {
 				return
 			}
 			switch expr.Op {

--- a/warn/warn_bazel_operation.go
+++ b/warn/warn_bazel_operation.go
@@ -22,7 +22,16 @@ func depsetUnionWarning(f *build.File, fix bool) []*Finding {
 				return
 			}
 			switch expr.Op {
-			case "+", "|", "+=", "|=":
+			case "+", "|":
+				addWarning(expr)
+			}
+		case *build.AssignmentExpr:
+			// `depset1 += depset2` or `depset1 |= depset2`
+			if types[expr.X] != Depset && types[expr.Y] != Depset {
+				return
+			}
+			switch expr.Op {
+			case "+=", "|=":
 				addWarning(expr)
 			}
 		case *build.CallExpr:

--- a/warn/warn_control_flow.go
+++ b/warn/warn_control_flow.go
@@ -158,7 +158,7 @@ func noEffectStatementsCheck(f *build.File, body []build.Expr, isTopLevel, isFun
 		}
 		switch s := (stmt).(type) {
 		case *build.DefStmt, *build.ForStmt, *build.IfStmt, *build.LoadStmt, *build.ReturnStmt,
-			*build.CallExpr, *build.CommentBlock, *build.BranchStmt, *build.AssignmentExpr:
+			*build.CallExpr, *build.CommentBlock, *build.BranchStmt, *build.AssignExpr:
 			continue
 		case *build.Comprehension:
 			if !isTopLevel || s.Curly {
@@ -217,12 +217,12 @@ func unusedVariableCheck(f *build.File, stmts []build.Expr, findings []*Finding)
 		}
 
 		// look for all assignments in the scope
-		as, ok := s.(*build.AssignmentExpr)
+		as, ok := s.(*build.AssignExpr)
 		if !ok {
 			continue
 		}
-		start, end := as.X.Span()
-		left, ok := as.X.(*build.Ident)
+		start, end := as.LHS.Span()
+		left, ok := as.LHS.(*build.Ident)
 		if !ok {
 			continue
 		}
@@ -251,12 +251,12 @@ func redefinedVariableWarning(f *build.File, fix bool) []*Finding {
 
 	for _, s := range f.Stmt {
 		// look for all assignments in the scope
-		as, ok := s.(*build.AssignmentExpr)
+		as, ok := s.(*build.AssignExpr)
 		if !ok {
 			continue
 		}
-		start, end := as.X.Span()
-		left, ok := as.X.(*build.Ident)
+		start, end := as.LHS.Span()
+		left, ok := as.LHS.(*build.Ident)
 		if !ok {
 			continue
 		}
@@ -344,8 +344,8 @@ func collectLocalVariables(stmts []build.Expr) []*build.Ident {
 		case *build.IfStmt:
 			variables = append(variables, collectLocalVariables(stmt.True)...)
 			variables = append(variables, collectLocalVariables(stmt.False)...)
-		case *build.AssignmentExpr:
-			variables = append(variables, bzlenv.CollectLValues(stmt.X)...)
+		case *build.AssignExpr:
+			variables = append(variables, bzlenv.CollectLValues(stmt.LHS)...)
 		}
 	}
 	return variables
@@ -373,8 +373,8 @@ func findUninitializedVariables(stmts []build.Expr, previouslyInitialized map[st
 		// For example, if the expression is `a = foo(b = c)`, only `c` can be an unused variable here.
 		lValues := make(map[*build.Ident]bool)
 		build.Walk(expr, func(expr build.Expr, stack []build.Expr) {
-			if as, ok := expr.(*build.AssignmentExpr); ok {
-				for _, ident := range bzlenv.CollectLValues(as.X) {
+			if as, ok := expr.(*build.AssignExpr); ok {
+				for _, ident := range bzlenv.CollectLValues(as.LHS) {
 					lValues[ident] = true
 				}
 			}
@@ -453,9 +453,9 @@ func findUninitializedVariables(stmts []build.Expr, previouslyInitialized map[st
 				}
 			}
 			continue
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			// Assignment expression. Collect all definitions from the lhs
-			for _, ident := range bzlenv.CollectLValues(stmt.X) {
+			for _, ident := range bzlenv.CollectLValues(stmt.LHS) {
 				newlyDefinedVariables[ident.Name] = true
 			}
 		}
@@ -479,9 +479,9 @@ func getFunctionParams(def *build.DefStmt) []*build.Ident {
 			if ident, ok := node.X.(*build.Ident); ok {
 				params = append(params, ident)
 			}
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			// x = value
-			if ident, ok := node.X.(*build.Ident); ok {
+			if ident, ok := node.LHS.(*build.Ident); ok {
 				params = append(params, ident)
 			}
 		}

--- a/warn/warn_control_flow.go
+++ b/warn/warn_control_flow.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/buildtools/bzlenv"
 	"github.com/bazelbuild/buildtools/edit"
-	"strings"
 )
 
 // findReturnsWithoutValue searches for return statements without a value, calls `callback` on
@@ -161,10 +160,6 @@ func noEffectStatementsCheck(f *build.File, body []build.Expr, isTopLevel, isFun
 		case *build.DefStmt, *build.ForStmt, *build.IfStmt, *build.LoadStmt, *build.ReturnStmt,
 			*build.CallExpr, *build.CommentBlock, *build.BranchStmt, *build.AssignmentExpr:
 			continue
-		case *build.BinaryExpr:
-			if s.Op != "==" && s.Op != "!=" && strings.HasSuffix(s.Op, "=") {
-				continue
-			}
 		case *build.Comprehension:
 			if !isTopLevel || s.Curly {
 				// List comprehensions are allowed on top-level.
@@ -484,7 +479,7 @@ func getFunctionParams(def *build.DefStmt) []*build.Ident {
 			if ident, ok := node.X.(*build.Ident); ok {
 				params = append(params, ident)
 			}
-		case *build.BinaryExpr:
+		case *build.AssignmentExpr:
 			// x = value
 			if ident, ok := node.X.(*build.Ident); ok {
 				params = append(params, ident)

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -59,7 +59,7 @@ func packageOnTopWarning(f *build.File, fix bool) []*Finding {
 	for _, stmt := range f.Stmt {
 		_, isString := stmt.(*build.StringExpr) // typically a docstring
 		_, isComment := stmt.(*build.CommentBlock)
-		_, isAssignExpr := stmt.(*build.AssignmentExpr) // e.g. variable declaration
+		_, isAssignExpr := stmt.(*build.AssignExpr) // e.g. variable declaration
 		_, isLoad := stmt.(*build.LoadStmt)
 		_, isPackageGroup := edit.ExprToRule(stmt, "package_group")
 		_, isLicense := edit.ExprToRule(stmt, "licenses")

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -59,11 +59,11 @@ func packageOnTopWarning(f *build.File, fix bool) []*Finding {
 	for _, stmt := range f.Stmt {
 		_, isString := stmt.(*build.StringExpr) // typically a docstring
 		_, isComment := stmt.(*build.CommentBlock)
-		_, isBinaryExpr := stmt.(*build.BinaryExpr) // e.g. variable declaration
+		_, isAssignExpr := stmt.(*build.AssignmentExpr) // e.g. variable declaration
 		_, isLoad := stmt.(*build.LoadStmt)
 		_, isPackageGroup := edit.ExprToRule(stmt, "package_group")
 		_, isLicense := edit.ExprToRule(stmt, "licenses")
-		if isString || isComment || isBinaryExpr || isLoad || isPackageGroup || isLicense {
+		if isString || isComment || isAssignExpr || isLoad || isPackageGroup || isLicense {
 			continue
 		}
 		if rule, ok := edit.ExprToRule(stmt, "package"); ok {

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -163,9 +163,9 @@ func getParamName(param build.Expr) string {
 	switch param := param.(type) {
 	case *build.Ident:
 		return param.Name
-	case *build.AssignmentExpr:
+	case *build.AssignExpr:
 		// keyword parameter
-		if ident, ok := param.X.(*build.Ident); ok {
+		if ident, ok := param.LHS.(*build.Ident); ok {
 			return ident.Name
 		}
 	case *build.UnaryExpr:

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -163,7 +163,7 @@ func getParamName(param build.Expr) string {
 	switch param := param.(type) {
 	case *build.Ident:
 		return param.Name
-	case *build.BinaryExpr:
+	case *build.AssignmentExpr:
 		// keyword parameter
 		if ident, ok := param.X.(*build.Ident); ok {
 			return ident.Name

--- a/warn/warn_naming.go
+++ b/warn/warn_naming.go
@@ -90,11 +90,11 @@ func nameConventionsWarning(f *build.File, fix bool) []*Finding {
 	build.WalkStatements(f, func(stmt build.Expr, stack []build.Expr) {
 		// looking for provider declaration statements: `xxx = provider()`
 		// note that the code won't trigger on complex assignments, such as `x, y = foo, provider()`
-		binary, ok := stmt.(*build.AssignmentExpr)
+		binary, ok := stmt.(*build.AssignExpr)
 		if !ok {
 			return
 		}
-		for _, ident := range bzlenv.CollectLValues(binary.X) {
+		for _, ident := range bzlenv.CollectLValues(binary.LHS) {
 			if isLowerSnakeCase(ident.Name) || isUpperSnakeCase(ident.Name) {
 				continue
 			}

--- a/warn/warn_naming.go
+++ b/warn/warn_naming.go
@@ -90,8 +90,8 @@ func nameConventionsWarning(f *build.File, fix bool) []*Finding {
 	build.WalkStatements(f, func(stmt build.Expr, stack []build.Expr) {
 		// looking for provider declaration statements: `xxx = provider()`
 		// note that the code won't trigger on complex assignments, such as `x, y = foo, provider()`
-		binary, ok := stmt.(*build.BinaryExpr)
-		if !ok || binary.Op != "=" {
+		binary, ok := stmt.(*build.AssignmentExpr)
+		if !ok {
 			return
 		}
 		for _, ident := range bzlenv.CollectLValues(binary.X) {

--- a/warn/warn_operation.go
+++ b/warn/warn_operation.go
@@ -2,24 +2,38 @@
 
 package warn
 
-import "github.com/bazelbuild/buildtools/build"
+import (
+	"fmt"
+	"github.com/bazelbuild/buildtools/build"
+)
 
 func dictionaryConcatenationWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
+
+	var addWarning = func(expr build.Expr) {
+		start, end := expr.Span()
+		findings = append(findings,
+			makeFinding(f, start, end, "dict-concatenation",
+				"Dictionary concatenation is deprecated.", true, nil))
+	}
+
 	types := detectTypes(f)
 	build.Walk(f, func(expr build.Expr, stack []build.Expr) {
-		binary, ok := expr.(*build.BinaryExpr)
-		if !ok {
-			return
-		}
-		if binary.Op != "+" && binary.Op != "+=" {
-			return
-		}
-		if types[binary.X] == Dict || types[binary.Y] == Dict {
-			start, end := binary.Span()
-			findings = append(findings,
-				makeFinding(f, start, end, "dict-concatenation",
-					"Dictionary concatenation is deprecated.", true, nil))
+		switch expr := expr.(type) {
+		case *build.BinaryExpr:
+			if expr.Op != "+" {
+				return
+			}
+			if types[expr.X] == Dict || types[expr.Y] == Dict {
+				addWarning(expr)
+			}
+		case *build.AssignmentExpr:
+			if expr.Op != "+=" {
+				return
+			}
+			if types[expr.X] == Dict || types[expr.Y] == Dict {
+				addWarning(expr)
+			}
 		}
 	})
 	return findings
@@ -73,22 +87,36 @@ func stringIterationWarning(f *build.File, fix bool) []*Finding {
 
 func integerDivisionWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
-	build.Walk(f, func(expr build.Expr, stack []build.Expr) {
-		binary, ok := expr.(*build.BinaryExpr)
-		if !ok {
-			return
-		}
-		if binary.Op != "/" && binary.Op != "/=" {
-			return
-		}
-		if fix {
-			binary.Op = "/" + binary.Op
-			return
-		}
-		start, end := binary.Span()
+
+	var addWarning = func(expr build.Expr, op string) {
+		start, end := expr.Span()
 		findings = append(findings,
 			makeFinding(f, start, end, "integer-division",
-				"The \""+binary.Op+"\" operator for integer division is deprecated in favor of \"/"+binary.Op+"\".", true, nil))
+				fmt.Sprintf(`The "%s" operator for integer division is deprecated in favor of "/%s".`, op, op), true, nil))
+	}
+
+	build.Walk(f, func(expr build.Expr, stack []build.Expr) {
+		switch expr := expr.(type) {
+		case *build.BinaryExpr:
+			if expr.Op != "/" {
+				return
+			}
+			if fix {
+				expr.Op = "//"
+				return
+			}
+			addWarning(expr, expr.Op)
+
+		case *build.AssignmentExpr:
+			if expr.Op != "/=" {
+				return
+			}
+			if fix {
+				expr.Op = "//="
+				return
+			}
+			addWarning(expr, expr.Op)
+		}
 	})
 	return findings
 }

--- a/warn/warn_operation.go
+++ b/warn/warn_operation.go
@@ -27,11 +27,11 @@ func dictionaryConcatenationWarning(f *build.File, fix bool) []*Finding {
 			if types[expr.X] == Dict || types[expr.Y] == Dict {
 				addWarning(expr)
 			}
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			if expr.Op != "+=" {
 				return
 			}
-			if types[expr.X] == Dict || types[expr.Y] == Dict {
+			if types[expr.LHS] == Dict || types[expr.RHS] == Dict {
 				addWarning(expr)
 			}
 		}
@@ -107,7 +107,7 @@ func integerDivisionWarning(f *build.File, fix bool) []*Finding {
 			}
 			addWarning(expr, expr.Op)
 
-		case *build.AssignmentExpr:
+		case *build.AssignExpr:
 			if expr.Op != "/=" {
 				return
 			}


### PR DESCRIPTION
Assignment expressions are special cases of binary expressions with operator == "=", they are often treated specially in various lint checks: as statements they define new (local) variables, as expressions inside other statements they correspond to keyword parameters.