### PR TITLE
Introduce an add_raw command

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -78,13 +78,20 @@ type CmdEnvironment struct {
 
 // The cmdXXX functions implement the various commands.
 
-func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
+func cmdAddRaw(opts *Options, env CmdEnvironment) (*build.File, error) {
 	attr := env.Args[0]
 	for _, val := range env.Args[1:] {
-		if IsIntList(attr) {
-			AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.Ident{Name: val}, &env.Vars)
-			continue
-		}
+		AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.Ident{Name: val}, &env.Vars)
+	}
+	return env.File, nil
+}
+
+func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
+	attr := env.Args[0]
+	if IsIntList(attr) {
+		return cmdAddRaw(opts, env)
+	}
+	for _, val := range env.Args[1:] {
 		strVal := &build.StringExpr{Value: ShortenLabel(val, env.Pkg)}
 		AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)
 	}
@@ -577,6 +584,7 @@ type CommandInfo struct {
 // of arguments.
 var AllCommands = map[string]CommandInfo{
 	"add":               {cmdAdd, true, 2, -1, "<attr> <value(s)>"},
+	"add_raw":           {cmdAddRaw, true, 2, -1, "<attr> <value(s)>"},
 	"new_load":          {cmdNewLoad, false, 1, -1, "<path> <[to=]from(s)>"},
 	"comment":           {cmdComment, true, 1, 3, "<attr>? <value>? <comment>"},
 	"print_comment":     {cmdPrintComment, true, 0, 2, "<attr>? <value>?"},

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -442,6 +442,21 @@ func ListFind(e build.Expr, item string, pkg string) *build.StringExpr {
 	return nil
 }
 
+// ListFindIdent looks for an identifier with the name given in `item` in the
+// list expression `e` (which may be a concatenation of lists). It returns the
+// first matching element if it is found. nil otherwise.
+func ListFindIdent(e build.Expr, item string) *build.Ident {
+	for _, li := range AllLists(e) {
+		for _, elem := range li.List {
+			ident, ok := elem.(*build.Ident)
+			if ok && ident.Name == item {
+				return ident
+			}
+		}
+	}
+	return nil
+}
+
 // hasComments returns whether the StringExpr literal has a comment attached to it.
 func hasComments(literal *build.StringExpr) bool {
 	return len(literal.Before) > 0 || len(literal.Suffix) > 0
@@ -615,7 +630,12 @@ func AddValueToList(oldList build.Expr, pkg string, item build.Expr, sorted bool
 
 	str, ok := item.(*build.StringExpr)
 	if ok && ListFind(oldList, str.Value, pkg) != nil {
-		// The value is already in the list.
+		// The string value is already in the list.
+		return oldList
+	}
+	ident, ok := item.(*build.Ident)
+	if ok && ListFindIdent(oldList, ident.Name) != nil {
+		// The identifier value is already in the list.
 		return oldList
 	}
 	li := FirstList(oldList)

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -153,7 +153,7 @@ load("other loc", "symbol")`,
 	}
 }
 
-func TestAddValueToListAttribute(t *testing.T) {
+func TestAddValueToListAttributeString(t *testing.T) {
 	tests := []struct{ input, expected string }{
 		{`rule(name="rule")`, `rule(name="rule", attr=["foo"])`},
 		{`rule(name="rule", attr=["foo"])`, `rule(name="rule", attr=["foo"])`},
@@ -172,6 +172,39 @@ func TestAddValueToListAttribute(t *testing.T) {
 		}
 		rule := bld.RuleAt(1)
 		AddValueToListAttribute(rule, "attr", "", &build.StringExpr{Value: "foo"}, nil)
+		got := strings.TrimSpace(string(build.Format(bld)))
+
+		wantBld, err := build.Parse("BUILD", []byte(tst.expected))
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		want := strings.TrimSpace(string(build.Format(wantBld)))
+		if got != want {
+			t.Errorf("AddValueToListAttribute(%s): got %s, expected %s", tst.input, got, want)
+		}
+	}
+}
+
+func TestAddValueToListAttributeIdent(t *testing.T) {
+	tests := []struct{ input, expected string }{
+		{`rule(name="rule")`, `rule(name="rule", attr=[foo])`},
+		{`rule(name="rule", attr=[foo])`, `rule(name="rule", attr=[foo])`},
+		{`rule(name="rule", attr=IDENT)`, `rule(name="rule", attr=IDENT+[foo])`},
+		{`rule(name="rule", attr=[foo] + IDENT)`, `rule(name="rule", attr=[foo] + IDENT)`},
+		{`rule(name="rule", attr=[bar] + IDENT)`, `rule(name="rule", attr=[bar, foo] + IDENT)`},
+		{`rule(name="rule", attr=IDENT + [foo])`, `rule(name="rule", attr=IDENT + [foo])`},
+		{`rule(name="rule", attr=IDENT + [bar])`, `rule(name="rule", attr=IDENT + [bar, foo])`},
+	}
+
+	for _, tst := range tests {
+		bld, err := build.Parse("BUILD", []byte(tst.input))
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		rule := bld.RuleAt(1)
+		AddValueToListAttribute(rule, "attr", "", &build.Ident{Name: "foo"}, nil)
 		got := strings.TrimSpace(string(build.Format(bld)))
 
 		wantBld, err := build.Parse("BUILD", []byte(tst.expected))


### PR DESCRIPTION
Resolves: #565

Some of the build-rule functions used within Facebook are higher-order functions that accept lists of parameters which are not basic strings. This change to buildozer allows me to programmatically insert new values of this type into those rules without introducing duplicates.