### PR TITLE
Set inputType to default for stdin

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -107,7 +107,7 @@ func ParseDefault(filename string, data []byte) (*File, error) {
 
 func getFileType(filename string) FileType {
 	if filename == "" { // stdin
-		return TypeBuild // For compatibility
+		return TypeDefault
 	}
 	basename := strings.ToLower(filepath.Base(filename))
 	ext := filepath.Ext(basename)

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -39,7 +39,7 @@ EOF
 
 diff test/build test/BUILD.golden
 diff test/test.bzl test/test.bzl.golden
-diff stdout test/BUILD.golden  # should use the build formatting mode by default
+diff stdout test/test.bzl
 
 diff test/test.bzl.out test/test.bzl.golden
 


### PR DESCRIPTION
In the case the user doesn't pass a specific inputType for files passed
with stdin we now change the inputType to default

Fixes https://github.com/bazelbuild/buildtools/issues/568