### PR TITLE
buildozer: Better handle Bazel's "glob" helper function

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -675,8 +675,8 @@ func SplitOnSpaces(input string) []string {
 // HealGlobIfPresent takes the output from SplitOnSpaces, which naively splits
 // Bazel's glob function, and rejoins tokens together to reconnect the glob function parts
 func HealGlobIfPresent(tokens []string) []string {
-	matchGlobStart := func(x string) bool { return strings.HasPrefix(x, "glob("); }
-	matchGlobEnd := func(x string) bool { return strings.HasSuffix(x, ")"); }
+	matchGlobStart := func(x string) bool { return strings.HasPrefix(x, "glob(") }
+	matchGlobEnd := func(x string) bool { return strings.HasSuffix(x, ")") }
 
 	newTokens := tokens[:0]
 	healedGlobStr := new(bytes.Buffer)

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -424,7 +424,7 @@ func getAttrValueExpr(attr string, args []string, env CmdEnvironment) build.Expr
 			list = append(list, &build.Ident{Name: i})
 		}
 		return &build.ListExpr{List: list}
-	case IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")):
+	case IsList(attr) && !IsGlob(args):
 		var list []build.Expr
 		for _, arg := range args {
 			list = append(list, &build.StringExpr{Value: ShortenLabel(arg, env.Pkg)})

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -426,8 +426,8 @@ func getAttrValueExpr(attr string, args []string, env CmdEnvironment) build.Expr
 		return &build.ListExpr{List: list}
 	case IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")):
 		var list []build.Expr
-		for _, i := range args {
-			list = append(list, &build.StringExpr{Value: ShortenLabel(i, env.Pkg)})
+		for _, arg := range args {
+			list = append(list, &build.StringExpr{Value: ShortenLabel(arg, env.Pkg)})
 		}
 		return &build.ListExpr{List: list}
 	case IsString(attr):

--- a/edit/types.go
+++ b/edit/types.go
@@ -18,6 +18,7 @@ import (
 	buildpb "github.com/bazelbuild/buildtools/build_proto"
 	"github.com/bazelbuild/buildtools/lang"
 	"github.com/bazelbuild/buildtools/tables"
+	"strings"
 )
 
 var typeOf = lang.TypeOf
@@ -59,6 +60,11 @@ func IsString(attr string) bool {
 // IsStringDict returns true for all attributes whose type is a string dictionary.
 func IsStringDict(attr string) bool {
 	return typeOf[attr] == buildpb.Attribute_STRING_DICT
+}
+
+// IsGlob returns true for all args lists whose type is a file glob
+func IsGlob(args []string) bool {
+	return len(args) == 1 && strings.HasPrefix(args[0], "glob(")
 }
 
 // ContainsLabels returns true for all attributes whose type is a label or a label list.


### PR DESCRIPTION
PR https://github.com/bazelbuild/buildtools/pull/100 allowed for setting basic `glob(...)`s with the `set` command, but I experienced a failure when attempting to set a more complex example that is close to the full function signature:  

```python
glob(include, exclude=[], exclude_directories=1)
```

The spaces in the function cause the program to produce undesired behaviour. Problems begin when `SplitOnSpaces(arg)` is done. 

The solution in this PR is not great, but it at least improves `buildozer`'s handling of glob. 

