### PR TITLE
Fix out-of-order-load warnings

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -172,6 +172,10 @@ func DisabledWarning(f *build.File, finding *Finding, warning string) bool {
 // FileWarnings returns a list of all warnings found in the file.
 func FileWarnings(f *build.File, pkg string, enabledWarnings []string, fix bool) []*Finding {
 	findings := []*Finding{}
+
+	// Sort the warnings to make sure they're applied in the same determined order
+	sort.Strings(enabledWarnings)
+
 	for _, warn := range enabledWarnings {
 		if fct, ok := FileWarningMap[warn]; ok {
 			for _, w := range fct(f, fix) {

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -162,6 +162,9 @@ func compareLoadLabels(load1Label, load2Label string) bool {
 	return isExplicitRepo1
 }
 
+// outOfOrderLoadWarning only sorts consequent chunks of load statements. If applied together with
+// loadOnTopWarning, should be applied after it. This is currently guaranteed by sorting the
+// warning categories names before applying them ("load-on-top" < "out-of-order-load")
 func outOfOrderLoadWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -130,7 +130,7 @@ func loadOnTopWarning(f *build.File, fix bool) []*Finding {
 // If the packages are the same, labels are sorted by their name
 func compareLoadLabels(load1Label, load2Label string) bool {
 	// handle absolute labels with explicit repositories separately to
-	// make sure they preceed absolute and relative labels without repos
+	// make sure they precede absolute and relative labels without repos
 	isExplicitRepo1 := strings.HasPrefix(load1Label, "@")
 	isExplicitRepo2 := strings.HasPrefix(load2Label, "@")
 

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -124,80 +124,101 @@ func loadOnTopWarning(f *build.File, fix bool) []*Finding {
 	return findings
 }
 
+// compareLoadLabels compares two module names
+func compareLoadLabels(load1Label, load2Label string) bool {
+	// handle absolute labels with explicit repositories separately to
+	// make sure they preceed absolute and relative labels without repos
+	isExplicitRepo1 := strings.HasPrefix(load1Label, "@")
+	isExplicitRepo2 := strings.HasPrefix(load2Label, "@")
+	if isExplicitRepo1 == isExplicitRepo2 {
+		// Either both labels have explicit repository names or both don't, compare their packages
+		// and break ties using file names if necessary
+
+		module1Parts := strings.SplitN(strings.TrimLeft(load1Label, "@"), ":", 2)
+		package1, filename1 := "", module1Parts[0]
+		if len(module1Parts) == 2 {
+			package1, filename1 = module1Parts[0], module1Parts[1]
+		}
+		module2Parts := strings.SplitN(strings.TrimLeft(load2Label, "@"), ":", 2)
+		package2, filename2 := "", module2Parts[0]
+		if len(module2Parts) == 2 {
+			package2, filename2 = module2Parts[0], module2Parts[1]
+		}
+
+		// in case both packages are the same, use file names to break ties
+		if package1 == package2 {
+			return filename1 < filename2
+		}
+
+		// in case one of the packages is empty, the empty one goes first
+		if len(package1) == 0 || len(package2) == 0 {
+			return len(package1) > 0
+		}
+
+		// both packages are non-empty and not equal, so compare them
+		return package1 < package2
+	}
+	// Exactly one label has an explicit repository name, it should be the first one.
+	return isExplicitRepo1
+}
+
 func outOfOrderLoadWarning(f *build.File, fix bool) []*Finding {
 	findings := []*Finding{}
 
-	if f.Type == build.TypeWorkspace {
-		// Not applicable for WORKSPACE files
-		return findings
-	}
+	// Consequent chunks of load statements (i.e. without statements of other types between them)
+	loadsChunks := [][]*build.LoadStmt{}
+	lastLoadIndex := -2
 
-	// compareLoadLabels compares two module names
-	compareLoadLabels := func(load1Label, load2Label string) bool {
-		// handle absolute labels with explicit repositories separately to
-		// make sure they preceed absolute and relative labels without repos
-		isExplicitRepo1 := strings.HasPrefix(load1Label, "@")
-		isExplicitRepo2 := strings.HasPrefix(load2Label, "@")
-		if isExplicitRepo1 == isExplicitRepo2 {
-			// Either both labels have explicit repository names or both don't, compare their packages
-			// and break ties using file names if necessary
-
-			module1Parts := strings.SplitN(strings.TrimLeft(load1Label, "@"), ":", 2)
-			package1, filename1 := "", module1Parts[0]
-			if len(module1Parts) == 2 {
-				package1, filename1 = module1Parts[0], module1Parts[1]
-			}
-			module2Parts := strings.SplitN(strings.TrimLeft(load2Label, "@"), ":", 2)
-			package2, filename2 := "", module2Parts[0]
-			if len(module2Parts) == 2 {
-				package2, filename2 = module2Parts[0], module2Parts[1]
-			}
-
-			// in case both packages are the same, use file names to break ties
-			if package1 == package2 {
-				return filename1 < filename2
-			}
-
-			// in case one of the packages is empty, the empty one goes first
-			if len(package1) == 0 || len(package2) == 0 {
-				return len(package1) > 0
-			}
-
-			// both packages are non-empty and not equal, so compare them
-			return package1 < package2
-		}
-		// Exactly one label has an explicit repository name, it should be the first one.
-		return isExplicitRepo1
-	}
-
-	sortedLoads := []*build.LoadStmt{}
 	for i := 0; i < len(f.Stmt); i++ {
 		load, ok := f.Stmt[i].(*build.LoadStmt)
 		if !ok {
 			continue
 		}
-		sortedLoads = append(sortedLoads, load)
+		if i-lastLoadIndex > 1 {
+			// There's a non-load statement between this load and the previous load
+			loadsChunks = append(loadsChunks, []*build.LoadStmt{})
+		}
+		loadsChunks[len(loadsChunks)-1] = append(loadsChunks[len(loadsChunks)-1], load)
+		lastLoadIndex = i
 	}
+
 	if fix {
-		sort.SliceStable(sortedLoads, func(i, j int) bool {
-			load1Label := sortedLoads[i].Module.Value
-			load2Label := sortedLoads[j].Module.Value
-			return compareLoadLabels(load1Label, load2Label)
-		})
-		sortedLoadIndex := 0
-		for globalLoadIndex := 0; globalLoadIndex < len(f.Stmt); globalLoadIndex++ {
-			if _, ok := f.Stmt[globalLoadIndex].(*build.LoadStmt); !ok {
+		// Sort the chunks
+		for i, chunk := range loadsChunks {
+			sort.SliceStable(chunk, func(i, j int) bool {
+				load1Label := (chunk)[i].Module.Value
+				load2Label := (chunk)[j].Module.Value
+				return compareLoadLabels(load1Label, load2Label)
+			})
+			loadsChunks[i] = chunk
+		}
+
+		// Flatten the chunks
+		sortedLoads := []*build.LoadStmt{}
+		for _, chunk := range loadsChunks {
+			for _, load := range chunk {
+				sortedLoads = append(sortedLoads, load)
+			}
+		}
+
+		loadIndex := 0
+		for stmtIndex := range f.Stmt {
+			if _, ok := f.Stmt[stmtIndex].(*build.LoadStmt); !ok {
 				continue
 			}
-			f.Stmt[globalLoadIndex] = sortedLoads[sortedLoadIndex]
-			sortedLoadIndex++
+			f.Stmt[stmtIndex] = sortedLoads[loadIndex]
+			loadIndex++
 		}
 		return findings
 	}
 
-	for i := 1; i < len(sortedLoads); i++ {
-		if compareLoadLabels(sortedLoads[i].Module.Value, sortedLoads[i-1].Module.Value) {
-			start, end := sortedLoads[i].Span()
+	for _, chunk := range loadsChunks {
+		for i, load := range chunk {
+			if i == 0 || !compareLoadLabels(chunk[i].Module.Value, chunk[i-1].Module.Value) {
+				// Correct position
+				continue
+			}
+			start, end := load.Span()
 			findings = append(findings, makeFinding(f, start, end, "out-of-order-load",
 				"Load statement is out of its lexicographical order.", true, nil))
 		}

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -159,17 +159,20 @@ func TestOutOfOrderLoad(t *testing.T) {
 # b comment
 load(":b.bzl", "b")
 b += 2
-# a comment
+# c comment
+load(":c.bzl", "c")
 load(":a.bzl", "a")
-a + b`, `
-# a comment
-load(":a.bzl", "a")
-b += 2
+a + b + c`, `
 # b comment
 load(":b.bzl", "b")
-a + b`,
-		[]string{":5: Load statement is out of its lexicographical order."},
-		scopeBuild|scopeBzl|scopeDefault)
+b += 2
+load(":a.bzl", "a")
+
+# c comment
+load(":c.bzl", "c")
+a + b + c`,
+		[]string{":6: Load statement is out of its lexicographical order."},
+		scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 # b comment
@@ -187,7 +190,7 @@ load(":b.bzl", "b")
 load(":c.bzl", "c")
 a + b + c`,
 		[]string{":6: Load statement is out of its lexicographical order."},
-		scopeBuild|scopeBzl|scopeDefault)
+		scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 load(":a.bzl", "a")
@@ -207,7 +210,7 @@ load(":b.bzl", "b")
 			":2: Load statement is out of its lexicographical order.",
 			":3: Load statement is out of its lexicographical order.",
 			":6: Load statement is out of its lexicographical order.",
-		}, scopeBuild|scopeBzl|scopeDefault)
+		}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 load(":a.bzl", "a")
@@ -215,7 +218,7 @@ load(":a.bzl", "a")
 `, `
 load(":a.bzl", "a")
 load(":a.bzl", "a")`,
-		[]string{}, scopeBuild|scopeBzl|scopeDefault)
+		[]string{}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 load("//foo:xyz.bzl", "xyz")
@@ -223,7 +226,7 @@ load("//foo/bar:mno.bzl", "mno")
 `, `
 load("//foo:xyz.bzl", "xyz")
 load("//foo/bar:mno.bzl", "mno")`,
-		[]string{}, scopeBuild|scopeBzl|scopeDefault)
+		[]string{}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 load("//foo:xyz.bzl", "xyz")
@@ -231,7 +234,7 @@ load("//foo2:mno.bzl", "mno")
 `, `
 load("//foo:xyz.bzl", "xyz")
 load("//foo2:mno.bzl", "mno")`,
-		[]string{}, scopeBuild|scopeBzl|scopeDefault)
+		[]string{}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 load("//foo:b.bzl", "b")
@@ -241,7 +244,7 @@ load("//foo:a.bzl", "a")
 load("//foo:b.bzl", "b")`,
 		[]string{
 			":2: Load statement is out of its lexicographical order.",
-		}, scopeBuild|scopeBzl|scopeDefault)
+		}, scopeEverywhere)
 }
 
 func TestUnsortedDictItems(t *testing.T) {


### PR DESCRIPTION
If buildifier applies `out-of-order-load` without applying `load-on-top` (either because of the flags or because "load-on-top" is not enabled for BUILD files), it may occur that there are other statements between load statements that depend on the first load, and swapping the loads lead to a breaking change:

    load(":b.bzl", "b")
    b()
    load(":a.bzl", "a")

With this update buildifier only sorts consequent chunks of load statements (i.e. load statements without other statements between them). Comments between the load statements are fine as long as they belong to one of the load statements, the following will be sorted:

    load(":b.bzl", "b")
    # after-comment for b
    
    # before-comment for a
    load(":a.bzl", "a")

The following will not be sorted:

    load(":b.bzl", "b")

    # standalone comment

    load(":a.bzl", "a")

Fixed #575 