### PR TITLE
Find relevant Starlark files recursively in directories

### DIFF
--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -27,7 +27,10 @@ sh_test(
 
 go_library(
     name = "go_default_library",
-    srcs = ["buildifier.go"],
+    srcs = [
+      "buildifier.go",
+      "utils.go",
+    ],
     importpath = "github.com/bazelbuild/buildtools/buildifier",
     visibility = ["//visibility:private"],
     deps = [

--- a/buildifier/README.md
+++ b/buildifier/README.md
@@ -19,6 +19,13 @@ same way that clang-format is used for source files.
 
 You can also process multiple files at once:
 
+    $ buildifier path/to/file1 path/to/file2
+
+You can make buildifier automatically find all Starlark files (i.e. BUILD, WORKSPACE, .bzl, or .sky)
+in a directory recursively:
+
+    $ buildifier -r path/to/dir
+
 Buildifier automatically detects the file type (either BUILD or .bzl) by its filename. If you 
 
     $ buildifier $(find . -type f \( -iname BUILD -or -iname BUILD.bazel \))

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -70,7 +70,7 @@ func stringList(name, help string) func() []string {
 }
 
 func usage() {
-	fmt.Fprintf(flag.CommandLine.Output(), `usage: buildifier [-d] [-v] [-diff_command=command] [-help] [-multi_diff] [-mode=mode] [-lint=lint_mode] [-path=path] [files...]
+	fmt.Fprintf(flag.CommandLine.Output(), `usage: buildifier [-d] [-v] [-r] [-diff_command=command] [-help] [-multi_diff] [-mode=mode] [-lint=lint_mode] [-path=path] [files...]
 
 Buildifier applies standard formatting to the named Starlark files.  The mode
 flag selects the processing: check, diff, fix, or print_if_changed.  In check

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -266,7 +266,7 @@ func main() {
 			files, err = ExpandDirectories(args)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
-				os.Exit(1)
+				os.Exit(3)
 			}
 		}
 		processFiles(files, *inputType, *lint, warningsList)

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -292,6 +292,13 @@ func processFiles(files []string, inputType, lint string, warningsList []string)
 		data []byte
 		err  error
 	}
+
+	files, err := expandDirectories(files)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
+		os.Exit(1)
+	}
+
 	ch := make([]chan result, nworker)
 	for i := 0; i < nworker; i++ {
 		ch[i] = make(chan result, 1)

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -45,6 +45,7 @@ var (
 	help          = flag.Bool("help", false, "print usage information")
 	vflag         = flag.Bool("v", false, "print verbose information to standard error")
 	dflag         = flag.Bool("d", false, "alias for -mode=diff")
+	rflag         = flag.Bool("r", false, "find starlark files recursively")
 	mode          = flag.String("mode", "", "formatting mode: check, diff, or fix (default fix)")
 	diffProgram   = flag.String("diff_command", "", "command to run when the formatting mode is diff (default uses the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables to create the diff command)")
 	multiDiff     = flag.Bool("multi_diff", false, "the command specified by the -diff_command flag can diff multiple files in the style of tkdiff (default false)")
@@ -259,10 +260,14 @@ func main() {
 		}
 		processFile("", data, *inputType, *lint, warningsList, false)
 	} else {
-		files, err := expandDirectories(args)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
-			os.Exit(1)
+		files := args
+		if (*rflag) {
+			var err error
+			files, err = ExpandDirectories(args)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
+				os.Exit(1)
+			}
 		}
 		processFiles(files, *inputType, *lint, warningsList)
 	}

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -259,7 +259,12 @@ func main() {
 		}
 		processFile("", data, *inputType, *lint, warningsList, false)
 	} else {
-		processFiles(args, *inputType, *lint, warningsList)
+		files, err := expandDirectories(args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
+			os.Exit(1)
+		}
+		processFiles(files, *inputType, *lint, warningsList)
 	}
 
 	if err := diff.Run(); err != nil {
@@ -291,12 +296,6 @@ func processFiles(files []string, inputType, lint string, warningsList []string)
 		file string
 		data []byte
 		err  error
-	}
-
-	files, err := expandDirectories(files)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
-		os.Exit(1)
 	}
 
 	ch := make([]chan result, nworker)

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -8,21 +8,24 @@ die () {
 buildifier=$1
 buildifier2=$2
 
-mkdir test
-mkdir test/subdir
+mkdir testdir
+mkdir testdir/subdir
 mkdir golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
-echo -e "$INPUT" > test/build  # case doesn't matter
-echo -e "$INPUT" > test/test.bzl
-echo -e "$INPUT" > test/subdir/test.bzl
-echo -e "$INPUT" > test.bzl  # outside the test directory
-echo -e "not valid +" > test/foo.bar
-cp test/foo.bar golden/foo.bar
+echo -e "$INPUT" > testdir/build  # case doesn't matter
+echo -e "$INPUT" > testdir/test.bzl
+echo -e "$INPUT" > testdir/subdir/test.bzl
+echo -e "$INPUT" > test.bzl  # outside the testdir directory
+echo -e "not valid +" > testdir/foo.bar
+cp testdir/foo.bar golden/foo.bar
 
-"$buildifier" < test/build > stdout
-"$buildifier" -r test
+"$buildifier" < testdir/build > stdout
+"$buildifier" -r testdir
 "$buildifier" test.bzl
-"$buildifier2" test/test.bzl > test/test.bzl.out
+"$buildifier2" testdir/test.bzl > testdir/test.bzl.out
+
+# directory without -r
+"$buildifier" testdir > directory_error 2>&1 || true
 
 cat > golden/BUILD.golden <<EOF
 load(":foo.bzl", "foo")
@@ -43,83 +46,86 @@ load(":foo.bzl", "foo")
 
 foo(tags = ["b", "a"], srcs = ["d", "c"])
 EOF
+cat > golden/directory_error <<EOF
+buildifier: read testdir: is a directory
+EOF
 
-diff test/build golden/BUILD.golden
-diff test/test.bzl golden/test.bzl.golden
-diff test/subdir/test.bzl golden/test.bzl.golden
-diff test/foo.bar golden/foo.bar
+diff testdir/build golden/BUILD.golden
+diff testdir/test.bzl golden/test.bzl.golden
+diff testdir/subdir/test.bzl golden/test.bzl.golden
+diff testdir/foo.bar golden/foo.bar
 diff test.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden
-
-diff test/test.bzl.out golden/test.bzl.golden
+diff testdir/test.bzl.out golden/test.bzl.golden
+diff directory_error golden/directory_error
 
 # Test the linter
 
-cat > test/to_fix.bzl <<EOF
+cat > testdir/to_fix.bzl <<EOF
 a = b / c
 d = {"b": 2, "a": 1}
 attr.foo(bar, cfg = "data")
 EOF
 
-cat > test/fixed_golden.bzl <<EOF
+cat > testdir/fixed_golden.bzl <<EOF
 a = b // c
 d = {"b": 2, "a": 1}
 attr.foo(bar)
 EOF
 
-cat > test/fixed_golden_all.bzl <<EOF
+cat > testdir/fixed_golden_all.bzl <<EOF
 a = b // c
 d = {"a": 1, "b": 2}
 attr.foo(bar)
 EOF
 
-cat > test/fixed_golden_dict_cfg.bzl <<EOF
+cat > testdir/fixed_golden_dict_cfg.bzl <<EOF
 a = b / c
 d = {"a": 1, "b": 2}
 attr.foo(bar)
 EOF
 
-cat > test/fixed_golden_cfg.bzl <<EOF
+cat > testdir/fixed_golden_cfg.bzl <<EOF
 a = b / c
 d = {"b": 2, "a": 1}
 attr.foo(bar)
 EOF
 
-cat > test/fix_report_golden <<EOF
-test/to_fix_tmp.bzl: applied fixes, 1 warnings left
-fixed test/to_fix_tmp.bzl
+cat > testdir/fix_report_golden <<EOF
+testdir/to_fix_tmp.bzl: applied fixes, 1 warnings left
+fixed testdir/to_fix_tmp.bzl
 EOF
 
-error_docstring="test/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
-error_integer="test/to_fix_tmp.bzl:1: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
-error_dict="test/to_fix_tmp.bzl:2: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
-error_cfg="test/to_fix_tmp.bzl:3: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"
+error_docstring="testdir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
+error_integer="testdir/to_fix_tmp.bzl:1: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
+error_dict="testdir/to_fix_tmp.bzl:2: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
+error_cfg="testdir/to_fix_tmp.bzl:3: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"
 
 test_lint () {
   ret=0
-  cp test/to_fix.bzl test/to_fix_tmp.bzl
+  cp testdir/to_fix.bzl testdir/to_fix_tmp.bzl
   echo "$4" > golden/error_golden
 
   cat > golden/fix_report_golden <<EOF
-test/to_fix_tmp.bzl: applied fixes, $5 warnings left
-fixed test/to_fix_tmp.bzl
+testdir/to_fix_tmp.bzl: applied fixes, $5 warnings left
+fixed testdir/to_fix_tmp.bzl
 EOF
 
-  $buildifier --lint=warn $2 test/to_fix_tmp.bzl 2> test/error || ret=$?
+  $buildifier --lint=warn $2 testdir/to_fix_tmp.bzl 2> testdir/error || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
   fi
-  diff test/error golden/error_golden || die "$1: wrong console output for --lint=warn"
+  diff testdir/error golden/error_golden || die "$1: wrong console output for --lint=warn"
 
-  $buildifier --lint=fix $2 -v test/to_fix_tmp.bzl 2> test/fix_report || ret=$?
+  $buildifier --lint=fix $2 -v testdir/to_fix_tmp.bzl 2> testdir/fix_report || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: fix: Expected buildifier to exit with 4, actual: $ret"
   fi
-  diff test/to_fix_tmp.bzl $3 || die "$1: wrong file output for --lint=fix"
-  diff test/fix_report golden/fix_report_golden || die "$1: wrong console output for --lint=fix"
+  diff testdir/to_fix_tmp.bzl $3 || die "$1: wrong file output for --lint=fix"
+  diff testdir/fix_report golden/fix_report_golden || die "$1: wrong console output for --lint=fix"
 }
 
-test_lint "default" "" "test/fixed_golden.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_cfg" 1
-test_lint "all" "--warnings=all" "test/fixed_golden_all.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
-test_lint "cfg" "--warnings=attr-cfg" "test/fixed_golden_cfg.bzl" "$error_cfg" 0
-test_lint "custom" "--warnings=-integer-division,+unsorted-dict-items" "test/fixed_golden_dict_cfg.bzl" "$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
+test_lint "default" "" "testdir/fixed_golden.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_cfg" 1
+test_lint "all" "--warnings=all" "testdir/fixed_golden_all.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
+test_lint "cfg" "--warnings=attr-cfg" "testdir/fixed_golden_cfg.bzl" "$error_cfg" 0
+test_lint "custom" "--warnings=-integer-division,+unsorted-dict-items" "testdir/fixed_golden_dict_cfg.bzl" "$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -23,9 +23,6 @@ cp test_dir/foo.bar golden/foo.bar
 "$buildifier" test.bzl
 "$buildifier2" test_dir/test.bzl > test_dir/test.bzl.out
 
-# directory without -r
-"$buildifier" test_dir > directory_error 2>&1 || true
-
 cat > golden/BUILD.golden <<EOF
 load(":foo.bzl", "foo")
 
@@ -45,9 +42,6 @@ load(":foo.bzl", "foo")
 
 foo(tags = ["b", "a"], srcs = ["d", "c"])
 EOF
-cat > golden/directory_error <<EOF
-buildifier: read test_dir: is a directory
-EOF
 
 diff test_dir/build golden/BUILD.golden
 diff test_dir/test.bzl golden/test.bzl.golden
@@ -56,7 +50,12 @@ diff test_dir/foo.bar golden/foo.bar
 diff test.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden
 diff test_dir/test.bzl.out golden/test.bzl.golden
-diff directory_error golden/directory_error
+
+# Test run on a directory without -r
+"$buildifier" test_dir || ret=$?
+if [[ $ret -ne 3 ]]; then
+  die "Directory without -r: expected buildifier to exit with 3, actual: $ret"
+fi
 
 # Test the linter
 

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -8,24 +8,24 @@ die () {
 buildifier=$1
 buildifier2=$2
 
-mkdir testdir
-mkdir testdir/subdir
+mkdir test_dir
+mkdir test_dir/subdir
 mkdir golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
-echo -e "$INPUT" > testdir/build  # case doesn't matter
-echo -e "$INPUT" > testdir/test.bzl
-echo -e "$INPUT" > testdir/subdir/test.bzl
-echo -e "$INPUT" > test.bzl  # outside the testdir directory
-echo -e "not valid +" > testdir/foo.bar
-cp testdir/foo.bar golden/foo.bar
+echo -e "$INPUT" > test_dir/build  # case doesn't matter
+echo -e "$INPUT" > test_dir/test.bzl
+echo -e "$INPUT" > test_dir/subdir/test.bzl
+echo -e "$INPUT" > test.bzl  # outside the test_dir directory
+echo -e "not valid +" > test_dir/foo.bar
+cp test_dir/foo.bar golden/foo.bar
 
-"$buildifier" < testdir/build > stdout
-"$buildifier" -r testdir
+"$buildifier" < test_dir/build > stdout
+"$buildifier" -r test_dir
 "$buildifier" test.bzl
-"$buildifier2" testdir/test.bzl > testdir/test.bzl.out
+"$buildifier2" test_dir/test.bzl > test_dir/test.bzl.out
 
 # directory without -r
-"$buildifier" testdir > directory_error 2>&1 || true
+"$buildifier" test_dir > directory_error 2>&1 || true
 
 cat > golden/BUILD.golden <<EOF
 load(":foo.bzl", "foo")
@@ -47,85 +47,85 @@ load(":foo.bzl", "foo")
 foo(tags = ["b", "a"], srcs = ["d", "c"])
 EOF
 cat > golden/directory_error <<EOF
-buildifier: read testdir: is a directory
+buildifier: read test_dir: is a directory
 EOF
 
-diff testdir/build golden/BUILD.golden
-diff testdir/test.bzl golden/test.bzl.golden
-diff testdir/subdir/test.bzl golden/test.bzl.golden
-diff testdir/foo.bar golden/foo.bar
+diff test_dir/build golden/BUILD.golden
+diff test_dir/test.bzl golden/test.bzl.golden
+diff test_dir/subdir/test.bzl golden/test.bzl.golden
+diff test_dir/foo.bar golden/foo.bar
 diff test.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden
-diff testdir/test.bzl.out golden/test.bzl.golden
+diff test_dir/test.bzl.out golden/test.bzl.golden
 diff directory_error golden/directory_error
 
 # Test the linter
 
-cat > testdir/to_fix.bzl <<EOF
+cat > test_dir/to_fix.bzl <<EOF
 a = b / c
 d = {"b": 2, "a": 1}
 attr.foo(bar, cfg = "data")
 EOF
 
-cat > testdir/fixed_golden.bzl <<EOF
+cat > test_dir/fixed_golden.bzl <<EOF
 a = b // c
 d = {"b": 2, "a": 1}
 attr.foo(bar)
 EOF
 
-cat > testdir/fixed_golden_all.bzl <<EOF
+cat > test_dir/fixed_golden_all.bzl <<EOF
 a = b // c
 d = {"a": 1, "b": 2}
 attr.foo(bar)
 EOF
 
-cat > testdir/fixed_golden_dict_cfg.bzl <<EOF
+cat > test_dir/fixed_golden_dict_cfg.bzl <<EOF
 a = b / c
 d = {"a": 1, "b": 2}
 attr.foo(bar)
 EOF
 
-cat > testdir/fixed_golden_cfg.bzl <<EOF
+cat > test_dir/fixed_golden_cfg.bzl <<EOF
 a = b / c
 d = {"b": 2, "a": 1}
 attr.foo(bar)
 EOF
 
-cat > testdir/fix_report_golden <<EOF
-testdir/to_fix_tmp.bzl: applied fixes, 1 warnings left
-fixed testdir/to_fix_tmp.bzl
+cat > test_dir/fix_report_golden <<EOF
+test_dir/to_fix_tmp.bzl: applied fixes, 1 warnings left
+fixed test_dir/to_fix_tmp.bzl
 EOF
 
-error_docstring="testdir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
-error_integer="testdir/to_fix_tmp.bzl:1: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
-error_dict="testdir/to_fix_tmp.bzl:2: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
-error_cfg="testdir/to_fix_tmp.bzl:3: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"
+error_docstring="test_dir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
+error_integer="test_dir/to_fix_tmp.bzl:1: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
+error_dict="test_dir/to_fix_tmp.bzl:2: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
+error_cfg="test_dir/to_fix_tmp.bzl:3: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"
 
 test_lint () {
   ret=0
-  cp testdir/to_fix.bzl testdir/to_fix_tmp.bzl
+  cp test_dir/to_fix.bzl test_dir/to_fix_tmp.bzl
   echo "$4" > golden/error_golden
 
   cat > golden/fix_report_golden <<EOF
-testdir/to_fix_tmp.bzl: applied fixes, $5 warnings left
-fixed testdir/to_fix_tmp.bzl
+test_dir/to_fix_tmp.bzl: applied fixes, $5 warnings left
+fixed test_dir/to_fix_tmp.bzl
 EOF
 
-  $buildifier --lint=warn $2 testdir/to_fix_tmp.bzl 2> testdir/error || ret=$?
+  $buildifier --lint=warn $2 test_dir/to_fix_tmp.bzl 2> test_dir/error || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
   fi
-  diff testdir/error golden/error_golden || die "$1: wrong console output for --lint=warn"
+  diff test_dir/error golden/error_golden || die "$1: wrong console output for --lint=warn"
 
-  $buildifier --lint=fix $2 -v testdir/to_fix_tmp.bzl 2> testdir/fix_report || ret=$?
+  $buildifier --lint=fix $2 -v test_dir/to_fix_tmp.bzl 2> test_dir/fix_report || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: fix: Expected buildifier to exit with 4, actual: $ret"
   fi
-  diff testdir/to_fix_tmp.bzl $3 || die "$1: wrong file output for --lint=fix"
-  diff testdir/fix_report golden/fix_report_golden || die "$1: wrong console output for --lint=fix"
+  diff test_dir/to_fix_tmp.bzl $3 || die "$1: wrong file output for --lint=fix"
+  diff test_dir/fix_report golden/fix_report_golden || die "$1: wrong console output for --lint=fix"
 }
 
-test_lint "default" "" "testdir/fixed_golden.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_cfg" 1
-test_lint "all" "--warnings=all" "testdir/fixed_golden_all.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
-test_lint "cfg" "--warnings=attr-cfg" "testdir/fixed_golden_cfg.bzl" "$error_cfg" 0
-test_lint "custom" "--warnings=-integer-division,+unsorted-dict-items" "testdir/fixed_golden_dict_cfg.bzl" "$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
+test_lint "default" "" "test_dir/fixed_golden.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_cfg" 1
+test_lint "all" "--warnings=all" "test_dir/fixed_golden_all.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
+test_lint "cfg" "--warnings=attr-cfg" "test_dir/fixed_golden_cfg.bzl" "$error_cfg" 0
+test_lint "custom" "--warnings=-integer-division,+unsorted-dict-items" "test_dir/fixed_golden_dict_cfg.bzl" "$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -8,8 +8,7 @@ die () {
 buildifier=$1
 buildifier2=$2
 
-mkdir test_dir
-mkdir test_dir/subdir
+mkdir -p test_dir/subdir
 mkdir golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
 echo -e "$INPUT" > test_dir/build  # case doesn't matter

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -15,11 +15,13 @@ INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatt
 echo -e "$INPUT" > test/build  # case doesn't matter
 echo -e "$INPUT" > test/test.bzl
 echo -e "$INPUT" > test/subdir/test.bzl
+echo -e "$INPUT" > test.bzl  # outside the test directory
 echo -e "not valid +" > test/foo.bar
 cp test/foo.bar golden/foo.bar
 
 "$buildifier" < test/build > stdout
-"$buildifier" test
+"$buildifier" -r test
+"$buildifier" test.bzl
 "$buildifier2" test/test.bzl > test/test.bzl.out
 
 cat > golden/BUILD.golden <<EOF
@@ -46,6 +48,7 @@ diff test/build golden/BUILD.golden
 diff test/test.bzl golden/test.bzl.golden
 diff test/subdir/test.bzl golden/test.bzl.golden
 diff test/foo.bar golden/foo.bar
+diff test.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden
 
 diff test/test.bzl.out golden/test.bzl.golden

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -9,15 +9,20 @@ buildifier=$1
 buildifier2=$2
 
 mkdir test
+mkdir test/subdir
+mkdir golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
 echo -e "$INPUT" > test/build  # case doesn't matter
 echo -e "$INPUT" > test/test.bzl
+echo -e "$INPUT" > test/subdir/test.bzl
+echo -e "not valid +" > test/foo.bar
+cp test/foo.bar golden/foo.bar
 
 "$buildifier" < test/build > stdout
-"$buildifier" test/*
+"$buildifier" test
 "$buildifier2" test/test.bzl > test/test.bzl.out
 
-cat > test/BUILD.golden <<EOF
+cat > golden/BUILD.golden <<EOF
 load(":foo.bzl", "foo")
 
 foo(
@@ -31,17 +36,19 @@ foo(
     ],
 )
 EOF
-cat > test/test.bzl.golden <<EOF
+cat > golden/test.bzl.golden <<EOF
 load(":foo.bzl", "foo")
 
 foo(tags = ["b", "a"], srcs = ["d", "c"])
 EOF
 
-diff test/build test/BUILD.golden
-diff test/test.bzl test/test.bzl.golden
-diff stdout test/test.bzl
+diff test/build golden/BUILD.golden
+diff test/test.bzl golden/test.bzl.golden
+diff test/subdir/test.bzl golden/test.bzl.golden
+diff test/foo.bar golden/foo.bar
+diff stdout golden/test.bzl.golden
 
-diff test/test.bzl.out test/test.bzl.golden
+diff test/test.bzl.out golden/test.bzl.golden
 
 # Test the linter
 
@@ -88,9 +95,9 @@ error_cfg="test/to_fix_tmp.bzl:3: attr-cfg: cfg = \"data\" for attr definitions 
 test_lint () {
   ret=0
   cp test/to_fix.bzl test/to_fix_tmp.bzl
-  echo "$4" > test/error_golden
+  echo "$4" > golden/error_golden
 
-  cat > test/fix_report_golden <<EOF
+  cat > golden/fix_report_golden <<EOF
 test/to_fix_tmp.bzl: applied fixes, $5 warnings left
 fixed test/to_fix_tmp.bzl
 EOF
@@ -99,14 +106,14 @@ EOF
   if [[ $ret -ne 4 ]]; then
     die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
   fi
-  diff test/error test/error_golden || die "$1: wrong console output for --lint=warn"
+  diff test/error golden/error_golden || die "$1: wrong console output for --lint=warn"
 
   $buildifier --lint=fix $2 -v test/to_fix_tmp.bzl 2> test/fix_report || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: fix: Expected buildifier to exit with 4, actual: $ret"
   fi
   diff test/to_fix_tmp.bzl $3 || die "$1: wrong file output for --lint=fix"
-  diff test/fix_report test/fix_report_golden || die "$1: wrong console output for --lint=fix"
+  diff test/fix_report golden/fix_report_golden || die "$1: wrong console output for --lint=fix"
 }
 
 test_lint "default" "" "test/fixed_golden.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_cfg" 1

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -9,7 +9,7 @@ buildifier=$1
 buildifier2=$2
 
 mkdir -p test_dir/subdir
-mkdir golden
+mkdir -p golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
 echo -e "$INPUT" > test_dir/build  # case doesn't matter
 echo -e "$INPUT" > test_dir/test.bzl

--- a/buildifier/utils.go
+++ b/buildifier/utils.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func isStarlarkFile(filename string) bool {
+	basename := strings.ToLower(filepath.Base(filename))
+	ext := filepath.Ext(basename)
+	switch ext {
+	case ".bzl", ".sky":
+		return true
+	}
+	base := basename[:len(basename)-len(ext)]
+	switch {
+	case ext == ".build" || base == "build":
+		return true
+	case ext == ".workspace" || base == "workspace":
+		return true
+	}
+	return false
+}
+
+func expandDirectories(args []string) ([]string, error) {
+	files := []string{}
+	for _, arg := range args {
+		info, err := os.Stat(arg)
+		if err != nil {
+			return []string{}, err
+		}
+		if !info.IsDir() {
+			files = append(files, arg)
+			continue
+		}
+		err = filepath.Walk(arg, func(path string, info os.FileInfo, err error) error {
+			if isStarlarkFile(path) {
+				files = append(files, path)
+			}
+			return err
+		})
+		if err != nil {
+			return []string{}, err
+		}
+	}
+	return files, nil
+}

--- a/buildifier/utils.go
+++ b/buildifier/utils.go
@@ -23,7 +23,7 @@ func isStarlarkFile(filename string) bool {
 	return false
 }
 
-func expandDirectories(args []string) ([]string, error) {
+func ExpandDirectories(args []string) ([]string, error) {
 	files := []string{}
 	for _, arg := range args {
 		info, err := os.Stat(arg)


### PR DESCRIPTION
If an argument to buildifier is not a file but a directory, recursively find all relevant Starlark files in it (i.e. with extensions `.bzl`, `.sky`, `.build`, or `.workspace`, or with names `build.*` or `workspace.*`, case insensitively).

Fixes #516.