### PR TITLE
Create a buildifier_utils package

### DIFF
--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -29,12 +29,12 @@ go_library(
     name = "go_default_library",
     srcs = [
       "buildifier.go",
-      "utils.go",
     ],
     importpath = "github.com/bazelbuild/buildtools/buildifier",
     visibility = ["//visibility:private"],
     deps = [
         "//build:go_default_library",
+        "//buildifier_utils:go_default_library",
         "//differ:go_default_library",
         "//tables:go_default_library",
         "//warn:go_default_library",

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/buildtools/buildifier_utils"
 	"github.com/bazelbuild/buildtools/differ"
 	"github.com/bazelbuild/buildtools/tables"
 	"github.com/bazelbuild/buildtools/warn"
@@ -261,9 +262,9 @@ func main() {
 		processFile("", data, *inputType, *lint, warningsList, false)
 	} else {
 		files := args
-		if (*rflag) {
+		if *rflag {
 			var err error
-			files, err = ExpandDirectories(args)
+			files, err = buildifier_utils.ExpandDirectories(args)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
 				os.Exit(3)
@@ -360,7 +361,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		}
 	}()
 
-	parser := getParser(inputType)
+	parser := buildifier_utils.GetParser(inputType)
 
 	f, err := parser(filename, data)
 	if err != nil {
@@ -486,21 +487,6 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 			exitCode = 3
 			return
 		}
-	}
-}
-
-func getParser(inputType string) func(filename string, data []byte) (*build.File, error) {
-	switch inputType {
-	case "build":
-		return build.ParseBuild
-	case "bzl":
-		return build.ParseBzl
-	case "auto":
-		return build.Parse
-	case "workspace":
-		return build.ParseWorkspace
-	default:
-		return build.ParseDefault
 	}
 }
 

--- a/buildifier_utils/BUILD.bazel
+++ b/buildifier_utils/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+      "utils.go",
+    ],
+    deps = [
+        "//build:go_default_library",
+    ],
+    importpath = "github.com/bazelbuild/buildtools/buildifier_utils",
+    visibility = ["//visibility:public"],
+)

--- a/buildifier_utils/utils.go
+++ b/buildifier_utils/utils.go
@@ -1,9 +1,11 @@
-package main
+package buildifier_utils
 
 import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/bazelbuild/buildtools/build"
 )
 
 func isStarlarkFile(filename string) bool {
@@ -47,4 +49,20 @@ func ExpandDirectories(args []string) ([]string, error) {
 		}
 	}
 	return files, nil
+}
+
+// GetParser returns a parser for a given file type
+func GetParser(inputType string) func(filename string, data []byte) (*build.File, error) {
+	switch inputType {
+	case "build":
+		return build.ParseBuild
+	case "bzl":
+		return build.ParseBzl
+	case "auto":
+		return build.Parse
+	case "workspace":
+		return build.ParseWorkspace
+	default:
+		return build.ParseDefault
+	}
 }


### PR DESCRIPTION
A separate package that can be used from different implementations of `buildifier.go` for shared logic.