### PR TITLE
Move buildifier_utils to buildifier/utils

### DIFF
--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -34,7 +34,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//build:go_default_library",
-        "//buildifier_utils:go_default_library",
+        "//buildifier/utils:go_default_library",
         "//differ:go_default_library",
         "//tables:go_default_library",
         "//warn:go_default_library",

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
-	"github.com/bazelbuild/buildtools/buildifier_utils"
+	"github.com/bazelbuild/buildtools/buildifier/utils"
 	"github.com/bazelbuild/buildtools/differ"
 	"github.com/bazelbuild/buildtools/tables"
 	"github.com/bazelbuild/buildtools/warn"
@@ -264,7 +264,7 @@ func main() {
 		files := args
 		if *rflag {
 			var err error
-			files, err = buildifier_utils.ExpandDirectories(args)
+			files, err = utils.ExpandDirectories(args)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
 				os.Exit(3)
@@ -361,7 +361,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		}
 	}()
 
-	parser := buildifier_utils.GetParser(inputType)
+	parser := utils.GetParser(inputType)
 
 	f, err := parser(filename, data)
 	if err != nil {

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
     deps = [
         "//build:go_default_library",
     ],
-    importpath = "github.com/bazelbuild/buildtools/buildifier_utils",
+    importpath = "github.com/bazelbuild/buildtools/buildifier/utils",
     visibility = ["//visibility:public"],
 )

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -1,4 +1,4 @@
-package buildifier_utils
+package utils
 
 import (
 	"os"

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -1,3 +1,5 @@
+// Package utils contains shared methods that can be used by different implementations of
+// buildifier binary
 package utils
 
 import (


### PR DESCRIPTION
This improves readability (a package-specific utils are now in a subpackage) as well as Go lint errors ("don't use an underscore in package name").