### PR TITLE
Allow --lint=warn to be combined with any value of --mode

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -129,92 +129,15 @@ func main() {
 	build.DisableRewrites = disable()
 	build.AllowSort = allowSort()
 
-	// Check input type.
-	switch *inputType {
-	case "build", "bzl", "workspace", "default", "auto":
-		// ok
-
-	default:
-		fmt.Fprintf(os.Stderr, "buildifier: unrecognized input type %s; valid types are build, bzl, workspace, default, auto\n", *inputType)
+	if err := utils.ValidateModes(inputType, mode, lint, dflag); err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(2)
 	}
 
-	if *dflag {
-		if *mode != "" {
-			fmt.Fprintf(os.Stderr, "buildifier: cannot specify both -d and -mode flags\n")
-			os.Exit(2)
-		}
-		*mode = "diff"
-	}
-
-	// Check mode.
-	switch *mode {
-	case "":
-		*mode = "fix"
-
-	case "check", "diff", "fix", "print_if_changed":
-		// ok
-
-	default:
-		fmt.Fprintf(os.Stderr, "buildifier: unrecognized mode %s; valid modes are check, diff, fix\n", *mode)
+	warningsList, err := utils.ValidateWarnings(warnings)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(2)
-	}
-
-	// Check lint mode.
-	switch *lint {
-	case "":
-		*lint = "off"
-
-	case "off":
-		// ok
-
-	case "warn", "fix":
-		if *mode != "fix" {
-			fmt.Fprintf(os.Stderr, "buildifier: lint mode %s is only compatible with --mode=fix\n", *lint)
-			os.Exit(2)
-		}
-
-	default:
-		fmt.Fprintf(os.Stderr, "buildifier: unrecognized lint mode %s; valid modes are warn and fix\n", *lint)
-		os.Exit(2)
-	}
-
-	// Check lint warnings
-	var warningsList []string
-	switch *warnings {
-	case "", "default":
-		warningsList = warn.DefaultWarnings
-	case "all":
-		warningsList = warn.AllWarnings
-	default:
-		// Either all or no warning categories should start with "+" or "-".
-		// If all of them start with "+" or "-", the semantics is
-		// "default set of warnings + something - something".
-		plus := map[string]bool{}
-		minus := map[string]bool{}
-		for _, warning := range strings.Split(*warnings, ",") {
-			if strings.HasPrefix(warning, "+") {
-				plus[warning[1:]] = true
-			} else if strings.HasPrefix(warning, "-") {
-				minus[warning[1:]] = true
-			} else {
-				warningsList = append(warningsList, warning)
-			}
-		}
-		if len(warningsList) > 0 && (len(plus) > 0 || len(minus) > 0) {
-			fmt.Fprintf(os.Stderr, "buildifier: warning categories with modifiers (\"+\" or \"-\") can't me mixed with raw warning categories\n")
-			os.Exit(2)
-		}
-		if len(warningsList) == 0 {
-			for _, warning := range warn.DefaultWarnings {
-				if !minus[warning] {
-					warningsList = append(warningsList, warning)
-				}
-			}
-			for warning := range plus {
-				warningsList = append(warningsList, warning)
-			}
-		}
 	}
 
 	// If the path flag is set, must only be formatting a single file.

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -109,12 +109,22 @@ test_dir/to_fix_tmp.bzl: applied fixes, $5 warnings left
 fixed test_dir/to_fix_tmp.bzl
 EOF
 
+  # --lint=warn with --mode=check
+  $buildifier --mode=check --lint=warn $2 test_dir/to_fix_tmp.bzl 2> test_dir/error || ret=$?
+  if [[ $ret -ne 4 ]]; then
+    die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
+  fi
+  diff test_dir/error golden/error_golden || die "$1: wrong console output for --mode=check --lint=warn"
+  diff test_dir/to_fix.bzl test_dir/to_fix.bzl || die "$1: --mode=check --lint=warn shouldn't modify files"
+
+  # --lint=warn
   $buildifier --lint=warn $2 test_dir/to_fix_tmp.bzl 2> test_dir/error || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
   fi
   diff test_dir/error golden/error_golden || die "$1: wrong console output for --lint=warn"
 
+  # --lint=fix
   $buildifier --lint=fix $2 -v test_dir/to_fix_tmp.bzl 2> test_dir/fix_report || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: fix: Expected buildifier to exit with 4, actual: $ret"

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -3,10 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+      "flags.go",
       "utils.go",
     ],
     deps = [
         "//build:go_default_library",
+        "//warn:go_default_library",
     ],
     importpath = "github.com/bazelbuild/buildtools/buildifier/utils",
     visibility = ["//visibility:public"],

--- a/buildifier/utils/flags.go
+++ b/buildifier/utils/flags.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bazelbuild/buildtools/warn"
+)
+
+func ValidateModes(inputType, mode, lint *string, dflag *bool) error {
+	// Check input type.
+	switch *inputType {
+	case "build", "bzl", "workspace", "default", "auto":
+		// ok
+
+	default:
+		return fmt.Errorf("buildifier: unrecognized input type %s; valid types are build, bzl, workspace, default, auto\n", *inputType)
+	}
+
+	if *dflag {
+		if *mode != "" {
+			return fmt.Errorf("buildifier: cannot specify both -d and -mode flags\n")
+		}
+		*mode = "diff"
+	}
+
+	// Check mode.
+	switch *mode {
+	case "":
+		*mode = "fix"
+
+	case "check", "diff", "fix", "print_if_changed":
+		// ok
+
+	default:
+		return fmt.Errorf("buildifier: unrecognized mode %s; valid modes are check, diff, fix\n", *mode)
+	}
+
+	// Check lint mode.
+	switch *lint {
+	case "":
+		*lint = "off"
+
+	case "off", "warn":
+		// ok
+
+	case "fix":
+		if *mode != "fix" {
+			return fmt.Errorf("buildifier: --lint=fix is only compatible with --mode=fix\n")
+		}
+
+	default:
+		return fmt.Errorf("buildifier: unrecognized lint mode %s; valid modes are warn and fix\n", *lint)
+	}
+
+	return nil
+}
+
+func ValidateWarnings(warnings *string) ([]string, error) {
+
+	// Check lint warnings
+	var warningsList []string
+	switch *warnings {
+	case "", "default":
+		warningsList = warn.DefaultWarnings
+	case "all":
+		warningsList = warn.AllWarnings
+	default:
+		// Either all or no warning categories should start with "+" or "-".
+		// If all of them start with "+" or "-", the semantics is
+		// "default set of warnings + something - something".
+		plus := map[string]bool{}
+		minus := map[string]bool{}
+		for _, warning := range strings.Split(*warnings, ",") {
+			if strings.HasPrefix(warning, "+") {
+				plus[warning[1:]] = true
+			} else if strings.HasPrefix(warning, "-") {
+				minus[warning[1:]] = true
+			} else {
+				warningsList = append(warningsList, warning)
+			}
+		}
+		if len(warningsList) > 0 && (len(plus) > 0 || len(minus) > 0) {
+			return []string{}, fmt.Errorf("buildifier: warning categories with modifiers (\"+\" or \"-\") can't me mixed with raw warning categories\n")
+		}
+		if len(warningsList) == 0 {
+			for _, warning := range warn.DefaultWarnings {
+				if !minus[warning] {
+					warningsList = append(warningsList, warning)
+				}
+			}
+			for warning := range plus {
+				warningsList = append(warningsList, warning)
+			}
+		}
+	}
+	return warningsList, nil
+}


### PR DESCRIPTION
Currently it's not allowed to combine `--lint=warn` with any value of `--mode` except `--mode=fix` (which is default). It makes it not possible to print lint warnings without reformatting a file.

`--lint=fix` still requires `--mode=fix` because applying fixes involves reformatting.

Fixes #453 