### PR TITLE
Move some functionality from buildifier.go to utils.go

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
-	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -47,10 +45,10 @@ var (
 	vflag         = flag.Bool("v", false, "print verbose information to standard error")
 	dflag         = flag.Bool("d", false, "alias for -mode=diff")
 	rflag         = flag.Bool("r", false, "find starlark files recursively")
-	mode          = flag.String("mode", "", "formatting mode: check, diff, or fix (default fix)")
+	mode          = flag.String("mode", "fix", "formatting mode: check, diff, or fix (default fix)")
 	diffProgram   = flag.String("diff_command", "", "command to run when the formatting mode is diff (default uses the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables to create the diff command)")
 	multiDiff     = flag.Bool("multi_diff", false, "the command specified by the -diff_command flag can diff multiple files in the style of tkdiff (default false)")
-	lint          = flag.String("lint", "", "lint mode: off, warn, or fix (default off)")
+	lint          = flag.String("lint", "off", "lint mode: off, warn, or fix (default off)")
 	warnings      = flag.String("warnings", "", "comma-separated warnings used in the lint mode or \"all\"")
 	filePath      = flag.String("path", "", "assume BUILD file has this path relative to the workspace directory")
 	tablesPath    = flag.String("tables", "", "path to JSON file with custom table definitions which will replace the built-in tables")
@@ -129,7 +127,12 @@ func main() {
 	build.DisableRewrites = disable()
 	build.AllowSort = allowSort()
 
-	if err := utils.ValidateModes(inputType, mode, lint, dflag); err != nil {
+	if err := utils.ValidateInputType(inputType); err != nil {
+		fmt.Fprintf(os.Stderr, "buildifier: %s\n", err)
+		os.Exit(2)
+	}
+
+	if err := utils.ValidateModes(mode, lint, dflag); err != nil {
 		fmt.Fprintf(os.Stderr, "buildifier: %s\n", err)
 		os.Exit(2)
 	}
@@ -298,17 +301,9 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		return
 	}
 
-	pkg := getPackageName(filename)
-	switch lint {
-	case "warn":
-		warnings := warn.FileWarnings(f, pkg, warningsList, false)
-		warn.PrintWarnings(f, warnings, false)
-		hasWarnings := len(warnings) > 0
-		if hasWarnings {
-			exitCode = 4
-		}
-	case "fix":
-		warn.FixWarnings(f, pkg, warningsList, *vflag)
+	pkg := utils.GetPackageName(filename)
+	if utils.Lint(f, pkg, lint, &warningsList, *vflag) {
+		exitCode = 4
 	}
 
 	if *filePath != "" {
@@ -353,7 +348,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		if bytes.Equal(data, ndata) {
 			return
 		}
-		outfile, err := writeTemp(ndata)
+		outfile, err := utils.WriteTemp(ndata, &toRemove)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
 			exitCode = 3
@@ -363,7 +358,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		if filename == "" {
 			// data was read from standard filename.
 			// Write it to a temporary file so diff can read it.
-			infile, err = writeTemp(data)
+			infile, err = utils.WriteTemp(data, &toRemove)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "buildifier: %v\n", err)
 				exitCode = 3
@@ -411,35 +406,4 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 			return
 		}
 	}
-}
-
-// writeTemp writes data to a temporary file and returns the name of the file.
-func writeTemp(data []byte) (file string, err error) {
-	f, err := ioutil.TempFile("", "buildifier-tmp-")
-	if err != nil {
-		return "", fmt.Errorf("creating temporary file: %v", err)
-	}
-	name := f.Name()
-	toRemove = append(toRemove, name)
-	defer f.Close()
-	_, err = f.Write(data)
-	if err != nil {
-		return "", fmt.Errorf("writing temporary file: %v", err)
-	}
-	return name, nil
-}
-
-// getPackageName returns the package name of a file by searching for a WORKSPACE file
-func getPackageName(filename string) string {
-	dirs := filepath.SplitList(path.Dir(filename))
-	parent := ""
-	index := len(dirs) - 1
-	for i, chunk := range dirs {
-		parent = path.Join(parent, chunk)
-		metadata := path.Join(parent, "METADATA")
-		if _, err := os.Stat(metadata); !os.IsNotExist(err) {
-			index = i
-		}
-	}
-	return strings.Join(dirs[index+1:], "/")
 }

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     ],
     deps = [
         "//build:go_default_library",
+        "//warn:go_default_library",
     ],
     importpath = "github.com/bazelbuild/buildtools/buildifier/utils",
     visibility = ["//buildifier:__pkg__"],

--- a/buildifier/utils/flags.go
+++ b/buildifier/utils/flags.go
@@ -5,17 +5,19 @@ import (
 	"strings"
 )
 
-// ValidateModes validates flags --type, --mode, --lint, and -d
-func ValidateModes(inputType, mode, lint *string, dflag *bool) error {
-	// Check input type.
+// ValidateModes validates the value of --type
+func ValidateInputType(inputType *string) error {
 	switch *inputType {
 	case "build", "bzl", "workspace", "default", "auto":
-		// ok
+		return nil
 
 	default:
 		return fmt.Errorf("unrecognized input type %s; valid types are build, bzl, workspace, default, auto", *inputType)
 	}
+}
 
+// ValidateModes validates flags --mode, --lint, and -d
+func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) error {
 	if *dflag {
 		if *mode != "" {
 			return fmt.Errorf("cannot specify both -d and -mode flags")
@@ -24,22 +26,22 @@ func ValidateModes(inputType, mode, lint *string, dflag *bool) error {
 	}
 
 	// Check mode.
-	switch *mode {
-	case "":
-		*mode = "fix"
+	validModes := []string{"check", "diff", "fix", "print_if_changed"}
+	validModes = append(validModes, additionalModes...)
 
-	case "check", "diff", "fix", "print_if_changed":
-		// ok
-
-	default:
-		return fmt.Errorf("unrecognized mode %s; valid modes are check, diff, fix", *mode)
+	recognizedMode := false
+	for _, m := range validModes {
+		if *mode == m {
+			recognizedMode = true
+			break
+		}
+	}
+	if !recognizedMode {
+		return fmt.Errorf("unrecognized mode %s; valid modes are %s", *mode, strings.Join(validModes, ", "))
 	}
 
 	// Check lint mode.
 	switch *lint {
-	case "":
-		*lint = "off"
-
 	case "off", "warn":
 		// ok
 

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -3,11 +3,15 @@
 package utils
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/buildtools/warn"
 )
 
 func isStarlarkFile(filename string) bool {
@@ -67,4 +71,48 @@ func GetParser(inputType string) func(filename string, data []byte) (*build.File
 	default:
 		return build.ParseDefault
 	}
+}
+
+// WriteTemp writes data to a temporary file and returns the name of the file.
+func WriteTemp(data []byte, toRemove *[]string) (file string, err error) {
+	f, err := ioutil.TempFile("", "buildifier-tmp-")
+	if err != nil {
+		return "", fmt.Errorf("creating temporary file: %v", err)
+	}
+	name := f.Name()
+	*toRemove = append(*toRemove, name)
+	defer f.Close()
+	_, err = f.Write(data)
+	if err != nil {
+		return "", fmt.Errorf("writing temporary file: %v", err)
+	}
+	return name, nil
+}
+
+// GetPackageName returns the package name of a file by searching for a WORKSPACE file
+func GetPackageName(filename string) string {
+	dirs := filepath.SplitList(path.Dir(filename))
+	parent := ""
+	index := len(dirs) - 1
+	for i, chunk := range dirs {
+		parent = path.Join(parent, chunk)
+		metadata := path.Join(parent, "METADATA")
+		if _, err := os.Stat(metadata); !os.IsNotExist(err) {
+			index = i
+		}
+	}
+	return strings.Join(dirs[index+1:], "/")
+}
+
+// Lint calls the linter and returns true if there are any unresolved warnings
+func Lint(f *build.File, pkg, lint string, warningsList *[]string, verbose bool) bool {
+	switch lint {
+	case "warn":
+		warnings := warn.FileWarnings(f, pkg, *warningsList, false)
+		warn.PrintWarnings(f, warnings, false)
+		return len(warnings) > 0
+	case "fix":
+		warn.FixWarnings(f, pkg, *warningsList, verbose)
+	}
+	return false
 }


### PR DESCRIPTION
The goal is to make different implementations of `buildifier.go` having as less repeated code as possible. This CL moves some of the methods implemented in `buildifier.go` to `buildifier/utils` so that it can be reused.

There will be more follow-up CLs.