### PR TITLE
Temporarily exclude `native.existing_rule` and `native.existing_rules` from the warning

### DIFF
--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -62,6 +62,12 @@ func nativeInBuildFilesWarning(f *build.File, fix bool) []*Finding {
 			return nil
 		}
 
+		// TODO(https://github.com/bazelbuild/bazel/issues/7496): remove as soon as `existing_rule`
+		// and `exsisting_rules` become available in BUILD files.
+		if dot.Name == "existing_rule" || dot.Name == "existing_rules" {
+			return nil
+		}
+
 		if fix {
 			start, _ := dot.Span()
 			return &build.Ident{

--- a/warn/warn_bazel_test.go
+++ b/warn/warn_bazel_test.go
@@ -30,6 +30,12 @@ cc_library(name = "lib")
 		`:1: The "native" module shouldn't be used in BUILD files, its members are available as global symbols.`,
 		`:3: The "native" module shouldn't be used in BUILD files, its members are available as global symbols.`,
 	}, scopeBuild)
+
+	checkFindings(t, "native-build", `
+native.existing_rule("foo")
+
+native.existing_rules()
+`, []string{}, scopeBuild)
 }
 
 func TestNativePackage(t *testing.T) {


### PR DESCRIPTION
These two functions still don't exist in BUILD files as builtin functions, the warning and the fix are currently not correct.

Related Bazel issue: https://github.com/bazelbuild/bazel/issues/7496