### PR TITLE
Allow providing quoted strings for string values

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -555,7 +555,7 @@ func (in *input) Lex(val *yySymType) int {
 			}
 		}
 		in.endToken(val)
-		s, triple, err := unquote(val.tok)
+		s, triple, err := Unquote(val.tok)
 		if err != nil {
 			in.Error(fmt.Sprint(err))
 		}

--- a/build/print.go
+++ b/build/print.go
@@ -394,7 +394,7 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		// If the Token is a correct quoting of Value and has double quotes, use it,
 		// also use it if it has single quotes and the value itself contains a double quote symbol.
 		// This preserves the specific escaping choices that BUILD authors have made.
-		s, triple, err := unquote(v.Token)
+		s, triple, err := Unquote(v.Token)
 		if s == v.Value && triple == v.TripleQuote && err == nil {
 			if strings.HasPrefix(v.Token, `"`) || strings.ContainsRune(v.Value, '"') {
 				p.printf("%s", v.Token)

--- a/build/quote.go
+++ b/build/quote.go
@@ -59,10 +59,10 @@ var esc = [256]byte{
 // being used as shell arguments containing regular expressions.
 const notEsc = " !#$%&()*+,-./:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~"
 
-// unquote unquotes the quoted string, returning the actual
+// Unquote unquotes the quoted string, returning the actual
 // string value, whether the original was triple-quoted, and
 // an error describing invalid input.
-func unquote(quoted string) (s string, triple bool, err error) {
+func Unquote(quoted string) (s string, triple bool, err error) {
 	// Check for raw prefix: means don't interpret the inner \.
 	raw := false
 	if strings.HasPrefix(quoted, "r") {

--- a/build/quote_test.go
+++ b/build/quote_test.go
@@ -74,7 +74,7 @@ func TestQuote(t *testing.T) {
 
 func TestUnquote(t *testing.T) {
 	for _, tt := range quoteTests {
-		s, triple, err := unquote(tt.q)
+		s, triple, err := Unquote(tt.q)
 		wantTriple := strings.HasPrefix(tt.q, `"""`) || strings.HasPrefix(tt.q, `'''`)
 		if s != tt.s || triple != wantTriple || err != nil {
 			t.Errorf("unquote(%s) = %#q, %v, %v want %#q, %v, nil", tt.q, s, triple, err, tt.s, wantTriple)

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -931,7 +931,7 @@ func formatDocstrings(f *File, info *RewriteInfo) {
 		if updatedToken != docstring.Token {
 			docstring.Token = updatedToken
 			// Update the value to keep it consistent with Token
-			docstring.Value, _, _ = unquote(updatedToken)
+			docstring.Value, _, _ = Unquote(updatedToken)
 			info.FormatDocstrings++
 		}
 	})
@@ -1010,7 +1010,7 @@ func editOctals(f *File, info *RewriteInfo) {
 		if !ok {
 			return
 		}
-		if len(l.Token) > 1 && l.Token[0] == '0' && l.Token[1] >= '0' && l.Token[1] <= '9'{
+		if len(l.Token) > 1 && l.Token[0] == '0' && l.Token[1] >= '0' && l.Token[1] <= '9' {
 			l.Token = "0o" + l.Token[1:]
 			info.EditOctal++
 		}

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -428,15 +428,23 @@ func getAttrValueExpr(attr string, args []string, env CmdEnvironment) build.Expr
 		return &build.ListExpr{List: list}
 	case IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")):
 		var list []build.Expr
-		for _, i := range args {
-			list = append(list, &build.StringExpr{Value: ShortenLabel(i, env.Pkg)})
+		for _, arg := range args {
+			list = append(list, getStringExpr(arg, env.Pkg))
 		}
 		return &build.ListExpr{List: list}
 	case IsString(attr):
-		return &build.StringExpr{Value: ShortenLabel(args[0], env.Pkg)}
+		return getStringExpr(args[0], env.Pkg)
 	default:
 		return &build.Ident{Name: args[0]}
 	}
+}
+
+func getStringExpr(value, pkg string) build.Expr {
+	unquoted, triple, err := build.Unquote(value)
+	if err == nil {
+		return &build.StringExpr{Value: ShortenLabel(unquoted, pkg), TripleQuote: triple}
+	}
+	return &build.StringExpr{Value: ShortenLabel(value, pkg)}
 }
 
 func cmdCopy(opts *Options, env CmdEnvironment) (*build.File, error) {

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -85,7 +85,7 @@ func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 			AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.Ident{Name: val}, &env.Vars)
 			continue
 		}
-		strVal := &build.StringExpr{Value: ShortenLabel(val, env.Pkg)}
+		strVal := getStringExpr(val, env.Pkg)
 		AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)
 	}
 	return env.File, nil
@@ -478,16 +478,12 @@ func cmdDictAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 
 	for _, x := range args {
 		kv := strings.Split(x, ":")
-		expr := build.StringExpr{
-			Value:       kv[1],
-			TripleQuote: false,
-			Token:       "",
-		}
+		expr := getStringExpr(kv[1], env.Pkg)
 
 		prev := DictionaryGet(dict, kv[0])
 		if prev == nil {
 			// Only set the value if the value is currently unset.
-			DictionarySet(dict, kv[0], &expr)
+			DictionarySet(dict, kv[0], expr)
 		}
 	}
 	env.Rule.SetAttr(attr, dict)
@@ -507,13 +503,9 @@ func cmdDictSet(opts *Options, env CmdEnvironment) (*build.File, error) {
 
 	for _, x := range args {
 		kv := strings.Split(x, ":")
-		expr := build.StringExpr{
-			Value:       kv[1],
-			TripleQuote: false,
-			Token:       "",
-		}
+		expr := getStringExpr(kv[1], env.Pkg)
 		// Set overwrites previous values.
-		DictionarySet(dict, kv[0], &expr)
+		DictionarySet(dict, kv[0], expr)
 	}
 	env.Rule.SetAttr(attr, dict)
 	return env.File, nil

--- a/edit/fix.go
+++ b/edit/fix.go
@@ -409,7 +409,7 @@ func movePackageDeclarationToTheTop(f *build.File) bool {
 	inserted := false // true when the package declaration has been inserted
 	for _, stmt := range f.Stmt {
 		_, isComment := stmt.(*build.CommentBlock)
-		_, isString := stmt.(*build.StringExpr) // typically a docstring
+		_, isString := stmt.(*build.StringExpr)     // typically a docstring
 		_, isAssignExpr := stmt.(*build.AssignExpr) // e.g. variable declaration
 		_, isLoad := stmt.(*build.LoadStmt)
 		if isComment || isString || isAssignExpr || isLoad {


### PR DESCRIPTION
If buildozer expects a value to be a string, it quotes it unconditionally. If the string provided is already quoted it will be doublequoted:

    $ buildozer set cmd "foo" :target

will result in

    cmd = "\"foo\""

The commit fixes the behavior by attempting to unquote the string, and, if can be unuqoted, using the unquoted value instead of the original value.