### PR TITLE
Refactor WriteTemp

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -176,7 +176,6 @@ func main() {
 	diff = differ
 
 	tf := &utils.TempFile{}
-	defer tf.Clean()
 
 	if len(args) == 0 || (len(args) == 1 && args[0] == "-") {
 		// Read from stdin, write to stdout.
@@ -201,6 +200,8 @@ func main() {
 		}
 		processFiles(files, *inputType, *lint, warningsList, tf)
 	}
+
+	tf.Clean()
 
 	if err := diff.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
       "flags.go",
+      "tempfile.go",
       "utils.go",
     ],
     deps = [

--- a/buildifier/utils/tempfile.go
+++ b/buildifier/utils/tempfile.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+type TempFile struct {
+	filenames []string
+}
+
+// WriteTemp writes data to a temporary file and returns the name of the file.
+func (tf *TempFile) WriteTemp(data []byte) (file string, err error) {
+	f, err := ioutil.TempFile("", "buildifier-tmp-")
+	if err != nil {
+		return "", fmt.Errorf("creating temporary file: %v", err)
+	}
+	defer f.Close()
+	name := f.Name()
+	if _, err := f.Write(data); err != nil {
+		return "", fmt.Errorf("writing temporary file: %v", err)
+	}
+	tf.filenames = append(tf.filenames, name)
+	return name, nil
+}
+
+func (tf *TempFile) Clean() {
+	for _, file := range tf.filenames {
+		os.Remove(file)
+	}
+}

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -31,9 +31,9 @@ func isStarlarkFile(filename string) bool {
 
 // ExpandDirectories takes a list of file/directory names and returns a list with file names
 // by traversing each directory recursively and searching for relevant Starlark files.
-func ExpandDirectories(args []string) ([]string, error) {
+func ExpandDirectories(args *[]string) ([]string, error) {
 	files := []string{}
-	for _, arg := range args {
+	for _, arg := range *args {
 		info, err := os.Stat(arg)
 		if err != nil {
 			return []string{}, err

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -3,8 +3,6 @@
 package utils
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -71,20 +69,6 @@ func GetParser(inputType string) func(filename string, data []byte) (*build.File
 	default:
 		return build.ParseDefault
 	}
-}
-
-// WriteTemp writes data to a temporary file and returns the name of the file.
-func WriteTemp(data []byte) (file string, err error) {
-	f, err := ioutil.TempFile("", "buildifier-tmp-")
-	if err != nil {
-		return "", fmt.Errorf("creating temporary file: %v", err)
-	}
-	defer f.Close()
-	name := f.Name()
-	if _, err := f.Write(data); err != nil {
-		return "", fmt.Errorf("writing temporary file: %v", err)
-	}
-	return name, nil
 }
 
 // GetPackageName returns the package name of a file by searching for a WORKSPACE file


### PR DESCRIPTION
Remove the global variable `toRemove` by replacing it with a class that keeps track of created temp files and cleans them up in the end.