### PR TITLE
Don't test on Ubuntu 14.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,9 +1,9 @@
 ---
 platforms:
-  ubuntu1404:
+  ubuntu1604:
     test_targets:
     - "//:tests"
-  ubuntu1604:
+  ubuntu1804:
     test_targets:
     - "//:tests"
   macos:


### PR DESCRIPTION
Ubuntu 14.04 is about to be end-of-life and Bazel CI will stop supporting it shortly afterwards.

Context: https://groups.google.com/d/msg/bazel-dev/_D6XzfNkQQE/8TNKiNmsCAAJ