### PR TITLE
Bug fix. Preserve inline comments within an attribute list as inline …

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -697,7 +697,7 @@ func (p *printer) useCompactMode(start *Position, list *[]Expr, end *End, mode s
 	// If there are line comments, use multiline
 	// so we can print the comments before the closing bracket.
 	for _, x := range *list {
-		if len(x.Comment().Before) > 0 {
+		if len(x.Comment().Before) > 0 || len(x.Comment().Suffix) > 0 {
 			return false
 		}
 	}

--- a/build/print.go
+++ b/build/print.go
@@ -697,7 +697,7 @@ func (p *printer) useCompactMode(start *Position, list *[]Expr, end *End, mode s
 	// If there are line comments, use multiline
 	// so we can print the comments before the closing bracket.
 	for _, x := range *list {
-		if len(x.Comment().Before) > 0 || len(x.Comment().Suffix) > 0 {
+		if len(x.Comment().Before) > 0 || (len(x.Comment().Suffix) > 0 && mode != modeDef) {
 			return false
 		}
 	}


### PR DESCRIPTION
…comments, even when there is only one list item remaining. Do not promote them to end-of-line comments.

Example rule:
	
java_library(
    name = "testrule",
    deps = [
      "depone",
      "deptwo",  # keep
    ],
)

Previously if depone was removed by buildozer, it would reformat like this:

java_library(
    name = "testrule",
    deps = ["deptwo"],  # keep
)

moving the "keep" comment outside the list, but now preserves the comment in the list:

java_library(
    name = "testrule",
    deps = [
      "deptwo",  # keep
    ]
)

This change was requested because tools depend on comments associated with specific deps.