### PR TITLE
Fix -r flag

### DIFF
--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -42,7 +42,11 @@ echo -e "$INPUT" > test_dir/subdir/test.bzl
 echo -e "$INPUT" > test.bzl  # outside the test_dir directory
 echo -e "not valid +" > test_dir/foo.bar
 mkdir test_dir/workspace  # name of a starlark file, but a directory
+mkdir test_dir/.git  # contents should be ignored
+echo -e "a+b" > test_dir/.git/git.bzl
+
 cp test_dir/foo.bar golden/foo.bar
+cp test_dir/.git/git.bzl golden/git.bzl
 
 "$buildifier" < test_dir/build > stdout
 "$buildifier" -r test_dir
@@ -76,6 +80,7 @@ diff test_dir/foo.bar golden/foo.bar
 diff test.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden
 diff test_dir/test.bzl.out golden/test.bzl.golden
+diff test_dir/.git/git.bzl golden/git.bzl
 
 # Test run on a directory without -r
 "$buildifier" test_dir || ret=$?

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -41,6 +41,7 @@ echo -e "$INPUT" > test_dir/test.bzl
 echo -e "$INPUT" > test_dir/subdir/test.bzl
 echo -e "$INPUT" > test.bzl  # outside the test_dir directory
 echo -e "not valid +" > test_dir/foo.bar
+mkdir test_dir/workspace  # name of a starlark file, but a directory
 cp test_dir/foo.bar golden/foo.bar
 
 "$buildifier" < test_dir/build > stdout

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -13,6 +13,11 @@ import (
 )
 
 func isStarlarkFile(filename string) bool {
+	info, err := os.Stat(filename)
+	if err != nil || info.IsDir() {
+		return false
+	}
+
 	basename := strings.ToLower(filepath.Base(filename))
 	ext := filepath.Ext(basename)
 	switch ext {

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -12,13 +12,12 @@ import (
 	"github.com/bazelbuild/buildtools/warn"
 )
 
-func isStarlarkFile(filename string) bool {
-	info, err := os.Stat(filename)
-	if err != nil || info.IsDir() {
+func isStarlarkFile(info os.FileInfo) bool {
+	if info.IsDir() {
 		return false
 	}
 
-	basename := strings.ToLower(filepath.Base(filename))
+	basename := strings.ToLower(info.Name())
 	ext := filepath.Ext(basename)
 	switch ext {
 	case ".bzl", ".sky":
@@ -32,6 +31,10 @@ func isStarlarkFile(filename string) bool {
 		return true
 	}
 	return false
+}
+
+func skip(info os.FileInfo) bool {
+	return info.IsDir() && info.Name() == ".git"
 }
 
 // ExpandDirectories takes a list of file/directory names and returns a list with file names
@@ -48,7 +51,10 @@ func ExpandDirectories(args *[]string) ([]string, error) {
 			continue
 		}
 		err = filepath.Walk(arg, func(path string, info os.FileInfo, err error) error {
-			if isStarlarkFile(path) {
+			if skip(info) {
+				return filepath.SkipDir
+			}
+			if isStarlarkFile(info) {
 				files = append(files, path)
 			}
 			return err


### PR DESCRIPTION
Skip directories named as Starlark files (e.g. `build/` or `workspace/`).
Skip .git directories entirely.

Fixes #614
Fixes #624 