### PR TITLE
Print correct filenames in case of stdin input

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -308,13 +308,6 @@ var diff *differ.Differ
 func processFile(filename string, data []byte, inputType, lint string, warningsList *[]string, displayFileNames bool, tf *utils.TempFile) (*utils.FileDiagnostics, int) {
 	var exitCode int
 
-	defer func() {
-		if err := recover(); err != nil {
-			fmt.Fprintf(os.Stderr, "buildifier: %s: internal error: %v\n", filename, err)
-			exitCode = 3
-		}
-	}()
-
 	parser := utils.GetParser(inputType)
 
 	f, err := parser(filename, data)
@@ -334,7 +327,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 	if len(warnings) > 0 {
 		exitCode = 4
 	}
-	fileDiagnostics := utils.NewFileDiagnostics(filename, warnings)
+	fileDiagnostics := utils.NewFileDiagnostics(f.DisplayPath(), warnings)
 
 	if *filePath != "" {
 		f.Path = *filePath
@@ -374,7 +367,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 			}
 		}
 		if displayFileNames {
-			fmt.Fprintf(os.Stderr, "%v:\n", filename)
+			fmt.Fprintf(os.Stderr, "%v:\n", f.DisplayPath())
 		}
 		if err := diff.Show(infile, outfile); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -399,7 +392,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		}
 
 		if *vflag {
-			fmt.Fprintf(os.Stderr, "fixed %s\n", filename)
+			fmt.Fprintf(os.Stderr, "fixed %s\n", f.DisplayPath())
 		}
 	case "print_if_changed":
 		if bytes.Equal(data, ndata) {

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -272,6 +272,20 @@ cat > golden/json_report_small_golden <<EOF
 }
 EOF
 
+cat > golden/json_report_stdin_golden <<EOF
+{
+    "success": true,
+    "files": [
+        {
+            "filename": "\u003cstdin\u003e",
+            "formatted": true,
+            "valid": true,
+            "warnings": []
+        }
+    ]
+}
+EOF
+
 cat > golden/json_report_invalid_file_golden <<EOF
 {
     "success": false,
@@ -299,6 +313,9 @@ diff json_report ../../golden/json_report_golden || die "$1: wrong console outpu
 
 $buildifier --mode=check --format=json --lint=warn --warnings=-module-docstring -v to_fix_4.bzl > json_report
 diff json_report ../../golden/json_report_small_golden || die "$1: wrong console output for --mode=check --format=json --lint=warn with a single file"
+
+$buildifier --mode=check --format=json --lint=warn --warnings=-module-docstring -v < to_fix_4.bzl > json_report
+diff json_report ../../golden/json_report_stdin_golden || die "$1: wrong console output for --mode=check --format=json --lint=warn with stdin"
 
 $buildifier --mode=check --format=json --lint=warn --warnings=-module-docstring -v to_fix_4.bzl foo.bar > json_report
 diff json_report ../../golden/json_report_invalid_file_golden || die "$1: wrong console output for --mode=check --format=json --lint=warn with an invalid file"

--- a/buildifier/utils/diagnostics.go
+++ b/buildifier/utils/diagnostics.go
@@ -134,13 +134,17 @@ func NewFileDiagnostics(filename string, warnings []*warn.Finding) *FileDiagnost
 
 // InvalidFileDiagnostics returns a new FileDiagnostics object for an invalid file
 func InvalidFileDiagnostics(filename string) *FileDiagnostics {
-	return &FileDiagnostics{
+	fileDiagnostics := &FileDiagnostics{
 		Filename:  filename,
 		Formatted: false,
 		Valid:     false,
 		Warnings:  []*warning{},
 		Rewrites:  map[string]int{},
 	}
+	if filename == "" {
+		fileDiagnostics.Filename = "<stdin>"
+	}
+	return fileDiagnostics
 }
 
 func makePosition(p build.Position) position {


### PR DESCRIPTION
Stdin filename is represented as `""` internally but should be printed as `<stdin>`.