### PR TITLE
Rewrite status.sh in Python

### DIFF
--- a/status.py
+++ b/status.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 from subprocess import Popen, PIPE
 from sys import exit
 
@@ -10,7 +10,7 @@ def run(*cmd):
     output, err = process.communicate()
     if process.wait():
         exit(1)
-    return output.strip()
+    return output.strip().decode("utf-8")
 
 
 def main():

--- a/status.py
+++ b/status.py
@@ -10,15 +10,15 @@ def run(*cmd):
     output, err = process.communicate()
     if process.wait():
         exit(1)
-    return output.strip().decode("utf-8")
+    return output.strip()
 
 
 def main():
     tags = run("git", "describe", "--tags")
-    print("STABLE_buildVersion {}".format(tags.split("-")[0]))
+    print("STABLE_buildVersion", tags.split(b"-")[0])
 
     revision = run("git", "rev-parse", "HEAD")
-    print("STABLE_buildScmRevision {}".format(revision))
+    print("STABLE_buildScmRevision", revision)
 
 
 if __name__ == "__main__":

--- a/status.py
+++ b/status.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+from subprocess import Popen, PIPE
+from sys import exit
+
+
+def run(*cmd):
+    process = Popen(cmd, stdout=PIPE)
+    output, err = process.communicate()
+    if process.wait():
+        exit(1)
+    return output.strip()
+
+
+def main():
+    tags = run("git", "describe", "--tags")
+    print("STABLE_buildVersion {}".format(tags.split("-")[0]))
+
+    revision = run("git", "rev-parse", "HEAD")
+    print("STABLE_buildScmRevision {}".format(revision))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`status.sh` is used by BazelCI to build buildtools-related binaries, but it can't be used on Windows.

`status.py` is a multiplatform alternative, it will completely replace `status.sh` once the latter is not used anymore by the CI configuration.

#375