### PR TITLE
Fix status.py for Python 3

### DIFF
--- a/status.py
+++ b/status.py
@@ -10,12 +10,12 @@ def run(*cmd):
     output, err = process.communicate()
     if process.wait():
         exit(1)
-    return output.strip()
+    return output.strip().decode('latin-1')
 
 
 def main():
     tags = run("git", "describe", "--tags")
-    print("STABLE_buildVersion", tags.split(b"-")[0])
+    print("STABLE_buildVersion", tags.split("-")[0])
 
     revision = run("git", "rev-parse", "HEAD")
     print("STABLE_buildScmRevision", revision)

--- a/status.py
+++ b/status.py
@@ -10,7 +10,7 @@ def run(*cmd):
     output, err = process.communicate()
     if process.wait():
         exit(1)
-    return output.strip().decode('latin-1')
+    return output.strip().decode()
 
 
 def main():


### PR DESCRIPTION
Python 3 prints byte strings as their `repr`:

    >>> print(b'asd')
    b'asd'

They need to be converted to unicode before printing.