### PR TITLE
Fix TestNativeAndroidWarning

### DIFF
--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -471,10 +471,10 @@ def macro():
     native.android_local_test()
 
 android_binary()
-`, `
+`, fmt.Sprintf(`
 """My file"""
 
-load("@rules_android//android:rules.bzl", "aar_import", "android_binary", "android_library", "android_local_test")
+load(%q, "aar_import", "android_binary", "android_library", "android_local_test")
 
 def macro():
     aar_import()
@@ -483,7 +483,7 @@ def macro():
     android_local_test()
 
 android_binary()
-`,
+`, tables.AndroidLoadPath),
 		[]string{
 			fmt.Sprintf(`:4: Function "aar_import" is not global anymore and needs to be loaded from "%s".`, tables.AndroidLoadPath),
 			fmt.Sprintf(`:5: Function "android_library" is not global anymore and needs to be loaded from "%s".`, tables.AndroidLoadPath),


### PR DESCRIPTION
The automatic fix uses values that can be overridden using tables.go, the test should also take it into account, otherwise it will fail when values are overridden.