### PR TITLE
Remove the special case for existing_rule(s)

### DIFF
--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -62,12 +62,6 @@ func nativeInBuildFilesWarning(f *build.File, fix bool) []*Finding {
 			return nil
 		}
 
-		// TODO(https://github.com/bazelbuild/bazel/issues/7496): remove as soon as `existing_rule`
-		// and `exsisting_rules` become available in BUILD files.
-		if dot.Name == "existing_rule" || dot.Name == "existing_rules" {
-			return nil
-		}
-
 		if fix {
 			start, _ := dot.Span()
 			return &build.Ident{

--- a/warn/warn_bazel_test.go
+++ b/warn/warn_bazel_test.go
@@ -30,12 +30,6 @@ cc_library(name = "lib")
 		`:1: The "native" module shouldn't be used in BUILD files, its members are available as global symbols.`,
 		`:3: The "native" module shouldn't be used in BUILD files, its members are available as global symbols.`,
 	}, scopeBuild)
-
-	checkFindings(t, "native-build", `
-native.existing_rule("foo")
-
-native.existing_rules()
-`, []string{}, scopeBuild)
 }
 
 func TestNativePackage(t *testing.T) {


### PR DESCRIPTION
Now that `existing_rule` and `existing_rules` are available in BUILD files, buildifier can remove the `native.` prefix for them as well.

https://github.com/bazelbuild/bazel/issues/7496