### PR TITLE
Make recursive file detection stricter

### DIFF
--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -36,9 +36,10 @@ buildifier2="$(rlocation "$buildifier2")"
 mkdir -p test_dir/subdir
 mkdir -p golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
-echo -e "$INPUT" > test_dir/build  # case doesn't matter
+echo -e "$INPUT" > test_dir/BUILD
 echo -e "$INPUT" > test_dir/test.bzl
 echo -e "$INPUT" > test_dir/subdir/test.bzl
+echo -e "$INPUT" > test_dir/subdir/build  # lowercase, should be ignored by -r
 echo -e "$INPUT" > test.bzl  # outside the test_dir directory
 echo -e "not valid +" > test_dir/foo.bar
 mkdir test_dir/workspace  # name of a starlark file, but a directory
@@ -46,9 +47,10 @@ mkdir test_dir/.git  # contents should be ignored
 echo -e "a+b" > test_dir/.git/git.bzl
 
 cp test_dir/foo.bar golden/foo.bar
+cp test_dir/subdir/build golden/build
 cp test_dir/.git/git.bzl golden/git.bzl
 
-"$buildifier" < test_dir/build > stdout
+"$buildifier" < test_dir/BUILD > stdout
 "$buildifier" -r test_dir
 "$buildifier" test.bzl
 "$buildifier2" test_dir/test.bzl > test_dir/test.bzl.out
@@ -73,9 +75,10 @@ load(":foo.bzl", "foo")
 foo(tags = ["b", "a"], srcs = ["d", "c"])
 EOF
 
-diff test_dir/build golden/BUILD.golden
+diff test_dir/BUILD golden/BUILD.golden
 diff test_dir/test.bzl golden/test.bzl.golden
 diff test_dir/subdir/test.bzl golden/test.bzl.golden
+diff test_dir/subdir/build golden/build
 diff test_dir/foo.bar golden/foo.bar
 diff test.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -13,21 +13,20 @@ import (
 )
 
 func isStarlarkFile(name string) bool {
-	basename := strings.ToLower(name)
-	ext := filepath.Ext(basename)
+	ext := filepath.Ext(name)
 	switch ext {
 	case ".bzl", ".sky":
 		return true
 	}
-	base := basename[:len(basename)-len(ext)]
+	base := name[:len(name)-len(ext)]
 
 	switch ext {
 	case ".bazel", ".oss":
 		// The extension can be ignored
-		basename = base
+		name = base
 	}
 
-	return basename == "build" || basename == "workspace"
+	return name == "BUILD" || name == "WORKSPACE"
 }
 
 func skip(info os.FileInfo) bool {

--- a/buildifier/utils/utils_test.go
+++ b/buildifier/utils/utils_test.go
@@ -18,8 +18,12 @@ func TestIsStarlarkFile(t *testing.T) {
 			ok:       true,
 		},
 		{
-			filename: "build.oss",
+			filename: "BUILD.oss",
 			ok:       true,
+		},
+		{
+			filename: "build.oss",
+			ok:       false,
 		},
 		{
 			filename: "WORKSPACE",
@@ -30,8 +34,12 @@ func TestIsStarlarkFile(t *testing.T) {
 			ok:       true,
 		},
 		{
-			filename: "workspace.oss",
+			filename: "WORKSPACE.oss",
 			ok:       true,
+		},
+		{
+			filename: "workspace.oss",
+			ok:       false,
 		},
 		{
 			filename: "build.gradle",
@@ -44,6 +52,10 @@ func TestIsStarlarkFile(t *testing.T) {
 		{
 			filename: "foo.bzl",
 			ok:       true,
+		},
+		{
+			filename: "foo.BZL",
+			ok:       false,
 		},
 		{
 			filename: "build.bzl",


### PR DESCRIPTION
Buildifier recognizes files called `build`, `workspace.oss` (lowercase), or `foo.BZL` as BUILD, WORKSPACE, and .bzl files respectively if the filenames are provided explicitly, however in the `-r` mode it shouldn't parse such files, normally Starlark files shouldn't be called like that, and buildifier is likely to crash with a syntax error if it attempts to parse files that it's not supposed to.

Fixes #662