### PR TITLE
Fix BUG: Remove bad format string arg

### DIFF
--- a/build/rule_test.go
+++ b/build/rule_test.go
@@ -202,7 +202,7 @@ rule()`, "foo", `Use an implicit name for one unnamed rule with load`},
 		}
 
 		if got := file.implicitRuleName(); got != tst.want {
-			t.Errorf("TestImplicitName(%s): got %s, want %s. %s", tst.description, got, tst.want)
+			t.Errorf("TestImplicitName(%s): got %s, want %s.", tst.description, got, tst.want)
 		}
 	}
 }


### PR DESCRIPTION
Remove dangling %s format arg that would not cause compilation issues in default mode.
t.Errorf("TestImplicitName(%s): got %s, want %s.", tst.description, got, tst.want)