### PR TITLE
Add `remove_comment` command to Buildozer.

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -83,6 +83,8 @@ Buildozer supports the following commands(`'command args'`):
   * `remove <attr> <value(s)>`: Removes `value(s)` from the list `attr`. The
     wildcard `*` matches all attributes. Lists containing none of the `value(s)` are
     not modified.
+  * `remove_comment <attr>? <value>?`: Removes the comment attached to the rule,
+    an attribute, or a specific value in a list.
   * `rename <old_attr> <new_attr>`: Rename the `old_attr` to `new_attr` which must
     not yet exist.
   * `replace <attr> <old_value> <new_value>`: Replaces `old_value` with `new_value`

--- a/edit/BUILD.bazel
+++ b/edit/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "buildozer_command_file_test.go",
+        "buildozer_test.go",
         "edit_test.go",
         "fix_test.go",
     ],

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -353,18 +353,25 @@ func cmdRemoveComment(opts *Options, env CmdEnvironment) (*build.File, error) {
 	case 0: // Remove comment attached to rule
 		env.Rule.Call.Comments.Before = nil
 		env.Rule.Call.Comments.Suffix = nil
+		env.Rule.Call.Comments.After = nil
 	case 1: // Remove comment attached to attr
 		if attr := env.Rule.AttrDefn(env.Args[0]); attr != nil {
 			attr.Comments.Before = nil
 			attr.Comments.Suffix = nil
+			attr.Comments.After = nil
 			attr.LHS.Comment().Before = nil
+			attr.LHS.Comment().Suffix = nil
+			attr.LHS.Comment().After = nil
+			attr.RHS.Comment().Before = nil
 			attr.RHS.Comment().Suffix = nil
+			attr.RHS.Comment().After = nil
 		}
 	case 2: // Remove comment attached to value
 		if attr := env.Rule.Attr(env.Args[0]); attr != nil {
 			if expr := ListFind(attr, env.Args[1], env.Pkg); expr != nil {
 				expr.Comments.Before = nil
 				expr.Comments.Suffix = nil
+				expr.Comments.After = nil
 			}
 		}
 	default:

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -348,6 +348,31 @@ func cmdRemove(opts *Options, env CmdEnvironment) (*build.File, error) {
 	return nil, nil
 }
 
+func cmdRemoveComment(opts *Options, env CmdEnvironment) (*build.File, error) {
+	switch len(env.Args) {
+	case 0: // Remove comment attached to rule
+		env.Rule.Call.Comments.Before = nil
+		env.Rule.Call.Comments.Suffix = nil
+	case 1: // Remove comment attached to attr
+		if attr := env.Rule.AttrDefn(env.Args[0]); attr != nil {
+			attr.Comments.Before = nil
+			attr.Comments.Suffix = nil
+			attr.LHS.Comment().Before = nil
+			attr.RHS.Comment().Suffix = nil
+		}
+	case 2: // Remove comment attached to value
+		if attr := env.Rule.Attr(env.Args[0]); attr != nil {
+			if expr := ListFind(attr, env.Args[1], env.Pkg); expr != nil {
+				expr.Comments.Before = nil
+				expr.Comments.Suffix = nil
+			}
+		}
+	default:
+		panic("cmdRemoveComment")
+	}
+	return env.File, nil
+}
+
 func cmdRename(opts *Options, env CmdEnvironment) (*build.File, error) {
 	oldAttr := env.Args[0]
 	newAttr := env.Args[1]
@@ -589,6 +614,7 @@ var AllCommands = map[string]CommandInfo{
 	"new":               {cmdNew, false, 2, 4, "<rule_kind> <rule_name> [(before|after) <relative_rule_name>]"},
 	"print":             {cmdPrint, true, 0, -1, "<attribute(s)>"},
 	"remove":            {cmdRemove, true, 1, -1, "<attr> <value(s)>"},
+	"remove_comment":    {cmdRemoveComment, true, 0, 2, "<attr>? <value>?"},
 	"rename":            {cmdRename, true, 2, 2, "<old_attr> <new_attr>"},
 	"replace":           {cmdReplace, true, 3, 3, "<attr> <old_value> <new_value>"},
 	"substitute":        {cmdSubstitute, true, 3, 3, "<attr> <old_regexp> <new_template>"},

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package edit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/buildtools/build"
+)
+
+var removeCommentTests = []struct {
+	args      []string
+	buildFile string
+	expected  string
+}{
+	{[]string{},
+		`# comment
+	foo(
+		name = "foo",
+	)`,
+		`foo(
+    name = "foo",
+)`,
+	},
+	{[]string{
+		"name",
+	},
+		`foo(
+		# comment
+		name = "foo",
+	)`,
+		`foo(
+    name = "foo",
+)`,
+	},
+	{[]string{
+		"name",
+	},
+		`foo(
+		name = "foo"  # comment,
+	)`,
+		`foo(
+    name = "foo",
+)`,
+	},
+	{[]string{
+		"deps", "bar",
+	},
+		`foo(
+		name = "foo",
+		deps = [
+				# comment
+				"bar",
+				"baz",
+		],
+	)`,
+		`foo(
+    name = "foo",
+    deps = [
+        "bar",
+        "baz",
+    ],
+)`,
+	},
+	{[]string{
+		"deps", "bar",
+	},
+		`foo(
+		name = "foo",
+		deps = [
+				"bar",  # comment
+				"baz",
+		],
+	)`,
+		`foo(
+    name = "foo",
+    deps = [
+        "bar",
+        "baz",
+    ],
+)`,
+	},
+}
+
+func TestCmdRemoveComment(t *testing.T) {
+	for i, tt := range removeCommentTests {
+		bld, err := build.Parse("BUILD", []byte(tt.buildFile))
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		rl := bld.Rules("foo")[0]
+		env := CmdEnvironment{
+			File: bld,
+			Rule: rl,
+			Args: tt.args,
+		}
+		bld, _ = cmdRemoveComment(NewOpts(), env)
+		got := strings.TrimSpace(string(build.Format(bld)))
+		if got != tt.expected {
+			t.Errorf("cmdRemoveComment(%d):\ngot:\n%s\nexpected:\n%s", i, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
This command removes the comment attached to the specified rule, attribute, or value in an attribute.