### PR TITLE
Fix function docstring warning position

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -216,7 +216,9 @@ func functionDocstringWarning(f *build.File) []*LinterFinding {
 		}
 
 		message := fmt.Sprintf("The function %q has no docstring.", def.Name)
-		findings = append(findings, makeLinterFinding(def, message))
+		finding := makeLinterFinding(def, message)
+		finding.End = def.ColonPos
+		findings = append(findings, finding)
 	}
 	return findings
 }


### PR DESCRIPTION
A recent change has broken the position of "no function docstring" warnings. Their span should be just the function's header (from `def` till `:`), not the whole body.