### PR TITLE
Fix the package-on-top warning

### DIFF
--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -95,7 +95,7 @@ func packageOnTopWarning(f *build.File) []*LinterFinding {
 		_, isLoad := stmt.(*build.LoadStmt)
 		_, isPackageGroup := edit.ExprToRule(stmt, "package_group")
 		_, isLicense := edit.ExprToRule(stmt, "licenses")
-		if isString || isComment || isAssignExpr || isLoad || isPackageGroup || isLicense {
+		if isString || isComment || isAssignExpr || isLoad || isPackageGroup || isLicense || stmt == nil {
 			continue
 		}
 		if rule, ok := edit.ExprToRule(stmt, "package"); ok {

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -107,6 +107,21 @@ my_macro(name = "foo")
 package()`,
 		[]string{":2: Package declaration should be at the top of the file, after the load() statements, but before any call to a rule or a macro. package_group() and licenses() may be called before package()."},
 		scopeEverywhere)
+
+	checkFindings(t, "package-on-top", `
+# Some comments
+
+"""This is a docstring"""
+
+load(":foo.bzl", "foo")
+load(":bar.bzl", baz = "bar")
+
+package()
+
+foo(baz)
+`,
+		[]string{},
+		scopeEverywhere)
 }
 
 func TestLoadOnTop(t *testing.T) {


### PR DESCRIPTION
package-on-top shouldn't be triggered if there are nil statements (e.g.
added by another warning function to be able to provide fixes).