### PR TITLE
Fix the usage of the --path argument

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -308,6 +308,10 @@ var diff *differ.Differ
 func processFile(filename string, data []byte, inputType, lint string, warningsList *[]string, displayFileNames bool, tf *utils.TempFile) (*utils.FileDiagnostics, int) {
 	var exitCode int
 
+	if *filePath != "" {
+		filename = *filePath
+	}
+
 	parser := utils.GetParser(inputType)
 
 	f, err := parser(filename, data)
@@ -329,9 +333,6 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 	}
 	fileDiagnostics := utils.NewFileDiagnostics(f.DisplayPath(), warnings)
 
-	if *filePath != "" {
-		f.Path = *filePath
-	}
 	var info build.RewriteInfo
 	build.Rewrite(f, &info)
 

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -137,6 +137,7 @@ test_lint () {
   ret=0
   cp test_dir/to_fix.bzl test_dir/to_fix_tmp.bzl
   echo "$4" > golden/error_golden
+  echo "${4//test_dir\/to_fix_tmp.bzl/foo.bzl}" > golden/error_golden_foo
 
   cat > golden/fix_report_golden <<EOF
 test_dir/to_fix_tmp.bzl: applied fixes, $5 warnings left
@@ -157,6 +158,13 @@ EOF
     die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
   fi
   diff test_dir/error golden/error_golden || die "$1: wrong console output for --lint=warn"
+
+  # --lint=warn with --path
+  $buildifier --lint=warn --path=foo.bzl $2 test_dir/to_fix_tmp.bzl 2> test_dir/error || ret=$?
+  if [[ $ret -ne 4 ]]; then
+    die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
+  fi
+  diff test_dir/error golden/error_golden_foo || die "$1: wrong console output for --lint=warn and --path"
 
   # --lint=fix
   $buildifier --lint=fix $2 -v test_dir/to_fix_tmp.bzl 2> test_dir/fix_report || ret=$?


### PR DESCRIPTION
The `--path` argument should affect everything except the actual reading of the input file, including linter warning messages.

Fixes #475