### PR TITLE
Change the span for not loaded function warnings

### DIFF
--- a/warn/warn_bazel_api.go
+++ b/warn/warn_bazel_api.go
@@ -202,7 +202,7 @@ func notLoadedFunctionUsageCheckInternal(expr *build.Expr, env *bzlenv.Environme
 		if name == global {
 			loads = append(loads, name)
 			findings = append(findings,
-				makeLinterFinding(call, fmt.Sprintf(`Function %q is not global anymore and needs to be loaded from %q.`, global, loadFrom), replacements...))
+				makeLinterFinding(call.X, fmt.Sprintf(`Function %q is not global anymore and needs to be loaded from %q.`, global, loadFrom), replacements...))
 			break
 		}
 	}


### PR DESCRIPTION
Warnings "Function is not global anymore" are currently bound to entire CallExpr nodes, if buildifier is used in IDEs, entire target definitions become underlined, which produces a lot of noise. With this change the behavior is chahged to only match `CallExpr.X` nodes, which for global functions is just their name (or maybe `native.<function_name>` in .bzl files).

This doesn't affect the console output because it only mentions start lines, which is the same for a call expression node and its `.X` subnode.