### PR TITLE
Allow go_yacc genrule to be executed remotely.

### DIFF
--- a/build/build_defs.bzl
+++ b/build/build_defs.bzl
@@ -33,7 +33,6 @@ def go_yacc(src, out, visibility = None):
                " $(location " + _GO_YACC_TOOL + ") " +
                " -o $(location " + out + ") $(SRCS) > /dev/null"),
         visibility = visibility,
-        local = 1,
     )
 
 def _extract_go_src(ctx):


### PR DESCRIPTION
I can't find any evidence that this genrule must run locally. It works when run remotely in Stripe's hermetic remote build environment, which is stricter than e.g. RBE, so I figure it's probably safe to remove the "force local build" argument.

Fixes #601 