### PR TITLE
Fix the behavior of the --path flag

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -308,13 +308,14 @@ var diff *differ.Differ
 func processFile(filename string, data []byte, inputType, lint string, warningsList *[]string, displayFileNames bool, tf *utils.TempFile) (*utils.FileDiagnostics, int) {
 	var exitCode int
 
+	displayFilename := filename
 	if *filePath != "" {
-		filename = *filePath
+		displayFilename = *filePath
 	}
 
 	parser := utils.GetParser(inputType)
 
-	f, err := parser(filename, data)
+	f, err := parser(displayFilename, data)
 	if err != nil {
 		// Do not use buildifier: prefix on this error.
 		// Since it is a parse error, it begins with file:line:
@@ -323,10 +324,10 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		if exitCode < 1 {
 			exitCode = 1
 		}
-		return utils.InvalidFileDiagnostics(filename), exitCode
+		return utils.InvalidFileDiagnostics(displayFilename), exitCode
 	}
 
-	pkg := utils.GetPackageName(filename)
+	pkg := utils.GetPackageName(displayFilename)
 	warnings := utils.Lint(f, pkg, lint, warningsList, *vflag)
 	if len(warnings) > 0 {
 		exitCode = 4

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -41,6 +41,7 @@ echo -e "$INPUT" > test_dir/test.bzl
 echo -e "$INPUT" > test_dir/subdir/test.bzl
 echo -e "$INPUT" > test_dir/subdir/build  # lowercase, should be ignored by -r
 echo -e "$INPUT" > test.bzl  # outside the test_dir directory
+echo -e "$INPUT" > test2.bzl  # outside the test_dir directory
 echo -e "not valid +" > test_dir/foo.bar
 mkdir test_dir/workspace  # name of a starlark file, but a directory
 mkdir test_dir/.git  # contents should be ignored
@@ -53,6 +54,7 @@ cp test_dir/.git/git.bzl golden/git.bzl
 "$buildifier" < test_dir/BUILD > stdout
 "$buildifier" -r test_dir
 "$buildifier" test.bzl
+"$buildifier" --path=foo.bzl test2.bzl
 "$buildifier2" test_dir/test.bzl > test_dir/test.bzl.out
 
 cat > golden/BUILD.golden <<EOF
@@ -81,6 +83,7 @@ diff test_dir/subdir/test.bzl golden/test.bzl.golden
 diff test_dir/subdir/build golden/build
 diff test_dir/foo.bar golden/foo.bar
 diff test.bzl golden/test.bzl.golden
+diff test2.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden
 diff test_dir/test.bzl.out golden/test.bzl.golden
 diff test_dir/.git/git.bzl golden/git.bzl


### PR DESCRIPTION
The flag should only affect the file names in the output, it shouldn't affect the actual path the file is read from and written to.