### PR TITLE
Fix for legacy named arguments

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -24,7 +24,7 @@ Warning categories supported by buildifier's linter:
   * [git-repository](#git-repository)
   * [http-archive](#http-archive)
   * [integer-division](#integer-division)
-  * [keyword-parameters](#keyword-parameters)
+  * [keyword-positional-params](#keyword-positional-params)
   * [load](#load)
   * [load-on-top](#load-on-top)
   * [module-docstring](#module-docstring)
@@ -401,9 +401,9 @@ d //= e
 
 --------------------------------------------------------------------------------
 
-## <a name="keyword-parameters"></a>Keyword parameter should be positional
+## <a name="keyword-positional-params"></a>Keyword parameter should be positional
 
-  * Category_name: `keyword-parameters`
+  * Category_name: `keyword-positional-params`
   * Automatic fix: yes
 
 Some parameters for builtin functions in Starlark are keyword for legacy reasons;

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -24,6 +24,7 @@ Warning categories supported by buildifier's linter:
   * [git-repository](#git-repository)
   * [http-archive](#http-archive)
   * [integer-division](#integer-division)
+  * [keyword-parameters](#keyword-parameters)
   * [load](#load)
   * [load-on-top](#load-on-top)
   * [module-docstring](#module-docstring)
@@ -399,6 +400,17 @@ d //= e
 `
 
 --------------------------------------------------------------------------------
+
+## <a name="keyword-parameters"></a>Keyword parameter should be positional
+
+  * Category_name: `keyword-parameters`
+  * Automatic fix: yes
+
+Some parameters for builtin functions in Starlark are keyword for legacy reasons;
+their names are not meaningful (e.g. `x`). Making them positional-only will improve
+the readability.
+
+ --------------------------------------------------------------------------------
 
 ## <a name="load"></a>Loaded symbol is unused
 

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -122,6 +122,7 @@ var FileWarningMap = map[string]func(f *build.File) []*LinterFinding{
 	"git-repository":            nativeGitRepositoryWarning,
 	"http-archive":              nativeHTTPArchiveWarning,
 	"integer-division":          integerDivisionWarning,
+	"keyword-parameters":         keywordParametersWarning,
 	"load":                      unusedLoadWarning,
 	"load-on-top":               loadOnTopWarning,
 	"module-docstring":          moduleDocstringWarning,

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -122,7 +122,7 @@ var FileWarningMap = map[string]func(f *build.File) []*LinterFinding{
 	"git-repository":            nativeGitRepositoryWarning,
 	"http-archive":              nativeHTTPArchiveWarning,
 	"integer-division":          integerDivisionWarning,
-	"keyword-parameters":         keywordParametersWarning,
+	"keyword-parameters":        keywordParametersWarning,
 	"load":                      unusedLoadWarning,
 	"load-on-top":               loadOnTopWarning,
 	"module-docstring":          moduleDocstringWarning,

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -122,7 +122,7 @@ var FileWarningMap = map[string]func(f *build.File) []*LinterFinding{
 	"git-repository":            nativeGitRepositoryWarning,
 	"http-archive":              nativeHTTPArchiveWarning,
 	"integer-division":          integerDivisionWarning,
-	"keyword-parameters":        keywordParametersWarning,
+	"keyword-positional-params": keywordPositionalParametersWarning,
 	"load":                      unusedLoadWarning,
 	"load-on-top":               loadOnTopWarning,
 	"module-docstring":          moduleDocstringWarning,

--- a/warn/warn_bazel_api.go
+++ b/warn/warn_bazel_api.go
@@ -850,8 +850,8 @@ var signatures = map[string]signature{
 	"int":     {[]string{"x"}, []string{}},
 	"dir":     {[]string{"x"}, []string{}},
 	"type":    {[]string{"x"}, []string{}},
-	"hasattr": {[]string{"x"}, []string{}},
-	"getattr": {[]string{"x"}, []string{}},
+	"hasattr": {[]string{"x", "name"}, []string{}},
+	"getattr": {[]string{"x", "name", "default"}, []string{}},
 	"select":  {[]string{"x"}, []string{}},
 	"glob":    {[]string{"include"}, []string{"exclude", "exclude_directories"}},
 }

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -581,7 +581,7 @@ java_test()
 }
 
 func TestNativePyWarning(t *testing.T) {
-  checkFindingsAndFix(t, "native-py", `
+	checkFindingsAndFix(t, "native-py", `
 """My file"""
 
 def macro():
@@ -604,14 +604,14 @@ def macro():
 
 py_test()
 `, tables.PyLoadPath),
-    []string{
-      fmt.Sprintf(`:4: Function "py_library" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
-      fmt.Sprintf(`:5: Function "py_binary" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
-      fmt.Sprintf(`:6: Function "py_test" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
-      fmt.Sprintf(`:7: Function "py_runtime" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
-      fmt.Sprintf(`:9: Function "py_test" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
-    },
-    scopeBzl|scopeBuild)
+		[]string{
+			fmt.Sprintf(`:4: Function "py_library" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
+			fmt.Sprintf(`:5: Function "py_binary" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
+			fmt.Sprintf(`:6: Function "py_test" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
+			fmt.Sprintf(`:7: Function "py_runtime" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
+			fmt.Sprintf(`:9: Function "py_test" is not global anymore and needs to be loaded from "%s".`, tables.PyLoadPath),
+		},
+		scopeBzl|scopeBuild)
 }
 
 func TestNativeProtoWarning(t *testing.T) {
@@ -649,4 +649,58 @@ def macro():
 			fmt.Sprintf(`:10: Symbol "proto_common" is not global anymore and needs to be loaded from "%s".`, tables.ProtoLoadPath),
 		},
 		scopeBzl|scopeBuild)
+}
+
+func TestKeywordParameters(t *testing.T) {
+	checkFindingsAndFix(t, "keyword-parameters", `
+foo(key = value)
+all(elements = [True, False])
+any(elements = [True, False])
+tuple(x = [1, 2, 3])
+list(x = [1, 2, 3])
+len(x = [1, 2, 3])
+str(x = foo)
+repr(x = foo)
+bool(x = 3)
+int(x = "3")
+int(x = "13", base = 8)
+dir(x = foo)
+type(x = foo)
+hasattr(x = foo, name = "bar")
+getattr(x = foo, name = "bar", default = "baz")
+select(x = {})
+`, `
+foo(key = value)
+all([True, False])
+any([True, False])
+tuple([1, 2, 3])
+list([1, 2, 3])
+len([1, 2, 3])
+str(foo)
+repr(foo)
+bool(3)
+int("3")
+int("13", base = 8)
+dir(foo)
+type(foo)
+hasattr(foo, name = "bar")
+getattr(foo, name = "bar", default = "baz")
+select({})
+`, []string{
+		`:2: Keyword parameter "elements" for "all" should be positional.`,
+		`:3: Keyword parameter "elements" for "any" should be positional.`,
+		`:4: Keyword parameter "x" for "tuple" should be positional.`,
+		`:5: Keyword parameter "x" for "list" should be positional.`,
+		`:6: Keyword parameter "x" for "len" should be positional.`,
+		`:7: Keyword parameter "x" for "str" should be positional.`,
+		`:8: Keyword parameter "x" for "repr" should be positional.`,
+		`:9: Keyword parameter "x" for "bool" should be positional.`,
+		`:10: Keyword parameter "x" for "int" should be positional.`,
+		`:11: Keyword parameter "x" for "int" should be positional.`,
+		`:12: Keyword parameter "x" for "dir" should be positional.`,
+		`:13: Keyword parameter "x" for "type" should be positional.`,
+		`:14: Keyword parameter "x" for "hasattr" should be positional.`,
+		`:15: Keyword parameter "x" for "getattr" should be positional.`,
+		`:16: Keyword parameter "x" for "select" should be positional.`,
+	}, scopeEverywhere)
 }

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -666,8 +666,6 @@ int(x = "3")
 int(x = "13", base = 8)
 dir(x = foo)
 type(x = foo)
-hasattr(x = foo, name = "bar")
-getattr(x = foo, name = "bar", default = "baz")
 select(x = {})
 `, `
 foo(key = value)
@@ -683,8 +681,6 @@ int("3")
 int("13", base = 8)
 dir(foo)
 type(foo)
-hasattr(foo, name = "bar")
-getattr(foo, name = "bar", default = "baz")
 select({})
 `, []string{
 		`:2: Keyword parameter "elements" for "all" should be positional.`,
@@ -699,9 +695,45 @@ select({})
 		`:11: Keyword parameter "x" for "int" should be positional.`,
 		`:12: Keyword parameter "x" for "dir" should be positional.`,
 		`:13: Keyword parameter "x" for "type" should be positional.`,
-		`:14: Keyword parameter "x" for "hasattr" should be positional.`,
-		`:15: Keyword parameter "x" for "getattr" should be positional.`,
-		`:16: Keyword parameter "x" for "select" should be positional.`,
+		`:14: Keyword parameter "x" for "select" should be positional.`,
+	}, scopeEverywhere)
+
+	checkFindingsAndFix(t, "keyword-positional-params", `
+hasattr(
+  x = foo,
+  name = "bar",
+)
+getattr(
+  x = foo,
+  name = "bar",
+)
+getattr(
+  x = foo,
+  name = "bar",
+  default = "baz",
+)
+`, `
+hasattr(
+  foo,
+  "bar",
+)
+getattr(
+  foo,
+  "bar",
+)
+getattr(
+  foo,
+  "bar",
+  "baz",
+)
+`, []string{
+		`:2: Keyword parameter "x" for "hasattr" should be positional.`,
+		`:3: Keyword parameter "name" for "hasattr" should be positional.`,
+		`:6: Keyword parameter "x" for "getattr" should be positional.`,
+		`:7: Keyword parameter "name" for "getattr" should be positional.`,
+		`:10: Keyword parameter "x" for "getattr" should be positional.`,
+		`:11: Keyword parameter "name" for "getattr" should be positional.`,
+		`:12: Keyword parameter "default" for "getattr" should be positional.`,
 	}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "keyword-positional-params", `

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -710,19 +710,24 @@ glob(["*.cc"])
 glob(include = [], exclude = [])
 glob([], exclude = [])
 glob([], [], 1)
+glob([], [], 1, 2)
 glob(*args, [])
 `, `
 glob(["*.cc"], exclude = ["test*"])
 glob(["*.cc"])
 glob([], exclude = [])
 glob([], exclude = [])
-glob([], [], 1)
+glob([], exclude = [], exclude_directories = 1)
+glob([], [], 1, 2)
 glob(*args, [])
 `, []string{
 		`:1: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
 		`:3: Keyword parameter "include" for "glob" should be positional.`,
 		`:5: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
+		`:5: Parameter at the position 3 for "glob" should be keyword (exclude_directories = ...)`,
 		`:6: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
+		`:6: Parameter at the position 3 for "glob" should be keyword (exclude_directories = ...)`,
+		`:7: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
 	}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "keyword-positional-params", `
@@ -731,18 +736,23 @@ native.glob(["*.cc"])
 native.glob(include = [], exclude = [])
 native.glob([], exclude = [])
 native.glob([], [], 1)
+native.glob([], [], 1, 2)
 native.glob(*args, [])
 `, `
 native.glob(["*.cc"], exclude = ["test*"])
 native.glob(["*.cc"])
 native.glob([], exclude = [])
 native.glob([], exclude = [])
-native.glob([], [], 1)
+native.glob([], exclude = [], exclude_directories = 1)
+native.glob([], [], 1, 2)
 native.glob(*args, [])
 `, []string{
 		`:1: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
 		`:3: Keyword parameter "include" for "glob" should be positional.`,
 		`:5: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
+		`:5: Parameter at the position 3 for "glob" should be keyword (exclude_directories = ...)`,
 		`:6: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
+		`:6: Parameter at the position 3 for "glob" should be keyword (exclude_directories = ...)`,
+		`:7: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
 	}, scopeEverywhere)
 }

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -652,7 +652,7 @@ def macro():
 }
 
 func TestKeywordParameters(t *testing.T) {
-	checkFindingsAndFix(t, "keyword-parameters", `
+	checkFindingsAndFix(t, "keyword-positional-params", `
 foo(key = value)
 all(elements = [True, False])
 any(elements = [True, False])
@@ -669,10 +669,6 @@ type(x = foo)
 hasattr(x = foo, name = "bar")
 getattr(x = foo, name = "bar", default = "baz")
 select(x = {})
-glob(["*.cc"], ["test*"])
-native.glob(["*.cc"], ["test*"])
-glob(["*.cc"])
-native.glob(["*.cc"])
 `, `
 foo(key = value)
 all([True, False])
@@ -690,10 +686,6 @@ type(foo)
 hasattr(foo, name = "bar")
 getattr(foo, name = "bar", default = "baz")
 select({})
-glob(["*.cc"], exclude = ["test*"])
-native.glob(["*.cc"], exclude = ["test*"])
-glob(["*.cc"])
-native.glob(["*.cc"])
 `, []string{
 		`:2: Keyword parameter "elements" for "all" should be positional.`,
 		`:3: Keyword parameter "elements" for "any" should be positional.`,
@@ -710,7 +702,47 @@ native.glob(["*.cc"])
 		`:14: Keyword parameter "x" for "hasattr" should be positional.`,
 		`:15: Keyword parameter "x" for "getattr" should be positional.`,
 		`:16: Keyword parameter "x" for "select" should be positional.`,
-		`:17: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
-		`:18: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
+	}, scopeEverywhere)
+
+	checkFindingsAndFix(t, "keyword-positional-params", `
+glob(["*.cc"], ["test*"])
+glob(["*.cc"])
+glob(include = [], exclude = [])
+glob([], exclude = [])
+glob([], [], 1)
+glob(*args, [])
+`, `
+glob(["*.cc"], exclude = ["test*"])
+glob(["*.cc"])
+glob([], exclude = [])
+glob([], exclude = [])
+glob([], [], 1)
+glob(*args, [])
+`, []string{
+		`:1: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
+		`:3: Keyword parameter "include" for "glob" should be positional.`,
+		`:5: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
+		`:6: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
+	}, scopeEverywhere)
+
+	checkFindingsAndFix(t, "keyword-positional-params", `
+native.glob(["*.cc"], ["test*"])
+native.glob(["*.cc"])
+native.glob(include = [], exclude = [])
+native.glob([], exclude = [])
+native.glob([], [], 1)
+native.glob(*args, [])
+`, `
+native.glob(["*.cc"], exclude = ["test*"])
+native.glob(["*.cc"])
+native.glob([], exclude = [])
+native.glob([], exclude = [])
+native.glob([], [], 1)
+native.glob(*args, [])
+`, []string{
+		`:1: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
+		`:3: Keyword parameter "include" for "glob" should be positional.`,
+		`:5: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
+		`:6: Parameter at the position 2 for "glob" should be keyword (exclude = ...)`,
 	}, scopeEverywhere)
 }

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -669,6 +669,10 @@ type(x = foo)
 hasattr(x = foo, name = "bar")
 getattr(x = foo, name = "bar", default = "baz")
 select(x = {})
+glob(["*.cc"], ["test*"])
+native.glob(["*.cc"], ["test*"])
+glob(["*.cc"])
+native.glob(["*.cc"])
 `, `
 foo(key = value)
 all([True, False])
@@ -686,6 +690,10 @@ type(foo)
 hasattr(foo, name = "bar")
 getattr(foo, name = "bar", default = "baz")
 select({})
+glob(["*.cc"], exclude = ["test*"])
+native.glob(["*.cc"], exclude = ["test*"])
+glob(["*.cc"])
+native.glob(["*.cc"])
 `, []string{
 		`:2: Keyword parameter "elements" for "all" should be positional.`,
 		`:3: Keyword parameter "elements" for "any" should be positional.`,
@@ -702,5 +710,7 @@ select({})
 		`:14: Keyword parameter "x" for "hasattr" should be positional.`,
 		`:15: Keyword parameter "x" for "getattr" should be positional.`,
 		`:16: Keyword parameter "x" for "select" should be positional.`,
+		`:17: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
+		`:18: Parameter at the position 2 for "glob" should be keyword (exclude = ...).`,
 	}, scopeEverywhere)
 }


### PR DESCRIPTION
Replaces legacy keyword arguments with positional arguments in some builtin functions, e.g. `bool(x = foo)` -> `bool(foo)`.

bazelbuild/bazel#5010