### PR TITLE
WIP: Add rewrite for @bazel_tools//tools/build_defs/pkg to @rules_pkg

### DIFF
--- a/build/testdata/066.golden
+++ b/build/testdata/066.golden
@@ -1,0 +1,12 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:rpm.bzl", "pkg_rpm")
+
+pkg_tar(
+    name = "test_tar",
+    srcs = [],
+)
+
+pkg_rpm(
+    name = "test_rpm",
+    srcs = [],
+)

--- a/build/testdata/066.in
+++ b/build/testdata/066.in
@@ -1,0 +1,12 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@bazel_tools//tools/build_defs/pkg:rpm.bzl", "pkg_rpm")
+
+pkg_tar(
+    name = "test_tar",
+    srcs = [],
+)
+
+pkg_rpm(
+    name = "test_rpm",
+    srcs = [],
+)


### PR DESCRIPTION
Add rewrite for load("@bazel_tools//tools/build_defs/pkg:...", ...) 
to load("@rules_pkg//:...", ...)

See: https://github.com/bazelbuild/bazel/issues/8857

It can't do WORKSPACE automatically, so it is sort of moot. Maybe not even legitimate to automate this kind of migration.  The only valid update is to add one of these stanza to the workspace

if bazel_federation is NOT mentioned in WORKSPACE

```
maybe(
        http_archive,
        name = "rules_pkg",
        urls = [
            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/rules_pkg-0.2.0.tar.gz",
            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
        ],
        sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
    )
```

Or, if @bazel_federation is already in the WORKSPACE

```
load("@bazel_federation//:repositories.bzl", "rules_pkg")
rules_pkg()
```
