### PR TITLE
Fix the string escape warning

### DIFF
--- a/warn/warn_operation.go
+++ b/warn/warn_operation.go
@@ -117,7 +117,10 @@ func stringEscapeWarning(f *build.File) []*LinterFinding {
 
 	build.WalkPointers(f, func(expr *build.Expr, stack []build.Expr) {
 		str, ok := (*expr).(*build.StringExpr)
-		if !ok {
+		if !ok || len(str.Token) == 0 {
+			// String literals with empty Token field may appear if they are manually created StringExpr nodes
+			// (token is only used as a hint to the printer, if it doesn't exist, the Value field is used to
+			// generate the string literal).
 			return
 		}
 


### PR DESCRIPTION
If multiple warning functions are applied to the same AST, another may generate a StringExpr node with an empty Token field. Such nodes can't have wrong escape sequences because their value will be encoded to a string literal later correctly, and they can cause index out of bound errors if buildifier attempts to parse their Token fields.