### PR TITLE
Fix false positive argument detection for function-docstring-args

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -69,12 +69,6 @@ type docstringInfo struct {
 	argumentsPos build.Position            // line of the `Arguments:` block (not `Args:`), if it exists
 }
 
-// docstringBlock contains a block of a docstring (separated by empty lines)
-type docstringBlock struct {
-	startLineNo int      // line number of the first line of the block
-	lines       []string // lines
-}
-
 // countLeadingSpaces returns the number of leading spaces of a string.
 func countLeadingSpaces(s string) int {
 	spaces := 0
@@ -133,6 +127,7 @@ func parseFunctionDocstring(doc *build.StringExpr) docstringInfo {
 			isArgumentsDescription = true
 			continue
 		case prefix + "Returns:":
+			isArgumentsDescription = false
 			info.returns = true
 			continue
 		}

--- a/warn/warn_docstring_test.go
+++ b/warn/warn_docstring_test.go
@@ -178,11 +178,16 @@ func TestFunctionDocstringArgs(t *testing.T) {
 def f(x):
    """This is a function.
 
+   Documented here:
+   http://example.com
+
    Args:
-     x: something
+     x: something, as described at
+       http://example.com
 
    Returns:
-     something
+     something, as described at
+     https://example.com
    """
    pass
    pass


### PR DESCRIPTION
If the `Returns:` section contains a line starting with `foo:` (for example, a link starting with `https://`), buildifier parses it as an argument description (and usually shows a false-positive warning for an argument which is documented but doesn't exist).