### PR TITLE
Disambiguate the definition of docstrings

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -334,11 +334,12 @@ just use a list of strings.
   * Automatic fix: no
 
 Public functions should have docstrings describing functions and their signatures.
-A docstring is a string statement which should be the first statement of the file
-(it may follow comment lines). Docstrings are expected to be formatted in the
-following way:
+A docstring is a string literal (not a comment) which should be the first statement
+of a function (it may follow comment lines). Function docstrings are expected to be
+formatted in the following way:
 
-    """One-line summary: must be followed and may be preceded by a blank line.
+    """
+    One-line summary: must be followed and may be preceded by a blank line.
 
     Optional additional description like this.
 
@@ -463,8 +464,15 @@ they can follow only comments and docstrings.
   * Category name: `module-docstring`
   * Automatic fix: no
 
-`.bzl` files should have docstrings on top of them. A docstring is a string statement
-which should be the first statement of the file (it may follow comment lines).
+`.bzl` files should have docstrings on top of them. A docstring is a string literal
+(not a comment) which should be the first statement of the file (it may follow
+comment lines). For example:
+
+    """
+    This module contains build rules for my project.
+    """
+    
+    ...
 
 --------------------------------------------------------------------------------
 

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -338,8 +338,7 @@ A docstring is a string literal (not a comment) which should be the first statem
 of a function (it may follow comment lines). Function docstrings are expected to be
 formatted in the following way:
 
-    """
-    One-line summary: must be followed and may be preceded by a blank line.
+    """One-line summary: must be followed and may be preceded by a blank line.
 
     Optional additional description like this.
 

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -131,7 +131,7 @@ test_dir/to_fix_tmp.bzl: applied fixes, 1 warnings left
 fixed test_dir/to_fix_tmp.bzl
 EOF
 
-error_docstring="test_dir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
+error_docstring="test_dir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring."$'\n'"A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines). (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
 error_integer="test_dir/to_fix_tmp.bzl:1: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
 error_dict="test_dir/to_fix_tmp.bzl:2: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
 error_cfg="test_dir/to_fix_tmp.bzl:3: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -212,7 +212,7 @@ func functionDocstringWarning(f *build.File) []*LinterFinding {
 		}
 
 		message := fmt.Sprintf(`The function %q has no docstring.
-A docstring is a string literal (not a comment) which should be the first statement of a function body (it may follow comment lines)`, def.Name)
+A docstring is a string literal (not a comment) which should be the first statement of a function body (it may follow comment lines).`, def.Name)
 		finding := makeLinterFinding(def, message)
 		finding.End = def.ColonPos
 		findings = append(findings, finding)

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -39,7 +39,8 @@ func moduleDocstringWarning(f *build.File) []*LinterFinding {
 			LineRune: start.LineRune + 1,
 			Byte:     start.Byte + 1,
 		}
-		finding := makeLinterFinding(stmt, "The file has no module docstring.")
+		finding := makeLinterFinding(stmt, `The file has no module docstring.
+A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines).`)
 		finding.End = end
 		return []*LinterFinding{finding}
 	}
@@ -210,7 +211,8 @@ func functionDocstringWarning(f *build.File) []*LinterFinding {
 			continue
 		}
 
-		message := fmt.Sprintf("The function %q has no docstring.", def.Name)
+		message := fmt.Sprintf(`The function %q has no docstring.
+A docstring is a string literal (not a comment) which should be the first statement of a function body (it may follow comment lines)`, def.Name)
 		finding := makeLinterFinding(def, message)
 		finding.End = def.ColonPos
 		findings = append(findings, finding)


### PR DESCRIPTION
Users often confuse docstrings with comments, make the difference clear.