### PR TITLE
expose add_table flag to buildifier rule

### DIFF
--- a/buildifier/def.bzl
+++ b/buildifier/def.bzl
@@ -18,6 +18,8 @@ def _buildifier_impl(ctx):
         args.append("-multi_diff")
     if ctx.attr.diff_command:
         args.append("-diff_command=%s" % ctx.attr.diff_command)
+    if ctx.attr.add_tables:
+        args.append("-add_tables=%s" % ctx.file.add_tables.path)
 
     exclude_patterns_str = ""
     if ctx.attr.exclude_patterns:
@@ -72,6 +74,11 @@ _buildifier = rule(
         "multi_diff": attr.bool(
             default = False,
             doc = "Set to True if the diff command specified by the 'diff_command' can diff multiple files in the style of 'tkdiff'",
+        ),
+        "add_tables": attr.label(
+            mandatory = False,
+            doc="path to JSON file with custom table definitions which will be merged with the built-in tables",
+            allow_single_file = True,
         ),
         "_buildifier": attr.label(
             default = "@com_github_bazelbuild_buildtools//buildifier",


### PR DESCRIPTION
In a repo with custom Bazel rules, we need to tell buildifier to sort additional list than those defined by default. This diff allows use to pass in a JSON file like:

```
{
  "IsSortableListArg": {
    "topics": true
  }
}
```

So the buildifier will sort `topics` list in BUILD files too.