### PR TITLE
Implement .bzl files visibility warning

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,7 @@ config_setting(
 filegroup(
     name = "warnings",
     srcs = ["WARNINGS.md"],
-    visibility = ["//warn:__pkg__"]
+    visibility = ["//warn:__pkg__"],
 )
 
 test_suite(

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -147,10 +147,12 @@ arguments should be explicit.
   * Category name: `bzl-visibility`
   * Automatic fix: no
 
-Some .bzl files are considered "hidden" and supposed to be loaded only from within the same packages.
-For example, if a .bzl file is located inside a directory named `internal` or `private`, e.g.
-`foo/bar/internal/sub/file.bzl`, it should be used only within the boundaries of the parent directory
-for `internal` or `private` (`foo/bar` in the example above).
+If a directory `foo` contains a subdirectory `internal` or `private`, only files located under `foo`
+can access it.
+
+For example, `dir/rules_mockascript/private/foo.bzl` can be loaded from
+`dir/rules_mockascript/private/bar.bzl` or `dir/rules_mockascript/sub/public.bzl`,
+but not from `dir/other_rule/file.bzl`.
 
 --------------------------------------------------------------------------------
 

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -8,6 +8,7 @@ Warning categories supported by buildifier's linter:
   * [attr-output-default](#attr-output-default)
   * [attr-single-file](#attr-single-file)
   * [build-args-kwargs](#build-args-kwargs)
+  * [bzl-visibility](#bzl-visibility)
   * [confusing-name](#confusing-name)
   * [constant-glob](#constant-glob)
   * [ctx-actions](#ctx-actions)
@@ -69,7 +70,7 @@ the expression that causes the warning. Historically comments with `buildozer` i
     A multiline comment as a string literal.
     Docstrings don't trigger the warning if they are first statements of a file or a function.
     """
-    
+
     if debug:
         print("Debug information:", foo)  # buildifier: disable=print
 
@@ -138,6 +139,18 @@ is deprecated, please use `allow_single_file` instead.
 
 Having `*args` or `**kwargs` makes BUILD files hard to read and manipulate. The list of
 arguments should be explicit.
+
+--------------------------------------------------------------------------------
+
+## <a name="bzl-visibility"></a>Module shouldn't be used directly
+
+  * Category name: `bzl-visibility`
+  * Automatic fix: no
+
+Some .bzl files are considered "hidden" and supposed to be loaded only from within the same packages.
+For example, if a .bzl file is located inside a directory named `internal` or `private`, e.g.
+`foo/bar/internal/sub/file.bzl`, it should be used only within the boundaries of the parent directory
+for `internal` or `private` (`foo/bar` in the example above).
 
 --------------------------------------------------------------------------------
 
@@ -475,7 +488,7 @@ comment lines). For example:
     """
     This module contains build rules for my project.
     """
-    
+
     ...
 
 --------------------------------------------------------------------------------

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -90,9 +90,10 @@ func stmtsEnd(stmts []Expr) Position {
 	return Position{}
 }
 
-// A File represents an entire BUILD file.
+// A File represents an entire BUILD or .bzl file.
 type File struct {
 	Path string // file path, relative to workspace directory
+	Pkg  string // optional; the package of the file
 	Type FileType
 	Comments
 	Stmt []Expr

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -327,8 +327,8 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		return utils.InvalidFileDiagnostics(displayFilename), exitCode
 	}
 
-	pkg := utils.GetPackageName(displayFilename)
-	warnings := utils.Lint(f, pkg, lint, warningsList, *vflag)
+	f.Pkg = utils.GetPackageName(displayFilename)
+	warnings := utils.Lint(f, lint, warningsList, *vflag)
 	if len(warnings) > 0 {
 		exitCode = 4
 	}

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -81,12 +81,13 @@ func GetParser(inputType string) func(filename string, data []byte) (*build.File
 // GetPackageName returns the package name of a file by searching for a WORKSPACE file
 func GetPackageName(filename string) string {
 	dirs := filepath.SplitList(path.Dir(filename))
+	dirs = append([]string{""}, dirs...)
 	parent := ""
 	index := len(dirs) - 1
 	for i, chunk := range dirs {
 		parent = path.Join(parent, chunk)
-		metadata := path.Join(parent, "METADATA")
-		if _, err := os.Stat(metadata); !os.IsNotExist(err) {
+		workspace := path.Join(parent, "WORKSPACE")
+		if _, err := os.Stat(workspace); !os.IsNotExist(err) {
 			index = i
 		}
 	}
@@ -94,12 +95,12 @@ func GetPackageName(filename string) string {
 }
 
 // Lint calls the linter and returns a list of unresolved findings
-func Lint(f *build.File, pkg, lint string, warningsList *[]string, verbose bool) []*warn.Finding {
+func Lint(f *build.File, lint string, warningsList *[]string, verbose bool) []*warn.Finding {
 	switch lint {
 	case "warn":
-		return warn.FileWarnings(f, pkg, *warningsList, nil, warn.ModeWarn)
+		return warn.FileWarnings(f, *warningsList, nil, warn.ModeWarn)
 	case "fix":
-		warn.FixWarnings(f, pkg, *warningsList, verbose)
+		warn.FixWarnings(f, *warningsList, verbose)
 	}
 	return nil
 }

--- a/warn/BUILD.bazel
+++ b/warn/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "warn_docstring.go",
         "warn_naming.go",
         "warn_operation.go",
+        "warn_visibility.go",
     ],
     importpath = "github.com/bazelbuild/buildtools/warn",
     visibility = ["//visibility:public"],
@@ -39,11 +40,12 @@ go_test(
         "warn_naming_test.go",
         "warn_operation_test.go",
         "warn_test.go",
+        "warn_visibility_test.go",
     ],
-    embed = [":go_default_library"],
     data = [
         "//:warnings",
     ],
+    embed = [":go_default_library"],
     deps = [
         "//testutils",
     ],

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -22,13 +22,13 @@ const (
 func getFilename(fileType build.FileType) string {
 	switch fileType {
 	case build.TypeBuild:
-		return "package/BUILD"
+		return "test/package/BUILD"
 	case build.TypeWorkspace:
-		return "package/WORKSPACE"
+		return "test/package/WORKSPACE"
 	case build.TypeBzl:
-		return "package/test_file.bzl"
+		return "test/package/test_file.bzl"
 	default:
-		return "test_file.strlrk"
+		return "test/package/test_file.strlrk"
 	}
 }
 
@@ -38,7 +38,8 @@ func getFindings(category, input string, fileType build.FileType) []*Finding {
 	if err != nil {
 		panic(fmt.Sprintf("%v", err))
 	}
-	return FileWarnings(buildFile, "the_package", []string{category}, nil, ModeWarn)
+	buildFile.Pkg = "test/package"
+	return FileWarnings(buildFile, []string{category}, nil, ModeWarn)
 }
 
 func compareFindings(t *testing.T, category, input string, expected []string, scope, fileType build.FileType) {
@@ -86,7 +87,7 @@ func checkFix(t *testing.T, category, input, expected string, scope, fileType bu
 		panic(fmt.Sprintf("%v", err))
 	}
 
-	FixWarnings(buildFile, "the_package", []string{category}, false)
+	FixWarnings(buildFile, []string{category}, false)
 	have := build.Format(buildFile)
 	want := build.Format(goldenFile)
 	if !bytes.Equal(have, want) {
@@ -106,7 +107,7 @@ func checkNoFix(t *testing.T, category, input string, fileType build.FileType) {
 	formatted := build.Format(buildFile)
 
 	// No fixes expected
-	FileWarnings(buildFile, "the_package", []string{category}, nil, ModeWarn)
+	FileWarnings(buildFile, []string{category}, nil, ModeWarn)
 	fixed := build.Format(buildFile)
 
 	if !bytes.Equal(formatted, fixed) {
@@ -244,7 +245,7 @@ attr.baz("baz", cfg = "data")
 		t.Fatalf("Parse error: %v", err)
 	}
 
-	findings := FileWarnings(f, "pkg", []string{"attr-cfg"}, nil, ModeSuggest)
+	findings := FileWarnings(f, []string{"attr-cfg"}, nil, ModeSuggest)
 	want := []struct {
 		start       int
 		end         int

--- a/warn/warn_visibility.go
+++ b/warn/warn_visibility.go
@@ -1,0 +1,40 @@
+// Warnings about visibility of .bzl files
+
+package warn
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/bazelbuild/buildtools/build"
+)
+
+var internalDirectory = regexp.MustCompile("/(internal|private)[/:]")
+
+func deprecatedBzlLoadWarning(f *build.File) []*LinterFinding {
+	var findings []*LinterFinding
+
+	for _, stmt := range f.Stmt {
+		load, ok := stmt.(*build.LoadStmt)
+		if !ok || load.Module == nil {
+			continue
+		}
+
+		pkg := "//" + f.Pkg  // Canonical name of the package
+		chunks := internalDirectory.Split(load.Module.Value, 2)
+		if len(chunks) < 2 {
+			continue
+		}
+
+		if strings.HasPrefix(pkg, chunks[0]) {
+			continue
+		}
+
+		findings = append(findings, makeLinterFinding(
+			load.Module,
+			fmt.Sprintf("Module %q can only be loaded from files located inside %q, not from %q.", load.Module.Value, chunks[0], pkg)))
+	}
+
+	return findings
+}

--- a/warn/warn_visibility_test.go
+++ b/warn/warn_visibility_test.go
@@ -1,0 +1,46 @@
+package warn
+
+import "testing"
+
+func TestBzlVisibility(t *testing.T) {
+	checkFindings(t, "bzl-visibility", `
+load("//foo/bar/internal/baz:module.bzl", "foo")
+load("//foo/bar/private/baz:module.bzl", "bar")
+load("//foo/bar/external/baz:module.bzl", "baz")
+
+foo()
+bar()
+baz()
+`,
+		[]string{
+			`:1: Module "//foo/bar/internal/baz:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+			`:2: Module "//foo/bar/private/baz:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+		},
+		scopeEverywhere)
+
+	checkFindings(t, "bzl-visibility", `
+load("//foo/bar/internal:module.bzl", "foo")
+load("//foo/bar/private:module.bzl", "bar")
+load("//foo/bar/external:module.bzl", "baz")
+
+foo()
+bar()
+baz()
+`,
+		[]string{
+			`:1: Module "//foo/bar/internal:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+			`:2: Module "//foo/bar/private:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+		},
+		scopeEverywhere)
+
+	checkFindings(t, "bzl-visibility", `
+load("//test/internal/foo:module.bzl", "foo")
+load("//test/private/foo:module.bzl", "bar")
+load("//test/external/foo:module.bzl", "baz")
+load("//test/internal:module.bzl", "foo")
+load("//test/private:module.bzl", "bar")
+load("//test/external:module.bzl", "baz")
+`,
+		[]string{},
+		scopeEverywhere)
+}


### PR DESCRIPTION
If a .bzl file is located within a directory called `private` or `internal`, it should only be loaded from files located directly or indirectly in the directory parent to `private` or `internal`.

Fixes #702.