### PR TITLE
Fix ResolveAttr

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -607,6 +607,10 @@ func ResolveAttr(r *build.Rule, attr, pkg string) {
 	var toExtract []build.Expr
 
 	e := r.Attr(attr)
+	if e == nil {
+		return
+	}
+
 	for _, sel := range AllSelects(e) {
 		intersection := SelectListsIntersection(sel, pkg)
 		if intersection != nil {


### PR DESCRIPTION
`ResolveAttr` simplifies a rule attribute by concatenating the lists and extracting common elements from selects, however it can be applied to attributes that has just been deleted, in that case it should do nothing (as opposed to setting the attribute's value to `nil` which leads to a broken AST).