### PR TITLE
buildifier: Add additional patterns in runner.bash.template

### DIFF
--- a/buildifier/runner.bash.template
+++ b/buildifier/runner.bash.template
@@ -13,6 +13,12 @@ buildifier_short_path=$(readlink "$BUILDIFIER_SHORT_PATH")
                 -o -name BUILD.bazel \
                 -o -name BUILD \
                 -o -name '*.BUILD' \
-                -o -name WORKSPACE \) \
+                -o -name 'BUILD.*.bazel' \
+                -o -name 'BUILD.*.oss' \
+                -o -name WORKSPACE \
+                -o -name WORKSPACE.bazel \
+                -o -name WORKSPACE.oss \
+                -o -name 'WORKSPACE.*.bazel' \
+                -o -name 'WORKSPACE.*.oss' \) \
              -print \
         | xargs "$buildifier_short_path" "${ARGS[@]}")


### PR DESCRIPTION
Add `(BUILD|WORKSPACE).*.(oss|bazel)` pattern in `runner.bash.template` so that they are processed on `bazel run //:buildifier`. Those patterns are introduced in f8b2ce4c.
Fixes #704