### PR TITLE
Allow string escapes for raw strings

### DIFF
--- a/warn/warn_operation.go
+++ b/warn/warn_operation.go
@@ -117,10 +117,11 @@ func stringEscapeWarning(f *build.File) []*LinterFinding {
 
 	build.WalkPointers(f, func(expr *build.Expr, stack []build.Expr) {
 		str, ok := (*expr).(*build.StringExpr)
-		if !ok || len(str.Token) == 0 {
+		if !ok || len(str.Token) == 0 || strings.HasPrefix(str.Token, "r") {
 			// String literals with empty Token field may appear if they are manually created StringExpr nodes
 			// (token is only used as a hint to the printer, if it doesn't exist, the Value field is used to
 			// generate the string literal).
+			// Raw strings are allowed to have backslashes anywhere.
 			return
 		}
 

--- a/warn/warn_operation_test.go
+++ b/warn/warn_operation_test.go
@@ -136,4 +136,18 @@ func TestStringEscape(t *testing.T) {
 `,
 		},
 		scopeEverywhere)
+
+	checkFindings(t, "string-escape", `
+r'foo'
+r'\\foo\\"bar"\\'
+r"\foo"
+r'"\foo"\\\bar'
+
+r'''
+"asdf"
+\a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x43\y\z\0\1\2\3\4\5\6\7\8\9
+'''
+`,
+		[]string{},
+		scopeEverywhere)
 }


### PR DESCRIPTION
The `string-escape` check shouldn't be applied to raw string literals.