### PR TITLE
more comments to syntax.go

### DIFF
--- a/build/syntax.go
+++ b/build/syntax.go
@@ -43,7 +43,8 @@ func (p Position) add(s string) Position {
 	return p
 }
 
-// An Expr represents an input element.
+// An Expr represents an input element (things like, go_binary, java_library,
+// and so on).
 type Expr interface {
 	// Span returns the start and end position of the expression,
 	// excluding leading or trailing comments.
@@ -380,11 +381,19 @@ func (x *BinaryExpr) Span() (start, end Position) {
 // An AssignExpr represents a binary expression with `=`: LHS = RHS.
 type AssignExpr struct {
 	Comments
-	LHS       Expr
-	OpPos     Position
-	Op        string
-	LineBreak bool // insert line break between Op and RHS
-	RHS       Expr
+	// LHS is the left hand side operation. For example, if the expression is
+	// "default_visibility = [:foo]", the LHS is "default_visibility".
+	LHS Expr
+	// OpPos is the position of the Op.
+	OpPos Position
+	// Op is the operation of the expression. For example, if the expression
+	// is "default_visibility = [:foo]", the Op is "="".
+	Op string
+	// LineBreak is whether there is a linebreak between Op and RHS.
+	LineBreak bool
+	// RHS is the left hand side operation. For example, if the expression is
+	// "default_visibility = [:foo]", the RHS is "[:foo]".
+	RHS Expr
 }
 
 func (x *AssignExpr) Span() (start, end Position) {


### PR DESCRIPTION
I took a stab at better documenting some things in syntax.go, which I've struggled to parse from godoc alone. I probably got some things slightly (or very) wrong - let me know if the comments can be improved.