### PR TITLE
buildozer: Add command for appending to lists in a dict attribute

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -111,6 +111,8 @@ Buildozer supports the following commands(`'command args'`):
   * `dict_set <attr> <(key:value)(s)>`:  Sets the value of a key for the dict
     attribute `attr`. If the key was already present, its old value is replaced.
   * `dict_delete <attr> <key(s)>`:  Deletes the key for the dict attribute `attr`.
+  * `dict_list_add <attr> <key> <value(s)>`:  Adds value(s) to the list in the
+    dict attribute `attr`.
 
 Here, `<attr>` represents an attribute (being `add`ed/`rename`d/`delete`d etc.),
 e.g.: `srcs`, `<value(s)>` represents values of the attribute and so on.

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -573,6 +573,33 @@ func cmdDictRemove(opts *Options, env CmdEnvironment) (*build.File, error) {
 	return env.File, nil
 }
 
+// cmdDictListAdd adds an item to a list in a dict.
+func cmdDictListAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
+	attr := env.Args[0]
+	key := env.Args[1]
+	args := env.Args[2:]
+
+	dict := &build.DictExpr{}
+	if currDict, ok := env.Rule.Attr(attr).(*build.DictExpr); ok {
+		dict = currDict
+	}
+
+	prev := DictionaryGet(dict, key)
+	if prev == nil {
+		prev = &build.ListExpr{}
+	}
+
+	for _, val := range args {
+		expr := getStringExpr(val, env.Pkg)
+		prev = AddValueToList(prev, env.Pkg, expr, true)
+	}
+
+	DictionarySet(dict, key, prev)
+	env.Rule.SetAttr(attr, dict)
+
+	return env.File, nil
+}
+
 func copyAttributeBetweenRules(env CmdEnvironment, attrName string, from string) (*build.File, error) {
 	fromRule := FindRuleByName(env.File, from)
 	if fromRule == nil {
@@ -634,6 +661,7 @@ var AllCommands = map[string]CommandInfo{
 	"dict_add":          {cmdDictAdd, true, 2, -1, "<attr> <(key:value)(s)>"},
 	"dict_set":          {cmdDictSet, true, 2, -1, "<attr> <(key:value)(s)>"},
 	"dict_remove":       {cmdDictRemove, true, 2, -1, "<attr> <key(s)>"},
+	"dict_list_add":     {cmdDictListAdd, true, 3, -1, "<attr> <key> <value(s)>"},
 }
 
 func expandTargets(f *build.File, rule string) ([]*build.Rule, error) {


### PR DESCRIPTION
We've recently added a build attribute which is a [string_list_dict](https://docs.bazel.build/versions/master/skylark/lib/attr.html#string_list_dict), just to find out that there is no way to operate on such an attribute from buildozer, so I'm sending this PR. Thanks.

Example:

```
buildozer 'dict_list_add attr key1 value1 value2' 'dict_list_add attr key2 value3' //some/target
```

Should generate:
```
a_rule(
    name = "target",
    attr = {
        "key1": [
            "value1",
            "value2",
        ],
        "key2": ["value3"],
    },
)
```

Internal bug: b/22484279