### PR TITLE
Don't warn about positional arguments if a macro has just one argument

### DIFF
--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -133,6 +133,9 @@ func positionalArgumentsWarning(call *build.CallExpr, pkg string) *LinterFinding
 	if id, ok := call.X.(*build.Ident); !ok || functionsWithPositionalArguments[id.Name] {
 		return nil
 	}
+	if len(call.List) <= 1 {
+		return nil
+	}
 	for _, arg := range call.List {
 		if _, ok := arg.(*build.AssignExpr); ok {
 			continue

--- a/warn/warn_bazel_test.go
+++ b/warn/warn_bazel_test.go
@@ -67,7 +67,7 @@ func TestPositionalArguments(t *testing.T) {
 my_macro(foo = "bar")
 my_macro("foo", "bar")
 my_macro(foo = bar(x))
-[my_macro(foo) for foo in bar]`,
+[my_macro(foo, bar) for foo in bar]`,
 		[]string{
 			":2: All calls to rules or macros should pass arguments by keyword (arg_name=value) syntax.",
 			":4: All calls to rules or macros should pass arguments by keyword (arg_name=value) syntax.",
@@ -78,6 +78,13 @@ my_macro(foo = bar(x))
 register_toolchains(
 	"//foo",
 	"//bar",
+)`,
+		[]string{},
+		scopeBuild|scopeWorkspace)
+
+	checkFindings(t, "positional-args", `
+my_macro(
+	"//foo",
 )`,
 		[]string{},
 		scopeBuild|scopeWorkspace)


### PR DESCRIPTION
Fixes #727.