### PR TITLE
Fix targetExpressionToBuildFiles

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -984,11 +984,12 @@ func targetExpressionToBuildFiles(rootDir string, target string) []string {
 		}
 	}
 
-	if !strings.HasSuffix(file, "/.../BUILD") {
+	suffix := filepath.Join("", "...", "BUILD") // /.../BUILD
+	if !strings.HasSuffix(file, suffix) {
 		return []string{file}
 	}
 
-	return findBuildFiles(strings.TrimSuffix(file, "/.../BUILD"))
+	return findBuildFiles(strings.TrimSuffix(file, suffix))
 }
 
 // Given a root directory, returns all "BUILD" files in that subtree recursively.

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -34,7 +34,6 @@ import (
 	apipb "github.com/bazelbuild/buildtools/api_proto"
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/buildtools/file"
-	"github.com/bazelbuild/buildtools/wspace"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -974,16 +973,8 @@ func runBuildifier(opts *Options, f *build.File) ([]byte, error) {
 }
 
 // Given a target, whose package may contain a trailing "/...", returns all
-// extisting BUILD file paths which match the package.
+// existing BUILD file paths which match the package.
 func targetExpressionToBuildFiles(rootDir string, target string) []string {
-	if strings.Contains(target, "/...") {
-		absoluteRoot, _ := wspace.FindWorkspaceRoot(rootDir)
-		_, pkg, _ := ParseLabel(target)
-		// if we have /... somewhere in the target ParseLabel will leave that at the end
-		pkg = strings.TrimSuffix(pkg, "...")
-		return findBuildFiles(filepath.Join(absoluteRoot, pkg))
-	}
-
 	file, _, _ := InterpretLabelForWorkspaceLocation(rootDir, target)
 	if rootDir == "" {
 		var err error
@@ -992,7 +983,12 @@ func targetExpressionToBuildFiles(rootDir string, target string) []string {
 			os.Exit(1)
 		}
 	}
-	return []string{file}
+
+	if !strings.HasSuffix(file, "/.../BUILD") {
+		return []string{file}
+	}
+
+	return findBuildFiles(strings.TrimSuffix(file, "/.../BUILD"))
 }
 
 // Given a root directory, returns all "BUILD" files in that subtree recursively.

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -164,7 +164,11 @@ func runTestTargetExpressionToBuildFiles(t *testing.T, buildFileName string) {
 		{tmp, "//a/b/...", []string{filepath.Join(tmp, "a", "b", buildFileName)}},
 		{tmp, "//a/c/...", []string{filepath.Join(tmp, "a", "c", buildFileName)}},
 		{tmp, "//a/c/...:foo", []string{filepath.Join(tmp, "a", "c", buildFileName)}},
+		{"", "...:foo", []string{filepath.Join(tmp, buildFileName), filepath.Join(tmp, "a", buildFileName), filepath.Join(tmp, "a", "b", buildFileName), filepath.Join(tmp, "a", "c", buildFileName)}},
 	} {
+		if err := os.Chdir(tmp); err != nil {
+			t.Fatal(err)
+		}
 		buildFiles := targetExpressionToBuildFiles(tc.rootDir, tc.target)
 		expectedBuildFilesMap := make(map[string]bool)
 		buildFilesMap := make(map[string]bool)

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -166,9 +166,13 @@ func runTestTargetExpressionToBuildFiles(t *testing.T, buildFileName string) {
 		{tmp, "//a/c/...:foo", []string{filepath.Join(tmp, "a", "c", buildFileName)}},
 		{"", "...:foo", []string{filepath.Join(tmp, buildFileName), filepath.Join(tmp, "a", buildFileName), filepath.Join(tmp, "a", "b", buildFileName), filepath.Join(tmp, "a", "c", buildFileName)}},
 	} {
-		if err := os.Chdir(tmp); err != nil {
-			t.Fatal(err)
+		if tc.rootDir == "" {
+			// buildozer should be able to find the WORKSPACE file in the current wd
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatal(err)
+			}
 		}
+
 		buildFiles := targetExpressionToBuildFiles(tc.rootDir, tc.target)
 		expectedBuildFilesMap := make(map[string]bool)
 		buildFilesMap := make(map[string]bool)

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -129,6 +129,13 @@ func runTestTargetExpressionToBuildFiles(t *testing.T, buildFileName string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// On MacOS "/tmp" is a symlink to "/private/tmp". Resolve it to make the testing easier
+	tmp, err = filepath.EvalSymlinks(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	defer os.RemoveAll(tmp)
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "b"), 0755); err != nil {
 		t.Fatal(err)

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -137,7 +137,7 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 
 	if strings.HasPrefix(target, "//") {
 		buildFile = filepath.Join(rootDir, pkg, "BUILD")
-		if !isFile(buildFile) {
+		if !isFile(buildFile) && isFile(buildFile+".bazel") {
 			// try it with the .bazel extension
 			buildFile += ".bazel"
 		}
@@ -154,7 +154,7 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 	} else {
 		buildFile = "BUILD"
 	}
-	if !isFile(buildFile) {
+	if !isFile(buildFile) && isFile(buildFile+".bazel") {
 		// try it with the .bazel extension
 		buildFile += ".bazel"
 	}


### PR DESCRIPTION
The behavior was partially broken by #732. `targetExpressionToBuildFiles` was returning incorrect results if it was called with an empty `rootDir` parameter and a `target` containing `"..."` (e.g. when buildozer was called with `...:*` as a target).