### PR TITLE
Fix parser for adding to dictionary

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -513,7 +513,7 @@ func cmdDictAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	}
 
 	for _, x := range args {
-		kv := strings.Split(x, ":")
+		kv := strings.SplitN(x, ":", 2)
 		expr := getStringExpr(kv[1], env.Pkg)
 
 		prev := DictionaryGet(dict, kv[0])
@@ -538,7 +538,7 @@ func cmdDictSet(opts *Options, env CmdEnvironment) (*build.File, error) {
 	}
 
 	for _, x := range args {
-		kv := strings.Split(x, ":")
+		kv := strings.SplitN(x, ":", 2)
 		expr := getStringExpr(kv[1], env.Pkg)
 		// Set overwrites previous values.
 		DictionarySet(dict, kv[0], expr)


### PR DESCRIPTION
This is a repeat of #730.  I opened the original with the wrong account for the CLA.

If a dictionary value contains a :, then the value is not parsed correctly. Need to preserve everything after the first :. One example where this comes up is setting environment variables for paths when using container_image from the docker rules. For example, when running dict_add env PATH:/a/b/c:/d/e/f it ends up only including /a/b/c and it ignores /d/e/f.