### PR TITLE
Print an empty line after statements with after-comments

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -225,7 +225,7 @@ func (p *printer) statements(rawStmts []Expr) {
 // We omit the blank line when both are subinclude statements
 // and the second one has no leading comments.
 func (p *printer) compactStmt(s1, s2 Expr) bool {
-	if len(s2.Comment().Before) > 0 {
+	if len(s2.Comment().Before) > 0 || len(s1.Comment().After) > 0 {
 		return false
 	} else if isLoad(s1) && isLoad(s2) {
 		// Load statements should be compact

--- a/build/testdata/055.golden
+++ b/build/testdata/055.golden
@@ -4,6 +4,9 @@ load(
     ":foobar.bzl",
     "foobar",
 )
+load(":baz.bzl", "baz")
+# after-comment
+
 load(
     # 0
     "foobar.bzl",  # 1

--- a/build/testdata/055.in
+++ b/build/testdata/055.in
@@ -4,6 +4,9 @@ load(":bar.bzl","bar")
 load(
   ":foobar.bzl",foobar="foobar")
 
+load(":baz.bzl", "baz")
+# after-comment
+
 load( # 0
   "foobar.bzl", # 1
   "foo", # 2

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -173,6 +173,25 @@ bar()`,
 			":9: Load statements should be at the top of the file.",
 			":15: Load statements should be at the top of the file.",
 		}, scopeDefault|scopeBzl|scopeBuild)
+
+	checkFindingsAndFix(t, "load-on-top", `
+load(":f.bzl", "x")
+# after-comment
+
+x()
+
+load(":g.bzl", "y")
+`, `
+load(":f.bzl", "x")
+# after-comment
+
+load(":g.bzl", "y")
+
+x()
+`,
+		[]string{
+			":6: Load statements should be at the top of the file.",
+		}, scopeDefault|scopeBzl|scopeBuild)
 }
 
 func TestOutOfOrderLoad(t *testing.T) {


### PR DESCRIPTION
If a statement has an after-comment it should be seaparated from the next statement by an empty line:

    foo()
    # comment

    bar()

The problem can't occur during formatting because the formatter attaches comments to the statement after by default, but it can occur if the parsed AST has been modified, e.g. during the `load-on-top` fix.