### PR TITLE
Add "disable" keywords for better docs search

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -60,7 +60,7 @@ Warning categories supported by buildifier's linter:
 
 ### How to disable warnings
 
-All warnings can be disabled by adding a special comment `# buildifier: disable=<category_name>` to
+All warnings can be disabled / suppressed / ignored by adding a special comment `# buildifier: disable=<category_name>` to
 the expression that causes the warning. Historically comments with `buildozer` instead of
 `buildifier` are also supported, they are equivalent.
 


### PR DESCRIPTION
This is basically GitHub SEO.

I'm adding this out of frustration I had while trying to find how does one suppress Buildifier warnings. I was sure I saw it somewhere in the docs but couldn't find it because I was searching for "suppress" and "ignore" but not the "disable" 😅