### PR TITLE
Improve the warning message if no documented args are found

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -290,12 +290,34 @@ func functionDocstringArgsWarning(f *build.File) []*LinterFinding {
 		// Check whether all existing arguments are commented
 		if len(notDocumentedArguments) > 0 {
 			message := fmt.Sprintf("Argument %q is not documented.", notDocumentedArguments[0])
+			plural := ""
 			if len(notDocumentedArguments) > 1 {
 				message = fmt.Sprintf(
 					`Arguments "%s" are not documented.`,
 					strings.Join(notDocumentedArguments, `", "`),
 				)
+				plural = "s"
 			}
+
+			if len(info.args) == 0 {
+				// No arguments are documented maybe the Args: block doesn't exist at all or
+				// formatted improperly. Add extra information to the warning message
+				message += fmt.Sprintf(`
+
+If the documentation for the argument%s exists but is not recognized by Buildifier
+make sure it follows the line "Args:" which has the same indentation as the opening """,
+and the argument description starts with "<argument_name>:" and indented with at least
+one (preferably two) space more than "Args:", for example:
+
+    def %s(%s):
+        """Function description.
+
+        Args:
+          %s: argument description, can be
+            multiline with additional indentation.
+        """`, plural, def.Name, notDocumentedArguments[0], notDocumentedArguments[0])
+			}
+
 			findings = append(findings, makeLinterFinding(doc, message))
 		}
 

--- a/warn/warn_docstring_test.go
+++ b/warn/warn_docstring_test.go
@@ -275,7 +275,7 @@ def f(x, y):
 		}, scopeEverywhere)
 
 	checkFindings(t, "function-docstring-args", `
-def f(x, y, z = None, *args, **kwargs):
+def my_function(x, y, z = None, *args, **kwargs):
    """This is a function.
    """
    pass
@@ -285,7 +285,20 @@ def f(x, y, z = None, *args, **kwargs):
    pass
 `,
 		[]string{
-			`2: Arguments "x", "y", "z", "*args", "**kwargs" are not documented.`,
+			`2: Arguments "x", "y", "z", "*args", "**kwargs" are not documented.
+
+If the documentation for the arguments exists but is not recognized by Buildifier
+make sure it follows the line "Args:" which has the same indentation as the opening """,
+and the argument description starts with "<argument_name>:" and indented with at least
+one (preferably two) space more than "Args:", for example:
+
+    def my_function(x):
+        """Function description.
+
+        Args:
+          x: argument description, can be
+            multiline with additional indentation.
+        """`,
 		},
 		scopeEverywhere)
 


### PR DESCRIPTION
It's possible that the arguments are documented but not correctly and Buildifier fails to parse that. If Buildifier thinks that no arguments are documented at all, print some additional information on how exactly the documentation should look like.