### PR TITLE
Fix string quoting

### DIFF
--- a/build/quote.go
+++ b/build/quote.go
@@ -240,17 +240,9 @@ func quote(unquoted string, triple bool) string {
 			continue
 		}
 		if c == '\\' {
+			// All backslashes should be escaped
 			buf.WriteByte('\\')
-			if i+1 < len(unquoted) && escapable[unquoted[i+1]] {
-				// Can pass \ through when followed by a byte that
-				// known not to be a valid escape sequence and also
-				// that does not trigger an escape sequence of its own.
-				// Use this, because various BUILD files do.
-				buf.WriteByte(unquoted[i+1])
-				i++
-			} else {
-				buf.WriteByte('\\')
-			}
+			buf.WriteByte('\\')
 			continue
 		}
 		if esc[c] != 0 {

--- a/build/testdata/060.golden
+++ b/build/testdata/060.golden
@@ -38,7 +38,7 @@ strings = [
     r'''"""\foo''',
     r"""\foo""",
     r"""'''\foo""",
-    r"\a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x43\y\z\0\1\2\3\4\5\6\7\8\9",
+    r"\a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x43\y\z\0\1\2\3\4\5\6\7\8\9\\n",
 
     # contain incorrect escape sequences
     "\\a'",

--- a/build/testdata/060.in
+++ b/build/testdata/060.in
@@ -38,7 +38,7 @@ strings = [
   r'''"""\foo''',
   r"""\foo""",
   r"""'''\foo""",
-  r"\a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x43\y\z\0\1\2\3\4\5\6\7\8\9",
+  r"\a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x43\y\z\0\1\2\3\4\5\6\7\8\9\\n",
 
   # contain incorrect escape sequences
   "\a'",


### PR DESCRIPTION
All backslashes now should be unconditionally escaped in string literals.

The behavior was broken by #762  
Fixed #766