### PR TITLE
Improve the warning message for missing argument documentation

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -323,22 +323,23 @@ one (preferably two) space more than "Args:", for example:
 
 		// Check whether all documented arguments actually exist in the function signature.
 		for name, pos := range info.args {
-			if !paramNames[name] {
-				msg := fmt.Sprintf("Argument %q is documented but doesn't exist in the function signature.", name)
-				// *args and **kwargs should be documented with asterisks
-				for _, asterisks := range []string{"*", "**"} {
-					if paramNames[asterisks+name] {
-						msg += fmt.Sprintf(` Do you mean "%s%s"?`, asterisks, name)
-						break
-					}
-				}
-				posEnd := pos
-				posEnd.LineRune += len(name)
-				finding := makeLinterFinding(doc, msg)
-				finding.Start = pos
-				finding.End = posEnd
-				findings = append(findings, finding)
+			if paramNames[name] {
+				continue
 			}
+			msg := fmt.Sprintf("Argument %q is documented but doesn't exist in the function signature.", name)
+			// *args and **kwargs should be documented with asterisks
+			for _, asterisks := range []string{"*", "**"} {
+				if paramNames[asterisks+name] {
+					msg += fmt.Sprintf(` Do you mean "%s%s"?`, asterisks, name)
+					break
+				}
+			}
+			posEnd := pos
+			posEnd.LineRune += len(name)
+			finding := makeLinterFinding(doc, msg)
+			finding.Start = pos
+			finding.End = posEnd
+			findings = append(findings, finding)
 		}
 	}
 	return findings

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -324,9 +324,17 @@ one (preferably two) space more than "Args:", for example:
 		// Check whether all documented arguments actually exist in the function signature.
 		for name, pos := range info.args {
 			if !paramNames[name] {
+				msg := fmt.Sprintf("Argument %q is documented but doesn't exist in the function signature.", name)
+				// *args and **kwargs should be documented with asterisks
+				for _, asterisks := range []string{"*", "**"} {
+					if paramNames[asterisks+name] {
+						msg += fmt.Sprintf(` Do you mean "%s%s"?`, asterisks, name)
+						break
+					}
+				}
 				posEnd := pos
 				posEnd.LineRune += len(name)
-				finding := makeLinterFinding(doc, fmt.Sprintf("Argument %q is documented but doesn't exist in the function signature.", name))
+				finding := makeLinterFinding(doc, msg)
 				finding.Start = pos
 				finding.End = posEnd
 				findings = append(findings, finding)

--- a/warn/warn_docstring_test.go
+++ b/warn/warn_docstring_test.go
@@ -344,6 +344,26 @@ def f(x):
 `,
 		[]string{},
 		scopeEverywhere)
+
+	checkFindings(t, "function-docstring-args", `
+def f(foobar, *bar, **baz):
+  """Some function
+  
+  Args:
+    foobar: something
+    foo: something
+    bar: something
+    baz: something
+  """
+  pass
+`,
+		[]string{
+			`:2: Arguments "*bar", "**baz" are not documented.`,
+			`:6: Argument "foo" is documented but doesn't exist in the function signature.`,
+			`:7: Argument "bar" is documented but doesn't exist in the function signature. Do you mean "*bar"?`,
+			`:8: Argument "baz" is documented but doesn't exist in the function signature. Do you mean "**baz"?`,
+		},
+		scopeEverywhere)
 }
 
 func TestFunctionDocstringReturn(t *testing.T) {


### PR DESCRIPTION
If a function signature contains arguments with asterisks ("*args" or "**kwargs") users often forget to include the asterisks into the documentation, which causes warnings like `Arguments "*args", "**kwargs" are not documented` and `Argument "args" is documented but doesn't exist in the function signature`. To avoid the confusion, the latter warning message is extended with `Do you mean "*args"?` (or `"**kwargs"`) if such an argument actually exists in the function signature.


Closes #768