### PR TITLE
Allow buildozer arguments to be joined with newlines

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -726,7 +726,7 @@ func checkCommandUsage(name string, cmd CommandInfo, count int) {
 }
 
 // Match text that only contains spaces if they're escaped with '\'.
-var spaceRegex = regexp.MustCompile(`(\\ |[^ ])+`)
+var spaceRegex = regexp.MustCompile(`(\\ |[^ \n])+`)
 
 // SplitOnSpaces behaves like strings.Fields, except that spaces can be escaped.
 // " some dummy\\ string" -> ["some", "dummy string"]

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -118,6 +118,7 @@ var splitOnSpacesTests = []struct {
 	{"a", []string{"a"}},
 	{"  abc def ", []string{"abc", "def"}},
 	{`  abc\ def `, []string{"abc def"}},
+	{"  abc def\nghi", []string{"abc",  "def", "ghi"}},
 }
 
 func TestSplitOnSpaces(t *testing.T) {


### PR DESCRIPTION
Fixes #735