### PR TITLE
Update the skylark_syntax repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,8 +32,9 @@ gazelle_dependencies()
 
 go_repository(
     name = "skylark_syntax",
-    commit = "6677ee5c7211380ec7e6a1b50dc45287e40ca9e1",
     importpath = "go.starlark.net",
+    sum = "h1:Qoe+9POtDT51UBQ8XEnS9QKeHDQzEl2QRh3eok9R4aw=",
+    version = "v0.0.0-20200203144150-6677ee5c7211",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,42 +4,49 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "b27e55d2dcc9e6020e17614ae6e0374818a3e3ce6f2024036e688ada24110444",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
     ],
-    sha256 = "b27e55d2dcc9e6020e17614ae6e0374818a3e3ce6f2024036e688ada24110444",
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
+
 go_register_toolchains()
 
 http_archive(
     name = "bazel_gazelle",
+    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
     ],
-    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
 )
+
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
 gazelle_dependencies()
+
 go_repository(
     name = "skylark_syntax",
-    commit = "fc7a7f44baedf13df916b2aad597bc944964dd27",
+    commit = "6677ee5c7211380ec7e6a1b50dc45287e40ca9e1",
     importpath = "go.starlark.net",
 )
 
 http_archive(
     name = "com_google_protobuf",
+    sha256 = "e8c7601439dbd4489fe5069c33d374804990a56c2f710e00227ee5d8fd650e67",
     strip_prefix = "protobuf-3.11.2",
     urls = [
         "https://github.com/protocolbuffers/protobuf/archive/v3.11.2.tar.gz",
     ],
-    sha256 = "e8c7601439dbd4489fe5069c33d374804990a56c2f710e00227ee5d8fd650e67",
 )
+
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()
 
 http_archive(
@@ -51,9 +58,13 @@ http_archive(
         "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
     ],
 )
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
+
 buildifier_dependencies()

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -28,9 +28,7 @@ sh_test(
 
 go_library(
     name = "go_default_library",
-    srcs = [
-      "buildifier.go",
-    ],
+    srcs = ["buildifier.go"],
     importpath = "github.com/bazelbuild/buildtools/buildifier",
     visibility = ["//visibility:private"],
     deps = [

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -3,24 +3,28 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-      "diagnostics.go",
-      "flags.go",
-      "tempfile.go",
-      "utils.go",
+        "diagnostics.go",
+        "flags.go",
+        "tempfile.go",
+        "utils.go",
     ],
+    importpath = "github.com/bazelbuild/buildtools/buildifier/utils",
+    visibility = ["//buildifier:__pkg__"],
     deps = [
         "//build:go_default_library",
         "//warn:go_default_library",
     ],
-    importpath = "github.com/bazelbuild/buildtools/buildifier/utils",
-    visibility = ["//buildifier:__pkg__"],
 )
 
 go_test(
     name = "utils_test",
     size = "small",
-    srcs = [
-        "utils_test.go",
-    ],
+    srcs = ["utils_test.go"],
+    embed = [":go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["utils_test.go"],
     embed = [":go_default_library"],
 )

--- a/buildozer/BUILD.bazel
+++ b/buildozer/BUILD.bazel
@@ -5,15 +5,15 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/bazelbuild/buildtools/buildozer",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "main.buildVersion": "{STABLE_buildVersion}",
+        "main.buildScmRevision": "{STABLE_buildScmRevision}",
+    },
     deps = [
         "//build:go_default_library",
         "//edit:go_default_library",
         "//tables:go_default_library",
     ],
-    x_defs = {
-        "main.buildVersion": "{STABLE_buildVersion}",
-        "main.buildScmRevision": "{STABLE_buildScmRevision}",
-    },
 )
 
 go_binary(

--- a/bzlenv/BUILD.bazel
+++ b/bzlenv/BUILD.bazel
@@ -14,3 +14,10 @@ go_test(
     srcs = ["bzlenv_test.go"],
     embed = [":go_default_library"],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = ["bzlenv_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//build:go_default_library"],
+)

--- a/warn/BUILD.bazel
+++ b/warn/BUILD.bazel
@@ -47,6 +47,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//build:go_default_library",
+        "//tables:go_default_library",
         "//testutils",
     ],
 )


### PR DESCRIPTION
The old repository definition is broken on the CI for Windows (but somehow works on the other platforms). Updating it fixes the problem (and also updates the dependency to the latest version).

Fixes #776