### PR TITLE
Add publishing to npm

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build:release -c opt --stamp --workspace_status_command="$PWD/status.py"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
+exports_files([
+    "LICENSE",
+    "launcher.js",
+])
+
 config_setting(
     name = "windows",
     values = {"cpu": "x64_windows"},

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,3 +69,12 @@ rules_proto_toolchains()
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
 
 buildifier_dependencies()
+
+# We don't use any nodejs but this includes a rule for publishing releases to npm
+http_archive(
+    name = "build_bazel_rules_nodejs",
+    sha256 = "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"],
+)
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+node_repositories()

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
@@ -73,4 +75,32 @@ go_library(
 exports_files(
     ["runner.bash.template"],
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "launcher",
+    srcs = ["//:launcher.js"],
+    outs = ["buildifier.js"],
+    cmd = "sed s/_TOOL_/buildifier/ $< > $@",
+)
+
+copy_file(
+    name = "copy_LICENSE",
+    src = "//:LICENSE",
+    out = "LICENSE",
+)
+
+pkg_npm(
+    name = "npm_package",
+    srcs = [
+        "package.json",
+        "README.md",
+    ],
+    deps = [
+        "LICENSE",
+        "buildifier.js",
+        ":buildifier-darwin",
+        ":buildifier-linux",
+        ":buildifier-windows",
+    ]
 )

--- a/buildifier/package.json
+++ b/buildifier/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@bazel/buildifier",
+    "description": "A tool for formatting bazel BUILD and .bzl files",
+    "version": "0.0.0-PLACEHOLDER",
+    "license": "Apache-2.0",
+    "bin": {
+        "buildifier": "buildifier.js"
+    },
+    "keywords": [
+        "bazel"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bazelbuild/buildtools.git"
+    },
+    "bugs": {
+        "url": "https://github.com/bazelbuild/buildtools/issues"
+    }
+}

--- a/buildozer/BUILD.bazel
+++ b/buildozer/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -50,4 +52,33 @@ go_binary(
     goos = "windows",
     pure = "on",
     visibility = ["//visibility:public"],
+)
+
+
+genrule(
+    name = "launcher",
+    srcs = ["//:launcher.js"],
+    outs = ["buildozer.js"],
+    cmd = "sed s/_TOOL_/buildozer/ $< > $@",
+)
+
+copy_file(
+    name = "copy_LICENSE",
+    src = "//:LICENSE",
+    out = "LICENSE",
+)
+
+pkg_npm(
+    name = "npm_package",
+    srcs = [
+        "package.json",
+        "README.md",
+    ],
+    deps = [
+        "LICENSE",
+        "buildozer.js",
+        ":buildozer-darwin",
+        ":buildozer-linux",
+        ":buildozer-windows",
+    ]
 )

--- a/buildozer/package.json
+++ b/buildozer/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@bazel/buildozer",
+    "description": "A command line tool to rewrite multiple BUILD files using standard commands",
+    "version": "0.0.0-PLACEHOLDER",
+    "license": "Apache-2.0",
+    "bin": {
+        "buildozer": "buildozer.js"
+    },
+    "keywords": [
+        "bazel"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bazelbuild/buildtools.git"
+    },
+    "bugs": {
+        "url": "https://github.com/bazelbuild/buildtools/issues"
+    }
+}

--- a/launcher.js
+++ b/launcher.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+// This package inspired by
+// https://github.com/angular/clang-format/blob/master/index.js
+const os = require('os');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+function getNativeBinary() {
+  const arch = {
+    'x64' : 'amd64',
+  }[os.arch()];
+  // Filter the platform based on the platforms that are build/included.
+  const platform = {
+    'darwin' : 'darwin',
+    'linux' : 'linux',
+    'win32' : 'windows',
+  }[os.platform()];
+  const extension = {
+    'darwin' : '',
+    'linux' : '',
+    'win32' : '.exe',
+  }[os.platform()];
+
+  if (arch == undefined || platform == undefined) {
+    console.error(`FATAL: Your platform/architecture combination ${
+        os.platform()} - ${os.arch()} is not yet supported.
+    See instructions at https://github.com/bazelbuild/buildtools/blob/master/_TOOL_/README.md.`);
+    return Promise.resolve(1);
+  }
+
+  const binary =
+      path.join(__dirname, `_TOOL_-${platform}_${arch}${extension}`);
+  return binary;
+}
+
+function main(args) {
+  const binary = getNativeBinary();
+  const ps = spawn(binary, args, {stdio : 'inherit'});
+
+  function shutdown() {
+    ps.kill("SIGTERM")
+    process.exit();
+  }
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  ps.on('close', e => process.exitCode = e);
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}
+
+module.exports = {
+  getNativeBinary,
+};

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -u -e -o pipefail 
+
+# TODO(vladmos): add bits for publishing go binaries to github￼
+
+# Googlers: you should npm login using the go/npm-publish service:
+#      $ npm login --registry https://wombat-dressing-room.appspot.com
+# Non-googlers: you should run this script with
+#      $ NPM_REGISTRY=https://registry.npmjs.org ./release.sh ...
+REGISTRY=${NPM_REGISTRY:-https://wombat-dressing-room.appspot.com}
+readonly NPM_ARGS=(
+    "--access public"
+    "--tag latest"
+    "--registry $REGISTRY"
+    # Uncomment for testing
+    # "--dry-run"
+)
+for pkg in buildifier buildozer; do
+    bazel run --config=release //$pkg:npm_package.publish -- ${NPM_ARGS[@]}
+done

--- a/status.py
+++ b/status.py
@@ -17,6 +17,9 @@ def main():
     tags = run("git", "describe", "--tags")
     print("STABLE_buildVersion", tags.split("-")[0])
 
+    # rules_nodejs expects to read from volatile-status.txt
+    print("BUILD_SCM_VERSION", tags.split("-")[0])
+    
     revision = run("git", "rev-parse", "HEAD")
     print("STABLE_buildScmRevision", revision)
 


### PR DESCRIPTION
This replaces the mirroring we currently do in https://github.com/bazelbuild/rules_nodejs/blob/master/scripts/mirror_buildtools.sh