### PR TITLE
builddozer: Remove exit code printout when reformat is needed for diff mode (#349)

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -373,8 +373,9 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		}
 		if err := diff.Show(infile, outfile); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return fileDiagnostics, 4
+			return fileDiagnostics, 3
 		}
+		return fileDiagnostics, 4
 
 	case "pipe":
 		// pipe mode - reading from stdin, writing to stdout.


### PR DESCRIPTION
Remove the exit code that is produced when we are using diff mode. This is due to that diff programs return 1 when there is a diff between files.