### PR TITLE
Fix .bzl visibility warnings

### DIFF
--- a/build/syntax.go
+++ b/build/syntax.go
@@ -92,9 +92,10 @@ func stmtsEnd(stmts []Expr) Position {
 
 // A File represents an entire BUILD or .bzl file.
 type File struct {
-	Path string // file path, relative to workspace directory
-	Pkg  string // optional; the package of the file
-	Type FileType
+	Path          string // absolute file path
+	Pkg           string // optional; the package of the file
+	WorkspaceRoot string // optional; path to the directory containing the WORKSPACE file
+	Type          FileType
 	Comments
 	Stmt []Expr
 }

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -327,7 +328,10 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 		return utils.InvalidFileDiagnostics(displayFilename), exitCode
 	}
 
-	_, f.Pkg = utils.SplitFilePath(displayFilename)
+	if absoluteFilename, err := filepath.Abs(displayFilename); err == nil {
+		f.WorkspaceRoot, f.Pkg = utils.SplitFilePath(absoluteFilename)
+	}
+
 	warnings := utils.Lint(f, lint, warningsList, *vflag)
 	if len(warnings) > 0 {
 		exitCode = 4

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -33,6 +33,7 @@ die () {
 buildifier="$(rlocation "$buildifier")"
 buildifier2="$(rlocation "$buildifier2")"
 
+touch WORKSPACE
 mkdir -p test_dir/subdir
 mkdir -p golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
@@ -97,50 +98,63 @@ fi
 # Test the linter
 
 cat > test_dir/to_fix.bzl <<EOF
+load("//foo/bar/internal/baz:module.bzl", "b")
+
 a = b / c
 d = {"b": 2, "a": 1}
 attr.foo(bar, cfg = "data")
 EOF
 
 cat > test_dir/fixed_golden.bzl <<EOF
+load("//foo/bar/internal/baz:module.bzl", "b")
+
 a = b // c
 d = {"b": 2, "a": 1}
 attr.foo(bar)
 EOF
 
 cat > test_dir/fixed_golden_all.bzl <<EOF
+load("//foo/bar/internal/baz:module.bzl", "b")
+
 a = b // c
 d = {"a": 1, "b": 2}
 attr.foo(bar)
 EOF
 
 cat > test_dir/fixed_golden_dict_cfg.bzl <<EOF
+load("//foo/bar/internal/baz:module.bzl", "b")
+
 a = b / c
 d = {"a": 1, "b": 2}
 attr.foo(bar)
 EOF
 
 cat > test_dir/fixed_golden_cfg.bzl <<EOF
+load("//foo/bar/internal/baz:module.bzl", "b")
+
 a = b / c
 d = {"b": 2, "a": 1}
 attr.foo(bar)
 EOF
 
 cat > test_dir/fix_report_golden <<EOF
-test_dir/to_fix_tmp.bzl: applied fixes, 1 warnings left
+test_dir/to_fix_tmp.bzl: applied fixes, 2 warnings left
 fixed test_dir/to_fix_tmp.bzl
 EOF
 
+error_bzl="test_dir/to_fix_tmp.bzl:1: bzl-visibility: Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//test_dir\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#bzl-visibility)"
 error_docstring="test_dir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring."$'\n'"A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines). (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
-error_integer="test_dir/to_fix_tmp.bzl:1: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
-error_dict="test_dir/to_fix_tmp.bzl:2: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
-error_cfg="test_dir/to_fix_tmp.bzl:3: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"
+error_integer="test_dir/to_fix_tmp.bzl:3: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
+error_dict="test_dir/to_fix_tmp.bzl:4: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
+error_cfg="test_dir/to_fix_tmp.bzl:5: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"
 
 test_lint () {
   ret=0
   cp test_dir/to_fix.bzl test_dir/to_fix_tmp.bzl
   echo "$4" > golden/error_golden
-  echo "${4//test_dir\/to_fix_tmp.bzl/foo.bzl}" > golden/error_golden_foo
+  cp golden/error_golden golden/error_golden_foo
+  sed -i 's/test_dir/another\/test\/dir/g' golden/error_golden_foo
+  sed -i 's/to_fix_tmp.bzl/foo.bzl/g' golden/error_golden_foo
 
   cat > golden/fix_report_golden <<EOF
 test_dir/to_fix_tmp.bzl: applied fixes, $5 warnings left
@@ -163,7 +177,7 @@ EOF
   diff test_dir/error golden/error_golden || die "$1: wrong console output for --lint=warn"
 
   # --lint=warn with --path
-  $buildifier --lint=warn --path=foo.bzl $2 test_dir/to_fix_tmp.bzl 2> test_dir/error || ret=$?
+  $buildifier --lint=warn --path=another/test/dir/foo.bzl $2 test_dir/to_fix_tmp.bzl 2> test_dir/error || ret=$?
   if [[ $ret -ne 4 ]]; then
     die "$1: warn: Expected buildifier to exit with 4, actual: $ret"
   fi
@@ -178,8 +192,8 @@ EOF
   diff test_dir/fix_report golden/fix_report_golden || die "$1: wrong console output for --lint=fix"
 }
 
-test_lint "default" "" "test_dir/fixed_golden.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_cfg" 1
-test_lint "all" "--warnings=all" "test_dir/fixed_golden_all.bzl" "$error_integer"$'\n'"$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
+test_lint "default" "" "test_dir/fixed_golden.bzl" "$error_docstring"$'\n'"$error_integer"$'\n'"$error_cfg" 1
+test_lint "all" "--warnings=all" "test_dir/fixed_golden_all.bzl" "$error_bzl"$'\n'"$error_docstring"$'\n'"$error_integer"$'\n'"$error_dict"$'\n'"$error_cfg" 2
 test_lint "cfg" "--warnings=attr-cfg" "test_dir/fixed_golden_cfg.bzl" "$error_cfg" 0
 test_lint "custom" "--warnings=-integer-division,+unsorted-dict-items" "test_dir/fixed_golden_dict_cfg.bzl" "$error_docstring"$'\n'"$error_dict"$'\n'"$error_cfg" 1
 
@@ -219,11 +233,11 @@ cat > golden/json_report_golden <<EOF
             "warnings": [
                 {
                     "start": {
-                        "line": 1,
+                        "line": 3,
                         "column": 5
                     },
                     "end": {
-                        "line": 1,
+                        "line": 3,
                         "column": 10
                     },
                     "category": "integer-division",
@@ -233,11 +247,11 @@ cat > golden/json_report_golden <<EOF
                 },
                 {
                     "start": {
-                        "line": 3,
+                        "line": 5,
                         "column": 15
                     },
                     "end": {
-                        "line": 3,
+                        "line": 5,
                         "column": 27
                     },
                     "category": "attr-cfg",

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -34,6 +34,7 @@ buildifier="$(rlocation "$buildifier")"
 buildifier2="$(rlocation "$buildifier2")"
 
 touch WORKSPACE.bazel
+rm -r test_dir || true
 mkdir -p test_dir/subdir
 mkdir -p golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -17,13 +17,6 @@ go_library(
 )
 
 go_test(
-    name = "utils_test",
-    size = "small",
-    srcs = ["utils_test.go"],
-    embed = [":go_default_library"],
-)
-
-go_test(
     name = "go_default_test",
     srcs = ["utils_test.go"],
     embed = [":go_default_library"],

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -77,7 +77,7 @@ func GetParser(inputType string) func(filename string, data []byte) (*build.File
 }
 
 // hasWorkspaceFile checks whether a given directory contains a file called
-// WORKSPACE or WORKSPACE.bazel. The contents are not checked
+// WORKSPACE or WORKSPACE.bazel.
 func hasWorkspaceFile(path string) bool {
 	for _, filename := range []string{"WORKSPACE", "WORKSPACE.bazel"} {
 		workspace := filepath.Join(path, filename)

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -4,7 +4,6 @@ package utils
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -95,7 +94,7 @@ func hasWorkspaceFile(path string) bool {
 // contains a WORKSPACE (or WORKSPACE.bazel) file.
 // Returns empty strings if no WORKSPACE file is found
 func SplitFilePath(filename string) (workspaceRoot, pkg string) {
-	directory := path.Dir(filename)
+	directory := filepath.Dir(filename)
 	root := "/"
 	if volume := filepath.VolumeName(directory); volume != "" {
 		// Windows

--- a/buildifier/utils/utils_test.go
+++ b/buildifier/utils/utils_test.go
@@ -148,6 +148,13 @@ func TestSplitFilePath(t *testing.T) {
 	checkSplitFilePathOutput(t, "WORKSPACE file exists", filename, dir, "path/to/package")
 	checkSplitFilePathOutput(t, "WORKSPACE file exists, empty package", filepath.Join(dir, "file.bzl"), dir, "")
 
+	// Rename WORKSPACE to WORKSPACE.bazel and try again (dir/WORKSPACE.bazel)
+	if err := os.Rename(filepath.Join(dir, "WORKSPACE"), filepath.Join(dir, "WORKSPACE.bazel")); err != nil {
+		t.Error(err)
+	}
+	checkSplitFilePathOutput(t, "WORKSPACE file exists", filename, dir, "path/to/package")
+	checkSplitFilePathOutput(t, "WORKSPACE file exists, empty package", filepath.Join(dir, "file.bzl"), dir, "")
+
 	// Create another WORKSPACE file and try again (dir/path/WORKSPACE)
 	newRoot := filepath.Join(dir, "path")
 	if err := os.MkdirAll(newRoot, os.ModePerm); err != nil {

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -106,7 +106,7 @@ var FileWarningMap = map[string]func(f *build.File) []*LinterFinding{
 	"attr-output-default":       attrOutputDefaultWarning,
 	"attr-single-file":          attrSingleFileWarning,
 	"build-args-kwargs":         argsKwargsInBuildFilesWarning,
-	"bzl-visibility":            deprecatedBzlLoadWarning,
+	"bzl-visibility":            bzlVisibilityWarning,
 	"confusing-name":            confusingNameWarning,
 	"constant-glob":             constantGlobWarning,
 	"ctx-actions":               ctxActionsWarning,

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -39,6 +39,7 @@ func getFindings(category, input string, fileType build.FileType) []*Finding {
 		panic(fmt.Sprintf("%v", err))
 	}
 	buildFile.Pkg = "test/package"
+	buildFile.WorkspaceRoot = "/home/users/foo/bar"
 	return FileWarnings(buildFile, []string{category}, nil, ModeWarn)
 }
 

--- a/warn/warn_visibility.go
+++ b/warn/warn_visibility.go
@@ -12,8 +12,15 @@ import (
 
 var internalDirectory = regexp.MustCompile("/(internal|private)[/:]")
 
-func deprecatedBzlLoadWarning(f *build.File) []*LinterFinding {
+func bzlVisibilityWarning(f *build.File) []*LinterFinding {
 	var findings []*LinterFinding
+
+	if f.WorkspaceRoot == "" {
+		// Empty workspace root means buildifier doesn't know the location of
+		// the file relative to the workspace directory and can't warn about .bzl
+		// file visibility correctly.
+		return findings
+	}
 
 	for _, stmt := range f.Stmt {
 		load, ok := stmt.(*build.LoadStmt)


### PR DESCRIPTION
The warning didn't work correctly with relative file paths.