### PR TITLE
fix(buildifier): add rules_nodejs to //buildifier:deps.bzl target

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,13 +70,6 @@ load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_depen
 
 buildifier_dependencies()
 
-# We don't use any nodejs but this includes a rule for publishing releases to npm
-http_archive(
-    name = "build_bazel_rules_nodejs",
-    sha256 = "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"],
-)
-
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 
 node_repositories()

--- a/buildifier/deps.bzl
+++ b/buildifier/deps.bzl
@@ -9,6 +9,13 @@ def buildifier_dependencies():
         url = "https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz",  # 2018-12-06
     )
 
+    _maybe(
+        http_archive,
+        name = "build_bazel_rules_nodejs",
+        sha256 = "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"],
+    )
+
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)


### PR DESCRIPTION
Commit `98244f725d46ab37614ac6bbb653a6827a46fabd` introduced an implicit
dependency on `rules_nodejs` within `//buildifier:BUILD`, which breaks
downstream user's ability to run Buildifier.

This patch uses the `_maybe()` rule (defined within
`//buildifier:deps.bzl`) to conditionally register
`@build_bazel_rules_nodejs` so that downstream users do not need to
define this internal dependency within their `WORKSPACE`.

closes bazelbuild/buildifier#796