### PR TITLE
Allow any characters in string literals to be escaped as code points

### DIFF
--- a/build/quote.go
+++ b/build/quote.go
@@ -55,6 +55,16 @@ var escapable = [256]bool{
 	'\'': true,
 	'\\': true,
 	'"':  true,
+	'0':  true,
+	'1':  true,
+	'2':  true,
+	'3':  true,
+	'4':  true,
+	'5':  true,
+	'6':  true,
+	'7':  true,
+	'8':  true,
+	'9':  true,
 }
 
 // Unquote unquotes the quoted string, returning the actual

--- a/build/testdata/060.golden
+++ b/build/testdata/060.golden
@@ -50,4 +50,5 @@ strings = [
     # correct escape sequences
     """ aa\\bb\n \
   """,
+    "\000\111\222",
 ]

--- a/build/testdata/060.in
+++ b/build/testdata/060.in
@@ -50,4 +50,5 @@ strings = [
   # correct escape sequences
   """ aa\\bb\n \
   """,
+  "\000\111\222",
 ]


### PR DESCRIPTION
Strings like `"\120\113"` won't be reformatted as `"PK"`.