### PR TITLE
Mute false positive warnings for private .bzl files

### DIFF
--- a/warn/warn_visibility.go
+++ b/warn/warn_visibility.go
@@ -37,7 +37,7 @@ func bzlVisibilityWarning(f *build.File) []*LinterFinding {
 		// warnings in case the private file is actually allowed to be used.
 		module := load.Module.Value
 		if strings.HasPrefix(module, "@") {
-			if chunks := strings.SplitN(module, "//",2); len(chunks) == 2 {
+			if chunks := strings.SplitN(module, "//", 2); len(chunks) == 2 {
 				module = "//" + chunks[1]
 			}
 		}

--- a/warn/warn_visibility.go
+++ b/warn/warn_visibility.go
@@ -28,8 +28,22 @@ func bzlVisibilityWarning(f *build.File) []*LinterFinding {
 			continue
 		}
 
+		// A load statement may use a fully qualified module name (including a
+		// repository name). Buildifier should check if the repository name refers
+		// to the current repository, but because it doesn't know the current
+		// repository name it's better to assume that it matches the repository name
+		// in the load statement: this way it may miss some usages of private .bzl
+		// files that aren't supposed to be visible, but won't show false-positive
+		// warnings in case the private file is actually allowed to be used.
+		module := load.Module.Value
+		if strings.HasPrefix(module, "@") {
+			if chunks := strings.SplitN(module, "//",2); len(chunks) == 2 {
+				module = "//" + chunks[1]
+			}
+		}
+
 		pkg := "//" + f.Pkg // Canonical name of the package
-		chunks := internalDirectory.Split(load.Module.Value, 2)
+		chunks := internalDirectory.Split(module, 2)
 		if len(chunks) < 2 {
 			continue
 		}

--- a/warn/warn_visibility_test.go
+++ b/warn/warn_visibility_test.go
@@ -34,12 +34,42 @@ baz()
 		scopeEverywhere)
 
 	checkFindings(t, "bzl-visibility", `
+load("@repo//foo/bar/internal:module.bzl", "foo")
+load("@repo//foo/bar/private:module.bzl", "bar")
+load("@repo//foo/bar/external:module.bzl", "baz")
+load("@repo/internal:module.bzl", "qux")  # incorrect, but shouldn't cause buildifier crashes
+
+
+foo()
+bar()
+baz()
+qux()
+`,
+		[]string{
+			`:1: Module "@repo//foo/bar/internal:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+			`:2: Module "@repo//foo/bar/private:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+			`:4: Module "@repo/internal:module.bzl" can only be loaded from files located inside "@repo", not from "//test/package".`,
+		},
+		scopeEverywhere)
+
+	checkFindings(t, "bzl-visibility", `
 load("//test/internal/foo:module.bzl", "foo")
 load("//test/private/foo:module.bzl", "bar")
 load("//test/external/foo:module.bzl", "baz")
 load("//test/internal:module.bzl", "foo")
 load("//test/private:module.bzl", "bar")
 load("//test/external:module.bzl", "baz")
+`,
+		[]string{},
+		scopeEverywhere)
+
+	checkFindings(t, "bzl-visibility", `
+load("@repo//test/internal/foo:module.bzl", "foo")
+load("@repo//test/private/foo:module.bzl", "bar")
+load("@repo//test/external/foo:module.bzl", "baz")
+load("@repo//test/internal:module.bzl", "foo")
+load("@repo//test/private:module.bzl", "bar")
+load("@repo//test/external:module.bzl", "baz")
 `,
 		[]string{},
 		scopeEverywhere)


### PR DESCRIPTION
If a private .bzl file which is allowed to be loaded from the current file is loaded using a fully quailfied path (including a repository name), buildifier shows a false positive warning for the `bzl-visibility` category.

This change makes buildifier ignore the repository name, which may mute some true positive warnings (if a file is being loaded from another repository but with a similar directory structure) but it also mutes the false positives.

Fixes #718.