### PR TITLE
Implement deprecated function warning

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -13,6 +13,7 @@ Warning categories supported by buildifier's linter:
   * [`constant-glob`](#constant-glob)
   * [`ctx-actions`](#ctx-actions)
   * [`ctx-args`](#ctx-args)
+  * [`deprecated-function`](#deprecated-function)
   * [`depset-iteration`](#depset-iteration)
   * [`depset-union`](#depset-union)
   * [`dict-concatenation`](#dict-concatenation)
@@ -241,6 +242,17 @@ depending on the desired behavior.
 
 --------------------------------------------------------------------------------
 
+## <a name="deprecated-function"></a>The function is deprecated
+
+  * Category name: `deprecated-function`
+  * Automatic fix: no
+
+The defined in another .bzl file has a docstring stating that it's deprecated, i. e. it
+contains a `Deprecated:` section. The convention for function docstrings is described by
+the [`function-docstring`](function-docstring) warning.
+
+--------------------------------------------------------------------------------
+
 ## <a name="depset-iteration"></a>Depset iteration is deprecated
 
   * Category name: `depset-iteration`
@@ -394,6 +406,9 @@ Returns:
   Description of the return value.
   Should be indented by at least one, preferably two spaces (as here)
   Can span multiple lines.
+
+Deprecated:
+  Optional, description of why the function is deprecated and what should be used instead. 
 """
 ```
 

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -124,6 +124,8 @@ func getFileReader(workspaceRoot string) *warn.FileReader {
 	}
 
 	readFile := func(filename string) ([]byte, error) {
+	    // Use OS-specific path separators
+        filename = strings.ReplaceAll(filename, "/", string(os.PathSeparator))
 		path := filepath.Join(workspaceRoot, filename)
 
 		data, err := ioutil.ReadFile(path)

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -131,9 +131,7 @@ func getFileReader(workspaceRoot string) *warn.FileReader {
 		return ioutil.ReadFile(path)
 	}
 
-	fileReader := &warn.FileReader{}
-	fileReader.NewFileReader(readFile)
-	return fileReader
+	return warn.NewFileReader(readFile)
 }
 
 // Lint calls the linter and returns a list of unresolved findings

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -3,7 +3,7 @@
 package utils
 
 import (
-    "io/ioutil"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,19 +124,15 @@ func getFileReader(workspaceRoot string) *warn.FileReader {
 	}
 
 	readFile := func(filename string) ([]byte, error) {
-	    // Use OS-specific path separators
-        filename = strings.ReplaceAll(filename, "/", string(os.PathSeparator))
+		// Use OS-specific path separators
+		filename = strings.ReplaceAll(filename, "/", string(os.PathSeparator))
 		path := filepath.Join(workspaceRoot, filename)
 
-		data, err := ioutil.ReadFile(path)
-		if err != nil {
-			return nil, err
-		}
-		return data, nil
+		return ioutil.ReadFile(path)
 	}
 
 	fileReader := &warn.FileReader{}
-	fileReader.Init(readFile)
+	fileReader.NewFileReader(readFile)
 	return fileReader
 }
 

--- a/warn/BUILD.bazel
+++ b/warn/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "multifile.go",
         "types.go",
         "warn.go",
         "warn_bazel.go",
@@ -10,6 +11,7 @@ go_library(
         "warn_bazel_operation.go",
         "warn_control_flow.go",
         "warn_cosmetic.go",
+        "warn_deprecated.go",
         "warn_docstring.go",
         "warn_naming.go",
         "warn_operation.go",
@@ -36,6 +38,7 @@ go_test(
         "warn_bazel_test.go",
         "warn_control_flow_test.go",
         "warn_cosmetic_test.go",
+        "warn_deprecated_test.go",
         "warn_docstring_test.go",
         "warn_naming_test.go",
         "warn_operation_test.go",

--- a/warn/multifile.go
+++ b/warn/multifile.go
@@ -11,12 +11,15 @@ type FileReader struct {
 	readFile func(string) ([]byte, error)
 }
 
-// NewFileReader initializes a FileReader instance with an instance of function
-// that can read an arbitrary file in the repository using a path relative
-// to the workspace root.
-func (fr *FileReader) NewFileReader(readFile func(string) ([]byte, error)) {
-	fr.cache = make(map[string]*build.File)
-	fr.readFile = readFile
+// NewFileReader creates and initializes a FileReader instance with a
+// custom readFile function that can read an arbitrary file in the
+// repository using a path relative to the workspace root
+// (OS-independent, with forward slashes).
+func NewFileReader(readFile func(string) ([]byte, error)) *FileReader {
+	return &FileReader{
+		cache: make(map[string]*build.File),
+		readFile: readFile,
+	}
 }
 
 // retrieveFile reads a Starlark file using only the readFile method

--- a/warn/multifile.go
+++ b/warn/multifile.go
@@ -11,10 +11,10 @@ type FileReader struct {
 	readFile func(string) ([]byte, error)
 }
 
-// Init initializes a FileReader instance with an instance of function
+// NewFileReader initializes a FileReader instance with an instance of function
 // that can read an arbitrary file in the repository using a path relative
 // to the workspace root.
-func (fr *FileReader) Init(readFile func(string) ([]byte, error)) {
+func (fr *FileReader) NewFileReader(readFile func(string) ([]byte, error)) {
 	fr.cache = make(map[string]*build.File)
 	fr.readFile = readFile
 }

--- a/warn/multifile.go
+++ b/warn/multifile.go
@@ -1,0 +1,48 @@
+package warn
+
+import (
+	"github.com/bazelbuild/buildtools/build"
+)
+
+// FileReader is a class that can read an arbitrary Starlark file
+// from the repository and cache the results.
+type FileReader struct {
+	cache    map[string]*build.File
+	readFile func(string) ([]byte, error)
+}
+
+// Init initializes a FileReader instance with an instance of function
+// that can read an arbitrary file in the repository using a path relative
+// to the workspace root.
+func (fr *FileReader) Init(readFile func(string) ([]byte, error)) {
+	fr.cache = make(map[string]*build.File)
+	fr.readFile = readFile
+}
+
+// retrieveFile reads a Starlark file using only the readFile method
+// (without using the cache).
+func (fr *FileReader) retrieveFile(filename string) *build.File {
+	contents, err := fr.readFile(filename)
+	if err != nil {
+		return nil
+	}
+
+	file, err := build.Parse(filename, contents)
+	if err != nil {
+		return nil
+	}
+
+	return file
+}
+
+// GetFile reads a Starlark file from the repository or the cache.
+// Returns nil if the file is not found or not valid.
+func (fr *FileReader) GetFile(filename string) *build.File {
+	// Try to retrieve from the cache
+	if file, ok := fr.cache[filename]; ok {
+		return file
+	}
+	file := fr.retrieveFile(filename)
+	fr.cache[filename] = file
+	return file
+}

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -155,6 +155,11 @@ var FileWarningMap = map[string]func(f *build.File) []*LinterFinding{
 	"unused-variable":           unusedVariableWarning,
 }
 
+// MultiFileWarningMap lists the warnings that run on the whole file, but may use other files.
+var MultiFileWarningMap = map[string]func(f *build.File, fileReader *FileReader) []*LinterFinding{
+	"deprecated-function": deprecatedFunctionWarning,
+}
+
 // nonDefaultWarnings contains warnings that are enabled by default because they're not applicable
 // for all files and cause too much diff noise when applied.
 var nonDefaultWarnings = map[string]bool{
@@ -163,17 +168,26 @@ var nonDefaultWarnings = map[string]bool{
 }
 
 // fileWarningWrapper is a wrapper that converts a file warning function to a generic function.
-// A generic function takes a `pkg string` argument which is not used for file warnings, so it's just removed.
-func fileWarningWrapper(fct func(f *build.File) []*LinterFinding) func(f *build.File, pkg string) []*LinterFinding {
-	return func(f *build.File, pkg string) []*LinterFinding {
+// A generic function takes a `pkg string` and a `*ReadFile` arguments which are not used for file warnings,
+// so they are just removed.
+func fileWarningWrapper(fct func(f *build.File) []*LinterFinding) func(*build.File, string, *FileReader) []*LinterFinding {
+	return func(f *build.File, _ string, _ *FileReader) []*LinterFinding {
 		return fct(f)
+	}
+}
+
+// multiFileWarningWrapper is a wrapper that converts a multifile warning function to a generic function.
+// A generic function takes a `pkg string` argument which is not used for file warnings, so it's just removed.
+func multiFileWarningWrapper(fct func(f *build.File, fileReader *FileReader) []*LinterFinding) func(*build.File, string, *FileReader) []*LinterFinding {
+	return func(f *build.File, _ string, fileReader *FileReader) []*LinterFinding {
+		return fct(f, fileReader)
 	}
 }
 
 // ruleWarningWrapper is a wrapper that converts a per-rule function to a per-file function.
 // It also doesn't run on .bzl or default files, only on BUILD and WORKSPACE files.
-func ruleWarningWrapper(ruleWarning func(call *build.CallExpr, pkg string) *LinterFinding) func(f *build.File, pkg string) []*LinterFinding {
-	return func(f *build.File, pkg string) []*LinterFinding {
+func ruleWarningWrapper(ruleWarning func(call *build.CallExpr, pkg string) *LinterFinding) func(*build.File, string, *FileReader) []*LinterFinding {
+	return func(f *build.File, pkg string, _ *FileReader) []*LinterFinding {
 		if f.Type != build.TypeBuild {
 			return nil
 		}
@@ -200,9 +214,9 @@ func ruleWarningWrapper(ruleWarning func(call *build.CallExpr, pkg string) *Lint
 }
 
 // runWarningsFunction runs a linter/fixer function over a file and applies the fixes conditionally
-func runWarningsFunction(category string, f *build.File, fct func(f *build.File, pkg string) []*LinterFinding, formatted *[]byte, mode LintMode) []*Finding {
+func runWarningsFunction(category string, f *build.File, fct func(f *build.File, pkg string, fileReader *FileReader) []*LinterFinding, formatted *[]byte, mode LintMode, fileReader *FileReader) []*Finding {
 	findings := []*Finding{}
-	for _, w := range fct(f, f.Pkg) {
+	for _, w := range fct(f, f.Pkg, fileReader) {
 		if !DisabledWarning(f, w.Start.Line, category) {
 			finding := makeFinding(f, w.Start, w.End, category, w.URL, w.Message, true, nil)
 			if len(w.Replacement) > 0 {
@@ -265,7 +279,7 @@ func DisabledWarning(f *build.File, findingLine int, warning string) bool {
 }
 
 // FileWarnings returns a list of all warnings found in the file.
-func FileWarnings(f *build.File, enabledWarnings []string, formatted *[]byte, mode LintMode) []*Finding {
+func FileWarnings(f *build.File, enabledWarnings []string, formatted *[]byte, mode LintMode, fileReader *FileReader) []*Finding {
 	findings := []*Finding{}
 
 	// Sort the warnings to make sure they're applied in the same determined order
@@ -281,9 +295,11 @@ func FileWarnings(f *build.File, enabledWarnings []string, formatted *[]byte, mo
 
 	for _, warn := range warnings {
 		if fct, ok := FileWarningMap[warn]; ok {
-			findings = append(findings, runWarningsFunction(warn, f, fileWarningWrapper(fct), formatted, mode)...)
+			findings = append(findings, runWarningsFunction(warn, f, fileWarningWrapper(fct), formatted, mode, fileReader)...)
+		} else if fct, ok := MultiFileWarningMap[warn]; ok {
+			findings = append(findings, runWarningsFunction(warn, f, multiFileWarningWrapper(fct), formatted, mode, fileReader)...)
 		} else if fct, ok := RuleWarningMap[warn]; ok {
-			findings = append(findings, runWarningsFunction(warn, f, ruleWarningWrapper(fct), formatted, mode)...)
+			findings = append(findings, runWarningsFunction(warn, f, ruleWarningWrapper(fct), formatted, mode, fileReader)...)
 		} else {
 			log.Fatalf("unexpected warning %q", warn)
 		}
@@ -340,8 +356,8 @@ func calculateDifference(old, new *[]byte) (start, end int, replacement string) 
 }
 
 // FixWarnings fixes all warnings that can be fixed automatically.
-func FixWarnings(f *build.File, enabledWarnings []string, verbose bool) {
-	warnings := FileWarnings(f, enabledWarnings, nil, ModeFix)
+func FixWarnings(f *build.File, enabledWarnings []string, verbose bool, fileReader *FileReader) {
+	warnings := FileWarnings(f, enabledWarnings, nil, ModeFix, fileReader)
 	if verbose {
 		fmt.Fprintf(os.Stderr, "%s: applied fixes, %d warnings left\n",
 			f.DisplayPath(),
@@ -353,6 +369,9 @@ func collectAllWarnings() []string {
 	var result []string
 	// Collect list of all warnings.
 	for k := range FileWarningMap {
+		result = append(result, k)
+	}
+	for k := range MultiFileWarningMap {
 		result = append(result, k)
 	}
 	for k := range RuleWarningMap {

--- a/warn/warn_deprecated.go
+++ b/warn/warn_deprecated.go
@@ -4,29 +4,23 @@ package warn
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
 )
 
 func getPathFromLabel(label, pkg string) string {
-	var path string // File path relative to the workspace root
 	switch {
 	case strings.HasPrefix(label, "//"):
 		// Absolute label path
-		path = strings.ReplaceAll(label[2:], ":", "/")
+		return strings.ReplaceAll(label[2:], ":", "/")
 	case strings.HasPrefix(label, ":"):
 		// Relative label path
-		path = pkg + "/" + label[1:]
+		return pkg + "/" + label[1:]
 	default:
 		// External repositories are not supported
 		return ""
 	}
-
-	// Use the correct OS-specific slashes
-	path = strings.ReplaceAll(path, "/", string(os.PathSeparator))
-	return path
 }
 
 func readBzlFile(path string, fileReader *FileReader) (*build.File, bool) {

--- a/warn/warn_deprecated.go
+++ b/warn/warn_deprecated.go
@@ -1,0 +1,93 @@
+// Warnings for using deprecated functions
+
+package warn
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bazelbuild/buildtools/build"
+)
+
+func getPathFromLabel(label, pkg string) string {
+	var path string // File path relative to the workspace root
+	switch {
+	case strings.HasPrefix(label, "//"):
+		// Absolute label path
+		path = strings.ReplaceAll(label[2:], ":", "/")
+	case strings.HasPrefix(label, ":"):
+		// Relative label path
+		path = pkg + "/" + label[1:]
+	default:
+		// External repositories are not supported
+		return ""
+	}
+
+	// Use the correct OS-specific slashes
+	path = strings.ReplaceAll(path, "/", string(os.PathSeparator))
+	return path
+}
+
+func readBzlFile(path string, fileReader *FileReader) (*build.File, bool) {
+	file := fileReader.GetFile(path)
+	if file == nil {
+		return nil, false
+	}
+	return file, true
+}
+
+func deprecatedFunctionWarning(f *build.File, fileReader *FileReader) []*LinterFinding {
+	if fileReader == nil {
+		return nil
+	}
+
+	findings := []*LinterFinding{}
+	for _, stmt := range f.Stmt {
+		load, ok := stmt.(*build.LoadStmt)
+		if !ok {
+			continue
+		}
+		path := getPathFromLabel(load.Module.Value, f.Pkg)
+		if path == "" {
+			continue
+		}
+		loadedFile, ok := readBzlFile(path, fileReader)
+		if !ok {
+			continue
+		}
+
+		loadedSymbols := make(map[string]*build.Ident)
+		for _, from := range load.From {
+			loadedSymbols[from.Name] = from
+		}
+
+		for _, stmt := range loadedFile.Stmt {
+			def, ok := stmt.(*build.DefStmt)
+			if !ok {
+				continue
+			}
+			if _, ok := loadedSymbols[def.Name]; !ok {
+				continue
+			}
+			docstring, ok := getDocstring(def.Body)
+			if !ok {
+				continue
+			}
+			str, ok := docstring.(*build.StringExpr)
+			if !ok {
+				continue
+			}
+			docstringInfo := parseFunctionDocstring(str)
+			if !docstringInfo.deprecated {
+				continue
+			}
+
+			findings = append(findings,
+				makeLinterFinding(loadedSymbols[def.Name], fmt.Sprintf(
+					"The function %q defined in %q is deprecated.", def.Name, path)))
+		}
+
+	}
+	return findings
+}

--- a/warn/warn_deprecated_test.go
+++ b/warn/warn_deprecated_test.go
@@ -1,0 +1,53 @@
+package warn
+
+import "testing"
+
+func TestDeprecatedFunction(t *testing.T) {
+	defer setUpFileReader(map[string]string{
+		"test/package/foo.bzl": `
+def foo():
+  """
+  This is a function foo.
+
+  Please use it in favor of the
+  deprecated function bar
+  """
+  pass
+
+def bar():
+  """
+  This is a function bar.
+
+  Deprecated:
+    please use foo instead.
+  """
+  pass
+`,
+		"test/package/invalid.bzl": `
+This is not a valid Starlark file
+`,
+	})()
+
+	checkFindings(t, "deprecated-function", `
+load(":foo.bzl", "foo", "bar", "baz")
+load("//test/package:foo.bzl", "foo", "bar", "baz")
+load(":invalid.bzl", "foo", "bar", "baz")
+load(":nonexistent.bzl", "foo", "bar", "baz")
+`,
+		[]string{
+			`1: The function "bar" defined in "test/package/foo.bzl" is deprecated.`,
+			`2: The function "bar" defined in "test/package/foo.bzl" is deprecated.`,
+		},
+		scopeEverywhere)
+}
+
+func TestDeprecatedFunctionNoReader(t *testing.T) {
+	checkFindings(t, "deprecated-function", `
+load(":foo.bzl", "foo", "bar", "baz")
+load("//test/package:foo.bzl", "foo", "bar", "baz")
+load(":invalid.bzl", "foo", "bar", "baz")
+load(":nonexistent.bzl", "foo", "bar", "baz")
+`,
+		[]string{},
+		scopeEverywhere)
+}

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -67,6 +67,7 @@ type docstringInfo struct {
 	hasHeader    bool                      // whether the docstring has a one-line header
 	args         map[string]build.Position // map of documented arguments, the values are line numbers
 	returns      bool                      // whether the return value is documented
+	deprecated   bool                      // whether the function is marked as deprecated
 	argumentsPos build.Position            // line of the `Arguments:` block (not `Args:`), if it exists
 }
 
@@ -130,6 +131,10 @@ func parseFunctionDocstring(doc *build.StringExpr) docstringInfo {
 		case prefix + "Returns:":
 			isArgumentsDescription = false
 			info.returns = true
+			continue
+		case prefix + "Deprecated:":
+			isArgumentsDescription = false
+			info.deprecated = true
 			continue
 		}
 

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -3,7 +3,6 @@ package warn
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -26,7 +25,6 @@ var testFileReader *FileReader
 
 func setUpFileReader(data map[string]string) func() {
 	readFile := func(filename string) ([]byte, error) {
-		filename = strings.ReplaceAll(filename, "/", string(os.PathSeparator))
 		if contents, ok := data[filename]; ok {
 			return []byte(contents), nil
 		}

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -23,7 +23,7 @@ const (
 // reset it when it finishes.
 var testFileReader *FileReader
 
-func setUpFileReader(data map[string]string) func() {
+func setUpFileReader(data map[string]string) (cleanup func()) {
 	readFile := func(filename string) ([]byte, error) {
 		if contents, ok := data[filename]; ok {
 			return []byte(contents), nil
@@ -31,7 +31,7 @@ func setUpFileReader(data map[string]string) func() {
 		return nil, fmt.Errorf("File not found")
 	}
 	testFileReader = &FileReader{}
-	testFileReader.Init(readFile)
+	testFileReader.NewFileReader(readFile)
 
 	return func() {
 		// Tear down

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -30,8 +30,7 @@ func setUpFileReader(data map[string]string) (cleanup func()) {
 		}
 		return nil, fmt.Errorf("File not found")
 	}
-	testFileReader = &FileReader{}
-	testFileReader.NewFileReader(readFile)
+	testFileReader = NewFileReader(readFile)
 
 	return func() {
 		// Tear down


### PR DESCRIPTION
Deprecated funcitons are defined in other .bzl files, so buildifier is now also able to read from loaded .bzl files.