### PR TITLE
Support line continuations in strings

### DIFF
--- a/build/quote.go
+++ b/build/quote.go
@@ -134,7 +134,9 @@ func Unquote(quoted string) (s string, triple bool, err error) {
 			quoted = quoted[2:]
 
 		case '\n':
-			// Ignore the escape and the line break.
+			// Line continuation detected, persist.
+			buf.WriteByte('\\')
+			buf.WriteByte('n')
 			quoted = quoted[2:]
 
 		case 'n', 'r', 't', '\\', '\'', '"':
@@ -243,6 +245,13 @@ func quote(unquoted string, triple bool) string {
 		if triple && c == '\n' {
 			// Can allow newline in triple-quoted string.
 			buf.WriteByte(c)
+			continue
+		}
+		if c == '\\' && unquoted[i+1] == 'n' {
+			// Backslashes followed by a newline should be treated as a line continuation and newline
+			buf.WriteByte(c)
+			buf.WriteByte('\n')
+			i++
 			continue
 		}
 		if c == '\'' {

--- a/build/quote_test.go
+++ b/build/quote_test.go
@@ -40,7 +40,10 @@ var quoteTests = []struct {
 	{`"foo\\(bar"`, `foo\(bar`, true},
 	{`"""hello
 world"""`, "hello\nworld", true},
-
+	{`"""hello\
+world\
+    foo
+    bar"""`, "hello\\nworld\\n    foo\n    bar", true},
 	{`"\\a\\b\\f\n\r\t\\v\000\377"`, "\\a\\b\\f\n\r\t\\v\000\xFF", true},
 	{`"\\a\\b\\f\n\r\t\\v\x00\xff"`, "\\a\\b\\f\n\r\t\\v\000\xFF", false},
 	{`"\\a\\b\\f\n\r\t\\v\000\xFF"`, "\\a\\b\\f\n\r\t\\v\000\xFF", false},


### PR DESCRIPTION
Strings used in attributes for build rules that contain commands may use line continuations to format the command for readability. Currently, these multiline commands are unwrapped into one line with poor spacing. 

Example:
```
genrule(
    name = "foo",
    srcs = [],
    outs = ["foo.h"],
    cmd = "./$(location create_foo.pl) \
                  > \"$@\"",
    tools = ["create_foo.pl"],
)
```
becomes
```
./$(location create_foo.pl) 	> "$@"

genrule(
    name = "foo",
    srcs = [],
    outs = ["foo.h"],
    cmd = "./$(location create_foo.pl)                   > \"$@\"",
    tools = ["create_foo.pl"],
)
```

We should maintain these line continuations such that if a backslash is followed by a newline, this is not stripped as it currently is.
