### PR TITLE
Fix file packages

### DIFF
--- a/build/syntax.go
+++ b/build/syntax.go
@@ -20,6 +20,7 @@ package build
 // Syntax data structure definitions.
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 )
@@ -93,7 +94,8 @@ func stmtsEnd(stmts []Expr) Position {
 // A File represents an entire BUILD or .bzl file.
 type File struct {
 	Path          string // absolute file path
-	Pkg           string // optional; the package of the file
+	Pkg           string // optional; the package of the file (always forward slashes)
+	Label         string // optional; file path relative to the package name (always forward slashes)
 	WorkspaceRoot string // optional; path to the directory containing the WORKSPACE file
 	Type          FileType
 	Comments
@@ -106,6 +108,14 @@ func (f *File) DisplayPath() string {
 		return "<stdin>"
 	}
 	return f.Path
+}
+
+// Full label of the file, e.g. "//package:file.bzl"
+func (f *File) FullLabel() string {
+	if f.Pkg == "" {
+		return fmt.Sprintf("//%s", f.Label)
+	}
+	return fmt.Sprintf("//%s:%s", f.Pkg, f.Label)
 }
 
 func (f *File) Span() (start, end Position) {

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -110,12 +110,12 @@ func (f *File) DisplayPath() string {
 	return f.Path
 }
 
-// Full label of the file, e.g. "//package:file.bzl"
-func (f *File) FullLabel() string {
+// CanonicalPath returns the path of a file relative to the workspace root with forward slashes only
+func (f *File) CanonicalPath() string {
 	if f.Pkg == "" {
-		return fmt.Sprintf("//%s", f.Label)
+		return "//" + f.Label
 	}
-	return fmt.Sprintf("//%s:%s", f.Pkg, f.Label)
+	return fmt.Sprintf("//%s/%s", f.Pkg, f.Label)
 }
 
 func (f *File) Span() (start, end Position) {

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -329,7 +329,7 @@ func processFile(filename string, data []byte, inputType, lint string, warningsL
 	}
 
 	if absoluteFilename, err := filepath.Abs(displayFilename); err == nil {
-		f.WorkspaceRoot, f.Pkg = utils.SplitFilePath(absoluteFilename)
+		f.WorkspaceRoot, f.Pkg, f.Label = utils.SplitFilePath(absoluteFilename)
 	}
 
 	warnings := utils.Lint(f, lint, warningsList, *vflag)

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -143,7 +143,7 @@ test_dir/to_fix_tmp.bzl: applied fixes, 2 warnings left
 fixed test_dir/to_fix_tmp.bzl
 EOF
 
-error_bzl="test_dir/to_fix_tmp.bzl:1: bzl-visibility: Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//test_dir\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#bzl-visibility)"
+error_bzl="test_dir/to_fix_tmp.bzl:1: bzl-visibility: Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//test_dir/to_fix_tmp.bzl\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#bzl-visibility)"
 error_docstring="test_dir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring."$'\n'"A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines). (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
 error_integer="test_dir/to_fix_tmp.bzl:3: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
 error_dict="test_dir/to_fix_tmp.bzl:4: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
@@ -241,7 +241,7 @@ cat > golden/json_report_golden <<EOF
                     },
                     "category": "bzl-visibility",
                     "actionable": true,
-                    "message": "Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//test_dir/json\".",
+                    "message": "Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//test_dir/json/to_fix.bzl\".",
                     "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#bzl-visibility"
                 },
                 {
@@ -393,7 +393,7 @@ load(":nonexistent.bzl", "foo2", "bar2")
 EOF
 
 cat > report_golden <<EOF
-BUILD:1: deprecated-function: The function "bar" defined in "/lib.bzl" is deprecated. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#deprecated-function)
+BUILD:1: deprecated-function: The function "bar" defined in "//lib.bzl" is deprecated. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#deprecated-function)
 EOF
 
 $buildifier --lint=warn --warnings=deprecated-function BUILD 2> report || ret=$?

--- a/buildifier/utils/utils_test.go
+++ b/buildifier/utils/utils_test.go
@@ -121,13 +121,16 @@ func TestIsStarlarkFile(t *testing.T) {
 	}
 }
 
-func checkSplitFilePathOutput(t *testing.T, name, filename, expectedWorkspaceRoot, expectedPkg string) {
-	workspaceRoot, pkg := SplitFilePath(filename)
+func checkSplitFilePathOutput(t *testing.T, name, filename, expectedWorkspaceRoot, expectedPkg, expectedLabel string) {
+	workspaceRoot, pkg, label := SplitFilePath(filename)
 	if workspaceRoot != expectedWorkspaceRoot {
 		t.Errorf("%s: expected the workspace root to be %q, was %q instead", name, expectedWorkspaceRoot, workspaceRoot)
 	}
 	if pkg != expectedPkg {
 		t.Errorf("%s: expected the package name to be %q, was %q instead", name, expectedPkg, pkg)
+	}
+	if label != expectedLabel {
+		t.Errorf("%s: expected the label to be %q, was %q instead", name, expectedLabel, label)
 	}
 }
 
@@ -138,22 +141,42 @@ func TestSplitFilePath(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	if err := os.MkdirAll(filepath.Join(dir, "path", "to", "package"), os.ModePerm); err != nil {
+		t.Error(err)
+	}
+
 	filename := filepath.Join(dir, "path", "to", "package", "file.bzl")
-	checkSplitFilePathOutput(t, "No WORKSPACE file", filename, "", "")
+	checkSplitFilePathOutput(t, "No WORKSPACE file", filename, "", "", "")
 
 	// Create a WORKSPACE file and try again (dir/WORKSPACE)
 	if err := ioutil.WriteFile(filepath.Join(dir, "WORKSPACE"), []byte{}, os.ModePerm); err != nil {
 		t.Error(err)
 	}
-	checkSplitFilePathOutput(t, "WORKSPACE file exists", filename, dir, "path/to/package")
-	checkSplitFilePathOutput(t, "WORKSPACE file exists, empty package", filepath.Join(dir, "file.bzl"), dir, "")
+	checkSplitFilePathOutput(t, "WORKSPACE file exists", filename, dir, "", "path/to/package/file.bzl")
+	checkSplitFilePathOutput(t, "WORKSPACE file exists, empty package", filepath.Join(dir, "file.bzl"), dir, "", "file.bzl")
+
+	// Add a BUILD file
+	buildPath := filepath.Join(dir, "path", "to", "BUILD")
+	if err := ioutil.WriteFile(buildPath, []byte{}, os.ModePerm); err != nil {
+		t.Error(err)
+	}
+	checkSplitFilePathOutput(t, "WORKSPACE and BUILD files exists 1", buildPath, dir, "path/to", "BUILD")
+	checkSplitFilePathOutput(t, "WORKSPACE and BUILD files exists 2", filename, dir, "path/to", "package/file.bzl")
+
+	// Add a subpackage BUILD file
+	subBuildPath := filepath.Join(dir, "path", "to", "package", "BUILD.bazel")
+	if err := ioutil.WriteFile(subBuildPath, []byte{}, os.ModePerm); err != nil {
+		t.Error(err)
+	}
+	checkSplitFilePathOutput(t, "WORKSPACE and two BUILD files exists 1", subBuildPath, dir, "path/to/package", "BUILD.bazel")
+	checkSplitFilePathOutput(t, "WORKSPACE and two BUILD files exists 2", filename, dir, "path/to/package", "file.bzl")
 
 	// Rename WORKSPACE to WORKSPACE.bazel and try again (dir/WORKSPACE.bazel)
 	if err := os.Rename(filepath.Join(dir, "WORKSPACE"), filepath.Join(dir, "WORKSPACE.bazel")); err != nil {
 		t.Error(err)
 	}
-	checkSplitFilePathOutput(t, "WORKSPACE file exists", filename, dir, "path/to/package")
-	checkSplitFilePathOutput(t, "WORKSPACE file exists, empty package", filepath.Join(dir, "file.bzl"), dir, "")
+	checkSplitFilePathOutput(t, "WORKSPACE file exists", filename, dir, "path/to/package", "file.bzl")
+	checkSplitFilePathOutput(t, "WORKSPACE file exists, empty package", filepath.Join(dir, "file.bzl"), dir, "", "file.bzl")
 
 	// Create another WORKSPACE file and try again (dir/path/WORKSPACE)
 	newRoot := filepath.Join(dir, "path")
@@ -163,5 +186,5 @@ func TestSplitFilePath(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(newRoot, "WORKSPACE"), []byte{}, os.ModePerm); err != nil {
 		t.Error(err)
 	}
-	checkSplitFilePathOutput(t, "Two WORKSPACE files exist", filename, newRoot, "to/package")
+	checkSplitFilePathOutput(t, "Two WORKSPACE files exist", filename, newRoot, "to/package", "file.bzl")
 }

--- a/warn/multifile.go
+++ b/warn/multifile.go
@@ -1,9 +1,8 @@
 package warn
 
 import (
-	"path"
-
 	"github.com/bazelbuild/buildtools/build"
+	"strings"
 )
 
 // FileReader is a class that can read an arbitrary Starlark file
@@ -19,7 +18,7 @@ type FileReader struct {
 // (OS-independent, with forward slashes).
 func NewFileReader(readFile func(string) ([]byte, error)) *FileReader {
 	return &FileReader{
-		cache: make(map[string]*build.File),
+		cache:    make(map[string]*build.File),
 		readFile: readFile,
 	}
 }
@@ -36,19 +35,48 @@ func (fr *FileReader) retrieveFile(filename string) *build.File {
 	if err != nil {
 		return nil
 	}
+	file.Path = filename
 
-	file.Pkg = path.Dir(filename)
 	return file
 }
 
 // GetFile reads a Starlark file from the repository or the cache.
 // Returns nil if the file is not found or not valid.
-func (fr *FileReader) GetFile(filename string) *build.File {
+func (fr *FileReader) GetFile(pkg, label string) *build.File {
+	filename := label
+	if pkg != "" {
+		filename = pkg + "/" + label
+	}
+
 	// Try to retrieve from the cache
 	if file, ok := fr.cache[filename]; ok {
 		return file
 	}
 	file := fr.retrieveFile(filename)
+	if file != nil {
+		file.Pkg = pkg
+		file.Label = label
+	}
 	fr.cache[filename] = file
 	return file
+}
+
+// ResolveLabel resolves a label to a .bzl file (which may be absolute or relative to the current package)
+// to a pair (package, label) for the .bzl file
+func ResolveLabel(currentPkg, label string) (pkg, newLabel string) {
+	switch {
+	case strings.HasPrefix(label, "//"):
+		// Absolute label path
+		label = label[2:]
+		if chunks := strings.SplitN(label, ":", 2); len(chunks) == 2 {
+			return chunks[0], chunks[1]
+		}
+		return "", label
+	case strings.HasPrefix(label, ":"):
+		// Relative label path
+		return currentPkg, label[1:]
+	default:
+		// External repositories are not supported
+		return "", ""
+	}
 }

--- a/warn/warn_deprecated.go
+++ b/warn/warn_deprecated.go
@@ -4,31 +4,11 @@ package warn
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
 )
 
-func getPathFromLabel(label, pkg string) string {
-	switch {
-	case strings.HasPrefix(label, "//"):
-		// Absolute label path
-		return strings.ReplaceAll(label[2:], ":", "/")
-	case strings.HasPrefix(label, ":"):
-		// Relative label path
-		return pkg + "/" + label[1:]
-	default:
-		// External repositories are not supported
-		return ""
-	}
-}
-
-func readBzlFile(path string, fileReader *FileReader) (*build.File, bool) {
-	file := fileReader.GetFile(path)
-	return file, file != nil
-}
-
-func checkDeprecatedFunction(stmt build.Expr, loadedSymbols *map[string]*build.Ident, path string) *LinterFinding {
+func checkDeprecatedFunction(stmt build.Expr, loadedSymbols *map[string]*build.Ident, fullLabel string) *LinterFinding {
 	def, ok := stmt.(*build.DefStmt)
 	if !ok {
 		return nil
@@ -50,7 +30,7 @@ func checkDeprecatedFunction(stmt build.Expr, loadedSymbols *map[string]*build.I
 		return nil
 	}
 
-	return makeLinterFinding(node, fmt.Sprintf("The function %q defined in %q is deprecated.", def.Name, path))
+	return makeLinterFinding(node, fmt.Sprintf("The function %q defined in %q is deprecated.", def.Name, fullLabel))
 }
 
 func deprecatedFunctionWarning(f *build.File, fileReader *FileReader) []*LinterFinding {
@@ -64,22 +44,21 @@ func deprecatedFunctionWarning(f *build.File, fileReader *FileReader) []*LinterF
 		if !ok {
 			continue
 		}
-		path := getPathFromLabel(load.Module.Value, f.Pkg)
-		if path == "" {
+		pkg, fileLabel := ResolveLabel(f.Pkg, load.Module.Value)
+		if fileLabel == "" {
 			continue
 		}
-		loadedFile, ok := readBzlFile(path, fileReader)
-		if !ok {
+		loadedFile := fileReader.GetFile(pkg, fileLabel)
+		if loadedFile == nil {
 			continue
 		}
-
 		loadedSymbols := make(map[string]*build.Ident)
 		for _, from := range load.From {
 			loadedSymbols[from.Name] = from
 		}
 
 		for _, stmt := range loadedFile.Stmt {
-			if finding := checkDeprecatedFunction(stmt, &loadedSymbols, path); finding != nil {
+			if finding := checkDeprecatedFunction(stmt, &loadedSymbols, loadedFile.FullLabel()); finding != nil {
 				findings = append(findings, finding)
 			}
 		}

--- a/warn/warn_deprecated.go
+++ b/warn/warn_deprecated.go
@@ -58,7 +58,7 @@ func deprecatedFunctionWarning(f *build.File, fileReader *FileReader) []*LinterF
 		}
 
 		for _, stmt := range loadedFile.Stmt {
-			if finding := checkDeprecatedFunction(stmt, &loadedSymbols, loadedFile.FullLabel()); finding != nil {
+			if finding := checkDeprecatedFunction(stmt, &loadedSymbols, loadedFile.CanonicalPath()); finding != nil {
 				findings = append(findings, finding)
 			}
 		}

--- a/warn/warn_deprecated_test.go
+++ b/warn/warn_deprecated_test.go
@@ -35,8 +35,8 @@ load(":invalid.bzl", "foo", "bar", "baz")
 load(":nonexistent.bzl", "foo", "bar", "baz")
 `,
 		[]string{
-			`1: The function "bar" defined in "//test/package:foo.bzl" is deprecated.`,
-			`2: The function "bar" defined in "//test/package:foo.bzl" is deprecated.`,
+			`1: The function "bar" defined in "//test/package/foo.bzl" is deprecated.`,
+			`2: The function "bar" defined in "//test/package/foo.bzl" is deprecated.`,
 		},
 		scopeEverywhere)
 }

--- a/warn/warn_deprecated_test.go
+++ b/warn/warn_deprecated_test.go
@@ -35,8 +35,8 @@ load(":invalid.bzl", "foo", "bar", "baz")
 load(":nonexistent.bzl", "foo", "bar", "baz")
 `,
 		[]string{
-			`1: The function "bar" defined in "test/package/foo.bzl" is deprecated.`,
-			`2: The function "bar" defined in "test/package/foo.bzl" is deprecated.`,
+			`1: The function "bar" defined in "//test/package:foo.bzl" is deprecated.`,
+			`2: The function "bar" defined in "//test/package:foo.bzl" is deprecated.`,
 		},
 		scopeEverywhere)
 }

--- a/warn/warn_macro_test.go
+++ b/warn/warn_macro_test.go
@@ -152,7 +152,7 @@ It is considered a macro because it calls a rule or another macro "my_rule" on l
 
 func TestUnnamedMacroWithReader(t *testing.T) {
 	defer setUpFileReader(map[string]string{
-		"test/package/foo.bzl": `
+		"test/package/subdir1/foo.bzl": `
 def foo():
   native.foo_binary()
 
@@ -161,8 +161,8 @@ def bar():
 
 my_rule = rule()
 `,
-		"test/package/baz.bzl": `
-load(":foo.bzl", "bar", your_rule = "my_rule")
+		"test/package/subdir2/baz.bzl": `
+load(":subdir1/foo.bzl", "bar", your_rule = "my_rule")
 load("//does/not:exist.bzl", "something")
 
 def baz():
@@ -178,8 +178,8 @@ def f():
 	})()
 
 	checkFindings(t, "unnamed-macro", `
-load("//test/package/foo.bzl", abc = "bar")
-load(":baz.bzl", "baz", "qux", "f")
+load("//test/package:subdir1/foo.bzl", abc = "bar")
+load(":subdir2/baz.bzl", "baz", "qux", "f")
 
 def macro1(surname):
   abc()
@@ -287,10 +287,10 @@ func TestUnnamedMacroLoadedFiles(t *testing.T) {
 	})()
 
 	checkFindings(t, "unnamed-macro", `
-load("//a.bzl", "a")
-load("//b.bzl", "b")
-load("//c.bzl", "c")
-load("//d.bzl", "d")
+load("//:a.bzl", "a")
+load("//:b.bzl", "b")
+load("//:c.bzl", "c")
+load("//:d.bzl", "d")
 
 def macro1():
   a()  # has to load a.bzl to analyze
@@ -330,8 +330,6 @@ It is considered a macro because it calls a rule or another macro "r" on line 19
 }
 
 func TestUnnamedMacroAliases(t *testing.T) {
-	// Test that not necessary files are not loaded
-
 	defer setUpFileReader(map[string]string{
 		"test/package/foo.bzl": `
 load(":bar.bzl", _bar = "bar")

--- a/warn/warn_visibility.go
+++ b/warn/warn_visibility.go
@@ -42,19 +42,19 @@ func bzlVisibilityWarning(f *build.File) []*LinterFinding {
 			}
 		}
 
-		pkg := "//" + f.Pkg // Canonical name of the package
+		path := strings.ReplaceAll(f.FullLabel(), ":", "/") // Canonical name of the file
 		chunks := internalDirectory.Split(module, 2)
 		if len(chunks) < 2 {
 			continue
 		}
 
-		if strings.HasPrefix(pkg, chunks[0]) {
+		if strings.HasPrefix(path, chunks[0]) {
 			continue
 		}
 
 		findings = append(findings, makeLinterFinding(
 			load.Module,
-			fmt.Sprintf("Module %q can only be loaded from files located inside %q, not from %q.", load.Module.Value, chunks[0], pkg)))
+			fmt.Sprintf("Module %q can only be loaded from files located inside %q, not from %q.", load.Module.Value, chunks[0], path)))
 	}
 
 	return findings

--- a/warn/warn_visibility.go
+++ b/warn/warn_visibility.go
@@ -42,7 +42,7 @@ func bzlVisibilityWarning(f *build.File) []*LinterFinding {
 			}
 		}
 
-		path := strings.ReplaceAll(f.FullLabel(), ":", "/") // Canonical name of the file
+		path := f.CanonicalPath() // Canonical name of the file
 		chunks := internalDirectory.Split(module, 2)
 		if len(chunks) < 2 {
 			continue

--- a/warn/warn_visibility_test.go
+++ b/warn/warn_visibility_test.go
@@ -13,8 +13,8 @@ bar()
 baz()
 `,
 		[]string{
-			`:1: Module "//foo/bar/internal/baz:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
-			`:2: Module "//foo/bar/private/baz:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+			`:1: Module "//foo/bar/internal/baz:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package/`,
+			`:2: Module "//foo/bar/private/baz:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package/`,
 		},
 		scopeEverywhere)
 
@@ -28,8 +28,8 @@ bar()
 baz()
 `,
 		[]string{
-			`:1: Module "//foo/bar/internal:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
-			`:2: Module "//foo/bar/private:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
+			`:1: Module "//foo/bar/internal:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package/`,
+			`:2: Module "//foo/bar/private:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package/`,
 		},
 		scopeEverywhere)
 
@@ -46,9 +46,9 @@ baz()
 qux()
 `,
 		[]string{
-			`:1: Module "@repo//foo/bar/internal:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
-			`:2: Module "@repo//foo/bar/private:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package".`,
-			`:4: Module "@repo/internal:module.bzl" can only be loaded from files located inside "@repo", not from "//test/package".`,
+			`:1: Module "@repo//foo/bar/internal:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package/`,
+			`:2: Module "@repo//foo/bar/private:module.bzl" can only be loaded from files located inside "//foo/bar", not from "//test/package/`,
+			`:4: Module "@repo/internal:module.bzl" can only be loaded from files located inside "@repo", not from "//test/package/`,
 		},
 		scopeEverywhere)
 


### PR DESCRIPTION
Currently buildifier determines a file's package as its base name (relative to the workspace root). Although that's always true for BUILD files, .bzl files may be located not necessarily in a package root but in a subdirectory.

That didn't matter before, but now with the functionality of loading additional .bzl files that's being used by some analyzers, it's important to know the current file's package to resolve relative labels correctly.

To achieve that it's enough to locate a BUILD file closest to the initial file; all other loaded files packages can be determined by analyzing their label: e.g. if "//some/package:label/name.bzl" is loaded, the package is set to "some/package" and the label to "label/name.bzl" without even looking at BUILD files.