### PR TITLE
Fixes for resolving import errors

### DIFF
--- a/buildifier/utils/diagnostics.go
+++ b/buildifier/utils/diagnostics.go
@@ -32,6 +32,9 @@ func (d *Diagnostics) Format(format string, verbose bool) string {
 					w.Message,
 					w.URL))
 			}
+			if !f.Formatted {
+				output.WriteString(fmt.Sprintf("%s # reformat\n", f.Filename))
+			}
 		}
 		return output.String()
 	case "json":


### PR DESCRIPTION
  * #815 by mistake removed the `# reformat` line from the output, restored.
  * The logic for splitting a relative path into package and label (by looking for a BUILD file) has been moved to a separate function because it can be reused in situations when a workspace root is already known.