### PR TITLE
Don't apply unnamed-macro to private functions

### DIFF
--- a/warn/warn_macro.go
+++ b/warn/warn_macro.go
@@ -4,6 +4,7 @@ package warn
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bazelbuild/buildtools/build"
 )
@@ -293,7 +294,7 @@ func unnamedMacroWarning(f *build.File, fileReader *FileReader) []*LinterFinding
 			continue
 		}
 
-		if !ok || acceptsNameArgument(def) {
+		if strings.HasPrefix(def.Name, "_") || acceptsNameArgument(def) {
 			continue
 		}
 

--- a/warn/warn_macro_test.go
+++ b/warn/warn_macro_test.go
@@ -357,3 +357,14 @@ def macro2(name):
 It is considered a macro because it calls a rule or another macro "baz" on line 6.`,
 	}, scopeBzl)
 }
+
+func TestUnnamedMacroPrivate(t *testing.T) {
+	checkFindings(t, "unnamed-macro", `
+my_rule = rule()
+
+def _not_macro(x):
+  my_rule(name = x)
+`,
+		[]string{},
+		scopeBzl)
+}

--- a/warn/warn_macro_test.go
+++ b/warn/warn_macro_test.go
@@ -364,7 +364,14 @@ my_rule = rule()
 
 def _not_macro(x):
   my_rule(name = x)
+
+def macro(x):
+  _not_macro(x)
 `,
-		[]string{},
+		[]string{
+			`6: Macro function "macro" doesn't accept a keyword argument "name".
+
+It is considered a macro because it calls a rule or another macro "_not_macro" on line 7.`,
+		},
 		scopeBzl)
 }


### PR DESCRIPTION
Private functions can't be imported at BUILD files and therefore can't be macros.