### PR TITLE
Correctly parse docstrings in CRLF-formatted files

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -94,6 +94,11 @@ func parseFunctionDocstring(doc *build.StringExpr) docstringInfo {
 	prefix := strings.Repeat(" ", indent)
 	lines := strings.Split(doc.Value, "\n")
 
+	// Trim "/r" in the end of the lines to parse CRLF-formatted files correctly
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
+	}
+
 	info := docstringInfo{}
 	info.args = make(map[string]build.Position)
 

--- a/warn/warn_docstring_test.go
+++ b/warn/warn_docstring_test.go
@@ -171,6 +171,18 @@ def f():
 `,
 		[]string{},
 		scopeEverywhere)
+
+	checkFindings(t, "function-docstring-header", `
+def f():
+   """\r
+   Header in a CRLF formatted file.\r
+\r
+   This is a\r
+   multiline description"""
+`,
+		[]string{},
+		scopeEverywhere)
+
 }
 
 func TestFunctionDocstringArgs(t *testing.T) {


### PR DESCRIPTION
Fixes #824 