### PR TITLE
Clarify unnamed macro warning

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -910,7 +910,7 @@ can potentially be empty.
 
 --------------------------------------------------------------------------------
 
-## <a name="unnamed-macro"></a>Macro function doesn't accept a keyword argument "name"
+## <a name="unnamed-macro"></a>By convention the macro should have a keyword argument called "name".
 
   * Category name: `unnamed-macro`
   * Automatic fix: no

--- a/warn/warn_macro.go
+++ b/warn/warn_macro.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"google3/third_party/bazel_buildifier/build/build"
+	"github.com/bazelbuild/buildtools/build"
 )
 
 // Internal constant that represents the native module

--- a/warn/warn_macro.go
+++ b/warn/warn_macro.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bazelbuild/buildtools/build"
+	"google3/third_party/bazel_buildifier/build/build"
 )
 
 // Internal constant that represents the native module
@@ -302,7 +302,7 @@ func unnamedMacroWarning(f *build.File, fileReader *FileReader) []*LinterFinding
 		if !report.isMacro {
 			continue
 		}
-		msg := fmt.Sprintf(`Macro function %q doesn't accept a keyword argument "name".`, def.Name)
+		msg := fmt.Sprintf(`By convention %q should have a keyword argument called "name".`, def.Name)
 		if report.fc != nil {
 			// fc shouldn't be nil because that's the only node that can be found inside a function.
 			msg += fmt.Sprintf(`

--- a/warn/warn_macro_test.go
+++ b/warn/warn_macro_test.go
@@ -24,10 +24,10 @@ def another_macro(x):
   [native.cc_library() for i in x]
 `,
 		[]string{
-			`5: Macro function "macro" doesn't accept a keyword argument "name".
+			`5: By convention "macro" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "my_rule" on line 7.`,
-			`16: Macro function "another_macro" doesn't accept a keyword argument "name".
+			`16: By convention "another_macro" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "native.cc_library" on line 18.`,
 		},
@@ -61,7 +61,7 @@ def bad_macro():
     alias(x)
 `,
 		[]string{
-			`8: Macro function "bad_macro" doesn't accept a keyword argument "name".
+			`8: By convention "bad_macro" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "alias" on line 10.`,
 		},
@@ -83,16 +83,16 @@ def macro4():
   my_rule()
 `,
 		[]string{
-			`3: Macro function "macro1" doesn't accept a keyword argument "name".
+			`3: By convention "macro1" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "my_rule" on line 4.`,
-			`6: Macro function "macro2" doesn't accept a keyword argument "name".
+			`6: By convention "macro2" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "macro1" on line 7`,
-			`9: Macro function "macro3" doesn't accept a keyword argument "name".
+			`9: By convention "macro3" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "macro2" on line 10.`,
-			`12: Macro function "macro4" doesn't accept a keyword argument "name".
+			`12: By convention "macro4" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "my_rule" on line 13.`,
 		},
@@ -140,10 +140,10 @@ def bar():
   my_rule()
 `,
 		[]string{
-			`3: Macro function "foo" doesn't accept a keyword argument "name".
+			`3: By convention "foo" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "bar" on line 4.`,
-			`6: Macro function "bar" doesn't accept a keyword argument "name".
+			`6: By convention "bar" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "my_rule" on line 8.`,
 		},
@@ -194,13 +194,13 @@ def not_macro(x):
   f()
 `,
 		[]string{
-			`4: Macro function "macro1" doesn't accept a keyword argument "name".
+			`4: By convention "macro1" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "abc" on line 5.`,
-			`7: Macro function "macro2" doesn't accept a keyword argument "name".
+			`7: By convention "macro2" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "baz" on line 8.`,
-			`10: Macro function "macro3" doesn't accept a keyword argument "name".
+			`10: By convention "macro3" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "qux" on line 11.`,
 		},
@@ -246,7 +246,7 @@ def macro():
   baz()
   quux()
 `, []string{
-		`4: Macro function "macro" doesn't accept a keyword argument "name".
+		`4: By convention "macro" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "quux" on line 7.`,
 	}, scopeBzl)
@@ -270,7 +270,7 @@ my_rule = rule()
 def macro():
   bar()
 `, []string{
-		`5: Macro function "macro" doesn't accept a keyword argument "name".
+		`5: By convention "macro" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "bar" on line 6.`,
 	}, scopeBzl)
@@ -309,16 +309,16 @@ def macro4():
 
 r = rule()
 `, []string{
-		`6: Macro function "macro1" doesn't accept a keyword argument "name".
+		`6: By convention "macro1" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "a" on line 7.`,
-		`9: Macro function "macro2" doesn't accept a keyword argument "name".
+		`9: By convention "macro2" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "native.cc_library" on line 11.`,
-		`13: Macro function "macro3" doesn't accept a keyword argument "name".
+		`13: By convention "macro3" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "a" on line 15.`,
-		`17: Macro function "macro4" doesn't accept a keyword argument "name".
+		`17: By convention "macro4" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "r" on line 19.`,
 	}, scopeBzl)
@@ -352,7 +352,7 @@ def macro1():
 def macro2(name):
   baz()
 `, []string{
-		`5: Macro function "macro1" doesn't accept a keyword argument "name".
+		`5: By convention "macro1" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "baz" on line 6.`,
 	}, scopeBzl)
@@ -369,7 +369,7 @@ def macro(x):
   _not_macro(x)
 `,
 		[]string{
-			`6: Macro function "macro" doesn't accept a keyword argument "name".
+			`6: By convention "macro" should have a keyword argument called "name".
 
 It is considered a macro because it calls a rule or another macro "_not_macro" on line 7.`,
 		},


### PR DESCRIPTION
Make the build warning for lack of `name` in a macro keyword arguments more clear.
