### PR TITLE
Add support for configuring build file names

### DIFF
--- a/buildozer/main.go
+++ b/buildozer/main.go
@@ -47,6 +47,7 @@ var (
 
 	shortenLabelsFlag  = flag.Bool("shorten_labels", true, "convert added labels to short form, e.g. //foo:bar => :bar")
 	deleteWithComments = flag.Bool("delete_with_comments", true, "If a list attribute should be deleted even if there is a comment attached to it")
+	buildFileNames     = stringList("build-file-names", "comma-separated list of files to consider as BUILD files, the default empty list means BUILD, BUILD.bazel and BUCK will be considered")
 )
 
 func stringList(name, help string) func() []string {
@@ -104,6 +105,10 @@ func main() {
 		Quiet:             *quiet,
 		EditVariables:     *editVariables,
 		IsPrintingProto:   *isPrintingProto,
+		BuildFileNames:    buildFileNames(),
+	}
+	if len(opts.BuildFileNames) == 0 {
+		opts.BuildFileNames = edit.DefaultBuildFileNames
 	}
 	os.Exit(edit.Buildozer(opts, flag.Args()))
 }

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -185,7 +185,7 @@ func runTestTargetExpressionToBuildFiles(t *testing.T, buildFileName string) {
 			defer os.Chdir(cwd)
 		}
 
-		buildFiles := targetExpressionToBuildFiles(tc.rootDir, tc.target)
+		buildFiles := targetExpressionToBuildFiles(tc.rootDir, DefaultBuildFileNames, tc.target)
 		expectedBuildFilesMap := make(map[string]bool)
 		buildFilesMap := make(map[string]bool)
 		for _, buildFile := range buildFiles {


### PR DESCRIPTION
Dropbox uses `BUILD` file templates extensively so that users don't have to edit `BUILD` files for common attributes like `deps`. It would be useful for us to apply `buildozer` commands on those template files, so it'll be useful for `buildozer` to take an optional argument to modify files other than the hardcoded `BUILD/BUILD.bazel/BUCK` files.