### PR TITLE
Thread through build file names to edit.go

### DIFF
--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -201,8 +201,9 @@ func runTestTargetExpressionToBuildFiles(t *testing.T, buildFileName string) {
 }
 
 func TestTargetExpressionToBuildFiles(t *testing.T) {
-	runTestTargetExpressionToBuildFiles(t, "BUILD")
-	runTestTargetExpressionToBuildFiles(t, "BUILD.bazel")
+	for _, buildFileName := range BuildFileNames {
+		runTestTargetExpressionToBuildFiles(t, buildFileName)
+	}
 }
 
 var dictListAddTests = []struct {


### PR DESCRIPTION
I tested this locally, and seemed to work for some commands like `set` and `add`

Even though buildozer had support for custom build file names, it didn't work for all commands like `add`. This was due to the assumption of `BUILD` file name in `edit.go`. This PR should fix that.