### PR TITLE
Fix windows handling of path to build file containing "/"

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -1076,6 +1076,8 @@ func appendCommands(opts *Options, commandMap map[string][]commandsForTarget, ar
 		for _, buildFileName := range BuildFileNames {
 			if strings.HasSuffix(target, filepath.FromSlash("/"+buildFileName)) {
 				target = strings.TrimSuffix(target, filepath.FromSlash("/"+buildFileName)) + ":__pkg__"
+			} else if strings.HasSuffix(target, "/"+buildFileName) {
+				target = strings.TrimSuffix(target, "/"+buildFileName) + ":__pkg__"
 			}
 		}
 		var buildFiles []string


### PR DESCRIPTION
Copybara invokes buildozer by passing the relative path to a
BUILD file using Unix separator.
This was broken in 19db42aa7a by the introduction
of `filepath.FromSlash` when evaluating the path to BUILD files.
Instead we can make it more tolerant by accepting both forms.