### PR TITLE
Replace genrule in go_yacc with custom bzl rule.

### DIFF
--- a/build/build_defs.bzl
+++ b/build/build_defs.bzl
@@ -22,16 +22,46 @@ load(
 
 _GO_YACC_TOOL = "@org_golang_x_tools//cmd/goyacc"
 
+def _go_yacc_impl(ctx):
+    args = ctx.actions.args()
+    args.add("-o", ctx.outputs.out)
+    args.add(ctx.file.src)
+    goroot = "%s/.." % ctx.executable._go_yacc_tool.dirname
+    ctx.actions.run(
+        executable = ctx.executable._go_yacc_tool,
+        arguments = [args],
+        inputs = [ctx.file.src],
+        outputs = [ctx.outputs.out],
+        env = {
+            "GOROOT": goroot,
+        },
+    )
+    return DefaultInfo(
+        files = depset([ctx.outputs.out]),
+    )
+
+_go_yacc = rule(
+    implementation = _go_yacc_impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+        ),
+        "out": attr.output(),
+        "_go_yacc_tool": attr.label(
+            default = _GO_YACC_TOOL,
+            allow_single_file = True,
+            executable = True,
+            cfg = "host",
+        ),
+    },
+)
+
+"""Runs go tool yacc -o $out $src."""
 def go_yacc(src, out, visibility = None):
-    """Runs go tool yacc -o $out $src."""
-    native.genrule(
+    _go_yacc(
         name = src + ".go_yacc",
-        srcs = [src],
-        outs = [out],
-        tools = [_GO_YACC_TOOL],
-        cmd = ("export GOROOT=$$(dirname $(location " + _GO_YACC_TOOL + "))/..;" +
-               " $(location " + _GO_YACC_TOOL + ") " +
-               " -o $(location " + out + ") $(SRCS) > /dev/null"),
+        src = src,
+        out = out,
         visibility = visibility,
     )
 


### PR DESCRIPTION
genrules require a bash shell, making them incompatible with
Windows unless a mingw dependency is added.

I made the private rule 1:1 compatible with the previous macro genrule
implementation in case there are some dependent repositories that use it.