### PR TITLE
Make the parameter 'bin' public

### DIFF
--- a/lang/defs.bzl
+++ b/lang/defs.bzl
@@ -3,7 +3,7 @@ def _generate_tables_impl(ctx):
     args.add("-input", ctx.file.src)
     args.add("-output", ctx.outputs.out)
     ctx.actions.run(
-        executable = ctx.executable._bin,
+        executable = ctx.executable.bin,
         inputs = [ctx.file.src],
         outputs = [ctx.outputs.out],
         arguments = [args],
@@ -14,7 +14,7 @@ generate_tables = rule(
     attrs = {
         "src": attr.label(allow_single_file=True),
         "out": attr.output(),
-        "_bin": attr.label(
+        "bin": attr.label(
             default = "//generatetables",
             executable = True,
             allow_single_file = True,


### PR DESCRIPTION
Otherwise it can't be overridden internally.