### PR TITLE
Fix nil nodes traversal

### DIFF
--- a/build/walk.go
+++ b/build/walk.go
@@ -66,7 +66,7 @@ func EditChildren(v Expr, f func(x Expr, stk []Expr) Expr) {
 
 // walk1 is a helper function for Walk, WalkWithPostfix, and Edit.
 func walk1(v *Expr, stack *[]Expr, f func(x *Expr, stk []Expr) Expr) Expr {
-	if v == nil {
+	if v == nil || *v == nil {
 		return nil
 	}
 


### PR DESCRIPTION
In order to be able to suggest replacements without applying them, buildifier can insert nil nodes that are no-op for the printer but can be replaced with new nodes if required. Such nodes can cause NPE in some other linter functions that can operate on a modified AST with nil nodes if not handled properly.

Some of such NPEs can be avoided if `build.Walk()` and `build.WalkPointers()` don't call the callback function on such nil nodes.