### PR TITLE
Make buildozer replace values inside select statements

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -57,6 +57,22 @@ two_deps='go_library(
     ],
 )'
 
+two_deps_with_select='go_library(
+    name = "edit",
+    deps = [
+        ":local",
+        "//buildifier:build",
+    ] + select({
+        "//tools/some:condition": [
+            "//some:value",
+            "//some/other:value",
+        ],
+        "//tools/other:condition": [
+            "//yet/another:value",
+        ],
+    }),
+)'
+
 quoted_deps='go_library(
     name = "edit",
     deps = [
@@ -208,6 +224,86 @@ function test_remove_dep() {
     name = "edit",
     deps = [":local"],
 )'
+}
+
+function test_remove_dep_outside_of_select() {
+  run "$two_deps_with_select" 'remove deps //buildifier:build' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [":local"] + select({
+        "//tools/some:condition": [
+            "//some:value",
+            "//some/other:value",
+        ],
+        "//tools/other:condition": [
+            "//yet/another:value",
+        ],
+    }),
+)'
+}
+
+function test_remove_all_deps_outside_of_select() {
+  run "$two_deps_with_select" 'remove deps //buildifier:build :local' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = select({
+        "//tools/some:condition": [
+            "//some:value",
+            "//some/other:value",
+        ],
+        "//tools/other:condition": [
+            "//yet/another:value",
+        ],
+    }),
+)'
+}
+
+function test_remove_dep_in_select() {
+  run "$two_deps_with_select" 'remove deps //some:value' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        ":local",
+        "//buildifier:build",
+    ] + select({
+        "//tools/some:condition": ["//some/other:value"],
+        "//tools/other:condition": [
+            "//yet/another:value",
+        ],
+    }),
+)'
+}
+
+function test_remove_deps_in_select() {
+  run "$two_deps_with_select" 'remove deps //some:value //some/other:value' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        ":local",
+        "//buildifier:build",
+    ] + select({
+        "//tools/some:condition": [],
+        "//tools/other:condition": [
+            "//yet/another:value",
+        ],
+    }),
+)'
+}
+
+function test_remove_all_deps_in_select() {
+  run "$two_deps_with_select" 'remove deps //some:value //some/other:value //yet/another:value' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        ":local",
+        "//buildifier:build",
+    ],
+)'
+}
+
+function test_remove_all_deps() {
+  run "$two_deps_with_select" 'remove deps //some:value //some/other:value //yet/another:value :local //buildifier:build' '//pkg:edit'
+  assert_equals 'go_library(name = "edit")'
 }
 
 function test_remove_dep_quotes() {
@@ -531,7 +627,11 @@ function test_replace_dep() {
         # Before-comment.
         ":local",  # Suffix comment.
         "//buildifier:build",
-    ],
+    ] + select({
+        "//tools/some:condition": [
+            "//some:value",
+        ],
+    }),
 )'
   run "$in" 'replace deps :local :new' '//pkg:edit'
   assert_equals 'go_library(
@@ -540,7 +640,40 @@ function test_replace_dep() {
         # Before-comment.
         ":new",  # Suffix comment.
         "//buildifier:build",
-    ],
+    ] + select({
+        "//tools/some:condition": [
+            "//some:value",
+        ],
+    }),
+)'
+}
+
+function test_replace_dep_select() {
+  # Replace a dep inside a select statement
+  in='go_library(
+    name = "edit",
+    deps = [":dep"] + select({
+        "//tools/some:condition": [
+            "//some/other:value",
+        ],
+        "//tools/other:condition": [
+            "//yet/another:value",
+        ],
+        "//conditions:default": SOME_CONSTANT,
+    }),
+)'
+  run "$in" 'replace deps //some/other:value :new' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [":dep"] + select({
+        "//tools/some:condition": [
+            ":new",
+        ],
+        "//tools/other:condition": [
+            "//yet/another:value",
+        ],
+        "//conditions:default": SOME_CONSTANT,
+    }),
 )'
 }
 

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -375,6 +375,10 @@ func cmdRemove(opts *Options, env CmdEnvironment) (*build.File, error) {
 				fixed = true
 			}
 			ResolveAttr(env.Rule, key, env.Pkg)
+			// Remove the attribute if's an empty list
+			if listExpr, ok := env.Rule.Attr(key).(*build.ListExpr); ok && len(listExpr.List) == 0 {
+				env.Rule.DelAttr(key)
+			}
 		}
 		if fixed {
 			return env.File, nil

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -422,6 +422,34 @@ func AllSelects(e build.Expr) []*build.CallExpr {
 	return nil
 }
 
+// allListsFromSelects returns all ListExpr nodes from all select statements
+// in an expression
+func allListsFromSelects(e build.Expr) []*build.ListExpr {
+	var lists []*build.ListExpr
+
+	for _, s := range AllSelects(e) {
+		if len(s.List) != 1 {
+			return nil
+		}
+		dict, ok := s.List[0].(*build.DictExpr)
+		if !ok {
+			return nil
+		}
+		for _, item := range dict.List {
+			kv, ok := item.(*build.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			list, ok := kv.Value.(*build.ListExpr)
+			if !ok {
+				continue
+			}
+			lists = append(lists, list)
+		}
+	}
+	return lists
+}
+
 // FirstList works in the same way as AllLists, except that it
 // returns only one list, or nil.
 func FirstList(e build.Expr) *build.ListExpr {
@@ -712,7 +740,7 @@ func ListAttributeDelete(rule *build.Rule, attr, item, pkg string) *build.String
 func ListReplace(e build.Expr, old, value, pkg string) bool {
 	replaced := false
 	old = ShortenLabel(old, pkg)
-	for _, li := range AllLists(e) {
+	for _, li := range append(AllLists(e), allListsFromSelects(e)...) {
 		for k, elem := range li.List {
 			str, ok := elem.(*build.StringExpr)
 			if !ok || !LabelsEqual(str.Value, old, pkg) {


### PR DESCRIPTION
The `replace` command now replaces values inside select statements. The `remove` command already worked correctly but this behavior wasn't covered by tests.