### PR TITLE
Fix working with comments inside select statememnts

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1388,6 +1388,24 @@ function test_value_multiline_print_comment() {
   assert_output 'Just a multiline comment'
 }
 
+function test_value_inside_select_print_comment() {
+  in='cc_library(
+    name = "a",
+    srcs = [
+        "a.cc",  # World
+        "b.cc",  # Hello
+    ] + select({
+        "foo": [
+            "c.cc",  # hello
+            "d.cc",  # world
+        ],
+    }),
+)'
+  ERROR=3 run "$in" 'print_comment srcs c.cc' 'print_comment srcs d.cc' //pkg:a
+  assert_output 'hello
+world'
+}
+
 # Test both absolute and relative package names
 function test_path() {
   mkdir -p "java/com/foo/myproject"

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -117,7 +117,7 @@ func cmdComment(opts *Options, env CmdEnvironment) (*build.File, error) {
 		}
 	case 3: // Attach to a specific value in a list
 		if attr := env.Rule.Attr(env.Args[0]); attr != nil {
-			if expr := ListFind(attr, env.Args[1], env.Pkg); expr != nil {
+			if expr := listOrSelectFind(attr, env.Args[1], env.Pkg); expr != nil {
 				if fullLine {
 					expr.Comments.Before = comment
 				} else {
@@ -169,7 +169,7 @@ func cmdPrintComment(opts *Options, env CmdEnvironment) (*build.File, error) {
 			return nil, attrError()
 		}
 		value := env.Args[1]
-		expr := ListFind(attr, value, env.Pkg)
+		expr := listOrSelectFind(attr, value, env.Pkg)
 		if expr == nil {
 			return nil, fmt.Errorf("attribute \"%s\" has no value \"%s\"", env.Args[0], value)
 		}
@@ -407,7 +407,7 @@ func cmdRemoveComment(opts *Options, env CmdEnvironment) (*build.File, error) {
 		}
 	case 2: // Remove comment attached to value
 		if attr := env.Rule.Attr(env.Args[0]); attr != nil {
-			if expr := ListFind(attr, env.Args[1], env.Pkg); expr != nil {
+			if expr := listOrSelectFind(attr, env.Args[1], env.Pkg); expr != nil {
 				expr.Comments.Before = nil
 				expr.Comments.Suffix = nil
 				expr.Comments.After = nil

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -491,13 +491,11 @@ func AllStrings(e build.Expr) []*build.StringExpr {
 	return nil
 }
 
-// ListFind looks for a string in the list expression (which may be a
-// concatenation of lists). It returns the element if it is found. nil
-// otherwise.
-func ListFind(e build.Expr, item string, pkg string) *build.StringExpr {
+// listsFind looks for a string in list expressions
+func listsFind(lists []*build.ListExpr, item string, pkg string) *build.StringExpr {
 	item = ShortenLabel(item, pkg)
-	for _, li := range AllLists(e) {
-		for _, elem := range li.List {
+	for _, list := range lists {
+		for _, elem := range list.List {
 			str, ok := elem.(*build.StringExpr)
 			if ok && LabelsEqual(str.Value, item, pkg) {
 				return str
@@ -505,6 +503,22 @@ func ListFind(e build.Expr, item string, pkg string) *build.StringExpr {
 		}
 	}
 	return nil
+}
+
+// ListFind looks for a string in the list expression (which may be a
+// concatenation of lists). It returns the element if it is found. nil
+// otherwise.
+func ListFind(e build.Expr, item string, pkg string) *build.StringExpr {
+	item = ShortenLabel(item, pkg)
+	return listsFind(AllLists(e), item, pkg)
+}
+
+// listOrSelectFind looks for a string in the list expression (which may be a
+// concatenation of lists and select statements). It returns the element
+// if it is found. nil otherwise.
+func listOrSelectFind(e build.Expr, item string, pkg string) *build.StringExpr {
+	item = ShortenLabel(item, pkg)
+	return listsFind(allListsIncludingSelects(e), item, pkg)
 }
 
 // hasComments returns whether the StringExpr literal has a comment attached to it.


### PR DESCRIPTION
Buildozer can now work with comments (e.g. print them) for strings inside select statements.