### PR TITLE
Fix dict nodes traversal

### DIFF
--- a/build/walk.go
+++ b/build/walk.go
@@ -95,6 +95,9 @@ func WalkOnce(v Expr, f func(x *Expr)) {
 	case *IndexExpr:
 		f(&v.X)
 		f(&v.Y)
+	case *KeyValueExpr:
+		f(&v.Key)
+		f(&v.Value)
 	case *SliceExpr:
 		f(&v.X)
 		if v.From != nil {
@@ -142,8 +145,8 @@ func WalkOnce(v Expr, f func(x *Expr)) {
 		}
 	case *DictExpr:
 		for i := range v.List {
-			f(&v.List[i].Key)
-			f(&v.List[i].Value)
+			e := Expr(v.List[i])
+			f(&e)
 		}
 	case *Comprehension:
 		f(&v.Body)


### PR DESCRIPTION
Some call sites of `build.Walk` expect `KeyValueExpr` nodes to be visited explicitly.