### PR TITLE
Add tests for lambdas and sets

### DIFF
--- a/build/parse.y
+++ b/build/parse.y
@@ -579,7 +579,7 @@ primary_expr:
 			ForceMultiLine: forceMultiLine($1, exprValues, $3),
 		}
 	}
-|	'{' tests comma_opt '}'  // TODO: remove, not supported
+|	'{' tests comma_opt '}'
 	{
 		$$ = &SetExpr{
 			Start: $1,
@@ -767,7 +767,7 @@ exprs_opt:
 
 test:
 	primary_expr
-|	_LAMBDA exprs_opt ':' expr  // TODO: remove, not supported
+|	_LAMBDA exprs_opt ':' expr
 	{
 		$$ = &LambdaExpr{
 			Function: Function{

--- a/build/print.go
+++ b/build/print.go
@@ -509,11 +509,12 @@ func (p *printer) expr(v Expr, outerPrec int) {
 
 	case *LambdaExpr:
 		addParen(precColon)
-		p.printf("lambda ")
+		p.printf("lambda")
 		for i, param := range v.Params {
 			if i > 0 {
-				p.printf(", ")
+				p.printf(",")
 			}
+			p.printf(" ")
 			p.expr(param, precLow)
 		}
 		p.printf(": ")

--- a/build/testdata/006.build.golden
+++ b/build/testdata/006.build.golden
@@ -1,0 +1,17 @@
+set = {
+    1,
+    2,
+    3,
+}
+
+multiline_set = {
+    4,
+    5,
+    [6],
+}
+
+plus = lambda x, y: x + y
+
+two = (lambda x: x(x))(lambda z: lambda y: z)(1)(2)(3)
+
+make_one = lambda: 1

--- a/build/testdata/006.bzl.golden
+++ b/build/testdata/006.bzl.golden
@@ -1,0 +1,13 @@
+set = {1, 2, 3}
+
+multiline_set = {
+    4,
+    5,
+    [6],
+}
+
+plus = lambda x, y: x + y
+
+two = (lambda x: x(x))(lambda z: lambda y: z)(1)(2)(3)
+
+make_one = lambda: 1

--- a/build/testdata/006.in
+++ b/build/testdata/006.in
@@ -1,0 +1,11 @@
+set = {1, 2, 3}
+
+multiline_set = {
+  4, 5, [6]
+}
+
+plus = lambda x, y: x + y
+
+two = (lambda x:x(x)) (lambda z:lambda y:z)( 1 ) ( 2 ) ( 3 )
+
+make_one = lambda: 1


### PR DESCRIPTION
Lambdas and sets are supported by Starlark-in-go and are supported by Buildifier already but haven't been covered by tests.

#852 