### PR TITLE
Fix potential NPE

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -16,6 +16,9 @@ const FunctionLengthDocstringThreshold = 5
 // Otherwise it returns the first non-comment statement and false.
 func getDocstring(stmts []build.Expr) (*build.Expr, bool) {
 	for i, stmt := range stmts {
+		if stmt == nil {
+			continue
+		}
 		switch stmt.(type) {
 		case *build.CommentBlock:
 			continue


### PR DESCRIPTION
The problem was introduced in #837. The return value of `getDocstring` has been changed from `build.Expr` to `*build.Expr` which made it possible to return `&nil` for special nil-nodes inserted by other linter/fixer functions.

That can lead to NPEs if such values are treated as `Expr` nodes, also that was not correct because nil-nodes should be ignored by linters that haven't created them.