### PR TITLE
Don't warn about disabling comments

### DIFF
--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -418,6 +418,10 @@ func skylarkCommentWarning(f *build.File) []*LinterFinding {
 
 		for _, block := range []*[]build.Comment{&newComments.Before, &newComments.Suffix, &newComments.After} {
 			for i, comment := range *block {
+				// Don't trigger on disabling comments
+				if strings.Contains(comment.Token, "disable=skylark-docstring") {
+					continue
+				}
 				newValue, changed := replaceSkylark(comment.Token)
 				(*block)[i] = build.Comment{
 					Start: comment.Start,

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -486,6 +486,26 @@ Label()
 		},
 		scopeEverywhere)
 
+	checkFindingsAndFix(t, "skylark-comment", `
+"""
+Some docstring with skylark
+""" # buildifier: disable=skylark-docstring
+
+def f():
+  """Some docstring with skylark"""
+  # buildozer: disable=skylark-docstring
+`, `
+"""
+Some docstring with skylark
+""" # buildifier: disable=skylark-docstring
+
+def f():
+  """Some docstring with skylark"""
+  # buildozer: disable=skylark-docstring
+`,
+		[]string{},
+		scopeEverywhere)
+
 	checkFindingsAndFix(t, "skylark-docstring", `
 # Some file
 


### PR DESCRIPTION
If a `skylark-docstring` warning is disabled by a special comment `# buildifier: disable=skylark-comment`, it triggers the `skylark-comment` warning. This commit fixes that.

Fixes #865.