### PR TITLE
Make disabling comments also disable warnings for comments

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -269,6 +269,13 @@ func DisabledWarning(f *build.File, findingLine int, warning string) bool {
 		}
 
 		start, end := expr.Span()
+		comments := expr.Comment()
+		if len(comments.Before) > 0 {
+			start, _ = comments.Before[0].Span()
+		}
+		if len(comments.After) > 0 {
+			_, end = comments.After[len(comments.After)-1].Span()
+		}
 		if findingLine < start.Line || findingLine > end.Line {
 			return
 		}

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -319,6 +319,9 @@ for y in "foobar":  # buildozer: disable=string-iteration
 cc_library(
    name = "foo",  # buildifier: disable=duplicated-name-1
 )
+
+# buildifier: disable=skylark-comment
+# some comment mentioning skylark
 `
 
 	f, err := build.ParseBzl("file.bzl", []byte(contents))
@@ -332,7 +335,7 @@ cc_library(
 		category string
 	}{
 		{
-			start:    4,
+			start:    3,
 			end:      5,
 			category: "depset-iteration",
 		},
@@ -347,7 +350,7 @@ cc_library(
 			category: "string-iteration",
 		},
 		{
-			start:    9,
+			start:    8,
 			end:      9,
 			category: "no-effect",
 		},
@@ -357,9 +360,14 @@ cc_library(
 			category: "duplicated-name-1",
 		},
 		{
-			start:    12,
+			start:    11,
 			end:      14,
 			category: "duplicated-name-2",
+		},
+		{
+			start:    16,
+			end:      17,
+			category: "skylark-comment",
 		},
 	}
 


### PR DESCRIPTION
A warning can be attached not to an AST node itself but to a comment line. A disabling comment (`# buildifier: disable=...`) should also disable such warnings.

Fixes #867