### PR TITLE
Decree package_group.packages as a non-label attribute

### DIFF
--- a/edit/fix.go
+++ b/edit/fix.go
@@ -78,7 +78,7 @@ func shortenLabels(_ *build.File, r *build.Rule, pkg string) bool {
 	fixed := false
 	for _, attr := range r.AttrKeys() {
 		e := r.Attr(attr)
-		if !ContainsLabels(attr) {
+		if !ContainsLabels(r.Kind(), attr) {
 			continue
 		}
 		for _, li := range AllLists(e) {

--- a/edit/types.go
+++ b/edit/types.go
@@ -64,8 +64,8 @@ func IsStringDict(attr string) bool {
 // ContainsLabels returns true for all attributes whose type is a label or a label list.
 func ContainsLabels(kind, attr string) bool {
 	if kind == "package_group" && attr == "packages" {
-	  // "package_group" is a special rule and its "packages" attribute is not a list of labels.
-		return false;
+		// "package_group" is a special rule and its "packages" attribute is not a list of labels.
+		return false
 	}
 	ty := typeOf[attr]
 	return ty == buildpb.Attribute_LABEL_LIST ||

--- a/edit/types.go
+++ b/edit/types.go
@@ -62,7 +62,11 @@ func IsStringDict(attr string) bool {
 }
 
 // ContainsLabels returns true for all attributes whose type is a label or a label list.
-func ContainsLabels(attr string) bool {
+func ContainsLabels(kind, attr string) bool {
+	if kind == "package_group" && attr == "packages" {
+	  // "package_group" is a special rule and its "packages" attribute is not a list of labels.
+		return false;
+	}
 	ty := typeOf[attr]
 	return ty == buildpb.Attribute_LABEL_LIST ||
 		ty == buildpb.Attribute_LABEL


### PR DESCRIPTION
The attribute doesn't contain labels, the values shouldn't be shortened.