### PR TITLE
Automatically remove superfluous parens

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -18,12 +18,13 @@ distributed under the License is distributed on an "AS IS" BASIS,
 package build
 
 import (
-	"github.com/bazelbuild/buildtools/tables"
 	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/bazelbuild/buildtools/tables"
 )
 
 // For debugging: flag to disable certain rewrites.
@@ -79,6 +80,7 @@ var rewrites = []struct {
 	fn    func(*File)
 	scope FileType
 }{
+	{"removeParens", removeParens, scopeBoth},
 	{"callsort", sortCallArgs, scopeBuild},
 	{"label", fixLabels, scopeBuild},
 	{"listsort", sortStringLists, scopeBoth},
@@ -933,4 +935,35 @@ func editOctals(f *File) {
 			l.Token = "0o" + l.Token[1:]
 		}
 	})
+}
+
+// removeParens removes trivial parens
+func removeParens(f *File) {
+	var simplify func(expr Expr, stack []Expr) Expr
+	simplify = func(expr Expr, stack []Expr) Expr {
+		// Look for parenthesized expressions, ignoring those with
+		// comments and those that are intentionally multiline.
+		pa, ok := expr.(*ParenExpr)
+		if !ok || pa.ForceMultiLine {
+			return expr
+		}
+		if len(pa.Comment().Before) > 0 || len(pa.Comment().After) > 0 || len(pa.Comment().Before) > 0 {
+			return expr
+		}
+
+		switch x := pa.X.(type) {
+		case *Comprehension, *DictExpr, *Ident, *ListExpr, *LiteralExpr, *ParenExpr, *SetExpr, *StringExpr:
+			// These expressions don't need parens, remove them (recursively).
+			return Edit(x, simplify)
+		case *CallExpr:
+			// Parens might be needed if the callable is multiline.
+			start, end := x.X.Span()
+			if start.Line == end.Line {
+				return Edit(x, simplify)
+			}
+		}
+		return expr
+	}
+
+	Edit(f, simplify)
 }

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -947,7 +947,7 @@ func removeParens(f *File) {
 		if !ok || pa.ForceMultiLine {
 			return expr
 		}
-		if len(pa.Comment().Before) > 0 || len(pa.Comment().After) > 0 || len(pa.Comment().Before) > 0 {
+		if len(pa.Comment().Before) > 0 || len(pa.Comment().After) > 0 || len(pa.Comment().Suffix) > 0 {
 			return expr
 		}
 

--- a/build/testdata/047.build.golden
+++ b/build/testdata/047.build.golden
@@ -40,7 +40,7 @@ dict_comprehension = {
     (b, c),
 ) in d]
 
-[a for (a) in b]
+[a for a in b]
 
 [a for (a,) in b]
 

--- a/build/testdata/047.bzl.golden
+++ b/build/testdata/047.bzl.golden
@@ -32,7 +32,7 @@ dict_comprehension = {
     (b, c),
 ) in d]
 
-[a for (a) in b]
+[a for a in b]
 [a for (a,) in b]
 [a for (
     a

--- a/build/testdata/066.golden
+++ b/build/testdata/066.golden
@@ -29,3 +29,11 @@ macro(
 )
 
 nested = 1
+
+comments = [
+    "a",
+    ("b"),  # end of line comment
+
+    # before comment
+    ("c"),
+]  # comment

--- a/build/testdata/066.golden
+++ b/build/testdata/066.golden
@@ -1,0 +1,31 @@
+st1 = "abc"
+
+st2 = """
+multiline"""
+
+st3 = (
+    "multi"
+)
+
+n = 123
+
+id = a
+
+fct1 = foo(1)
+
+fct2 = foo(
+    arg = 1,
+)
+
+fct3 = (
+    foo(
+        arg = 1,
+    )
+)
+
+macro(
+    name = "foo",
+    arg = ["a"],
+)
+
+nested = 1

--- a/build/testdata/066.in
+++ b/build/testdata/066.in
@@ -1,0 +1,31 @@
+st1 = ("abc")
+
+st2 = ("""
+multiline""")
+
+st3 = (
+"multi"
+)
+
+n = (123)
+
+id = (a)
+
+fct1 = (foo(1))
+
+fct2 = (foo(
+    arg = 1,
+))
+
+fct3 = (
+    foo(
+        arg = 1,
+    )
+)
+
+(macro(
+    name = ("foo"),
+    arg = ([("a")]),
+))
+
+nested = (((((1)))))

--- a/build/testdata/066.in
+++ b/build/testdata/066.in
@@ -4,7 +4,7 @@ st2 = ("""
 multiline""")
 
 st3 = (
-"multi"
+    "multi"
 )
 
 n = (123)
@@ -29,3 +29,11 @@ fct3 = (
 ))
 
 nested = (((((1)))))
+
+comments = ([
+    "a",
+    ("b"),  # end of line comment
+
+    # before comment
+    ("c"),
+])  # comment


### PR DESCRIPTION
This transformation applies only in a few safe cases. Parens are
preserved in multiline expressions, in presence of a comment, or in
complex expressions.

This change can modify the formatting of existing files, but such cases
should be relatively rare.