### PR TITLE
Fix wrong error msg & doc about --mode=check

### DIFF
--- a/buildifier/README.md
+++ b/buildifier/README.md
@@ -139,7 +139,7 @@ bazel run //:buildifier
 ## File diagnostics in json
 
 Buildifier supports diagnostics output in machine-readable format (json), triggered by
-`--format=json` (only works in combination with `--type=check`). If used in combination with `-v`,
+`--format=json` (only works in combination with `--mode=check`). If used in combination with `-v`,
 the output json will be indented for better readability.
 
 The output format is the following:

--- a/buildifier/utils/flags.go
+++ b/buildifier/utils/flags.go
@@ -40,7 +40,7 @@ func ValidateFormat(format, mode *string) error {
 
 	case "text", "json":
 		if *mode != "check" {
-			return fmt.Errorf("cannot specify --format without --type=check")
+			return fmt.Errorf("cannot specify --format without --mode=check")
 		}
 
 	default:


### PR DESCRIPTION
It's a typo in both error message and the doc, should be `--mode=check` instead of `--type=check` :)

I tried using it with `--type=check` and was getting following error:

```console
buildifier -v --format=json --type=check myfile.bzl
buildifier: unrecognized input type check; valid types are build, bzl, workspace, default, auto
```