### PR TITLE
Format files with a builtin buildifier correctly

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -946,6 +946,19 @@ function test_set_if_absent_present() {
 )'
 }
 
+function test_set_custom_code() {
+  in='cc_test(name = "a")'
+
+  run "$in" 'set attr foo(a=1,b=2)' '//pkg:a'
+  assert_equals 'cc_test(
+    name = "a",
+    attr = foo(
+        a = 1,
+        b = 2,
+    ),
+)'
+}
+
 function assert_output() {
   echo "$1" > "expected"
   diff -u "expected" "$log" || fail "Output didn't match"


### PR DESCRIPTION
An AST after buildozer transformations may be not correct, e.g. it may have an `Ident` node with a complex expression inside. In order to format such AST correctly it should be printed to a string, re-parsed correctly and printed again.

Fixes #894