### PR TITLE
Restore removed methods

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -1121,3 +1121,25 @@ func ReplaceLoad(stmts []build.Expr, location string, from, to []string) []build
 	// 2. Insert new loads.
 	return InsertLoad(all, location, from, to)
 }
+
+// ParseLabel parses a Blaze label (eg. //devtools/buildozer:rule), and returns
+// the repo name ("" for the main repo), package (with leading slashes trimmed)
+// and rule name (e.g. ["", "devtools/buildozer", "rule"]).
+// Deprecated; use labels.ParseLabel instead
+func ParseLabel(target string) (string, string, string) {
+	label := labels.ParseLabel(target)
+	return label.Repository, label.Package, label.Target
+}
+
+// ShortenLabel rewrites labels to use the canonical form (the form
+// recommended by build-style).
+// Deprecated; use labels.ShortenLabel instead
+func ShortenLabel(label string, pkg string) string {
+	return labels.ShortenLabel(label, pkg)
+}
+
+// LabelsEqual returns true if label1 and label2 are equal.
+// Deprecated; use labels.Equal instead
+func LabelsEqual(label1, label2, pkg string) bool {
+	return labels.Equal(label1, label2, pkg)
+}

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -29,6 +29,92 @@ import (
 	"github.com/bazelbuild/buildtools/build"
 )
 
+var parseLabelTests = []struct {
+	in   string
+	repo string
+	pkg  string
+	rule string
+}{
+	{"//devtools/buildozer:rule", "", "devtools/buildozer", "rule"},
+	{"devtools/buildozer:rule", "", "devtools/buildozer", "rule"},
+	{"//devtools/buildozer", "", "devtools/buildozer", "buildozer"},
+	{"//base", "", "base", "base"},
+	{"//base:", "", "base", "base"},
+	{"@r//devtools/buildozer:rule", "r", "devtools/buildozer", "rule"},
+	{"@r//devtools/buildozer", "r", "devtools/buildozer", "buildozer"},
+	{"@r//base", "r", "base", "base"},
+	{"@r//base:", "r", "base", "base"},
+	{"@foo", "foo", "", "foo"},
+	{":label", "", "", "label"},
+	{"label", "", "", "label"},
+	{"/abs/path/to/WORKSPACE:rule", "", "/abs/path/to/WORKSPACE", "rule"},
+}
+
+func TestParseLabel(t *testing.T) {
+	for i, tt := range parseLabelTests {
+		repo, pkg, rule := ParseLabel(tt.in)
+		if repo != tt.repo || pkg != tt.pkg || rule != tt.rule {
+			t.Errorf("%d. ParseLabel(%q) => (%q, %q, %q), want (%q, %q, %q)",
+				i, tt.in, repo, pkg, rule, tt.repo, tt.pkg, tt.rule)
+		}
+	}
+}
+
+var shortenLabelTests = []struct {
+	in     string
+	pkg    string
+	result string
+}{
+	{"//devtools/buildozer:rule", "devtools/buildozer", ":rule"},
+	{"@//devtools/buildozer:rule", "devtools/buildozer", ":rule"},
+	{"//devtools/buildozer:rule", "devtools", "//devtools/buildozer:rule"},
+	{"//base:rule", "devtools", "//base:rule"},
+	{"//base:base", "devtools", "//base"},
+	{"//base", "base", ":base"},
+	{"//devtools/buildozer:buildozer", "", "//devtools/buildozer"},
+	{"@r//devtools/buildozer:buildozer", "devtools/buildozer", "@r//devtools/buildozer"},
+	{"@r//devtools/buildozer", "devtools/buildozer", "@r//devtools/buildozer"},
+	{"@r//devtools", "devtools", "@r//devtools"},
+	{"@r:rule", "", "@r:rule"},
+	{"@r", "", "@r"},
+	{"@foo//:foo", "", "@foo"},
+	{"@foo//devtools:foo", "", "@foo//devtools:foo"},
+	{"@foo//devtools:foo", "devtools", "@foo//devtools:foo"},
+	{"@foo//foo:foo", "", "@foo//foo"},
+	{":local", "", ":local"},
+	{"something else", "", "something else"},
+	{"/path/to/file", "path/to", "/path/to/file"},
+}
+
+func TestShortenLabel(t *testing.T) {
+	for i, tt := range shortenLabelTests {
+		result := ShortenLabel(tt.in, tt.pkg)
+		if result != tt.result {
+			t.Errorf("%d. ShortenLabel(%q, %q) => %q, want %q",
+				i, tt.in, tt.pkg, result, tt.result)
+		}
+	}
+}
+
+var labelsEqualTests = []struct {
+	label1   string
+	label2   string
+	pkg      string
+	expected bool
+}{
+	{"//devtools/buildozer:rule", "rule", "devtools/buildozer", true},
+	{"//devtools/buildozer:rule", "rule:jar", "devtools", false},
+}
+
+func TestLabelsEqual(t *testing.T) {
+	for i, tt := range labelsEqualTests {
+		if got := LabelsEqual(tt.label1, tt.label2, tt.pkg); got != tt.expected {
+			t.Errorf("%d. LabelsEqual(%q, %q, %q) => %v, want %v",
+				i, tt.label1, tt.label2, tt.pkg, got, tt.expected)
+		}
+	}
+}
+
 var splitOnSpacesTests = []struct {
 	in  string
 	out []string


### PR DESCRIPTION
Some methods have been moved from `edit` to `labels` in #903. They are still being used internally, so they should be restored for backward compatibility.