### PR TITLE
Restore the --shorten_label flag

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -187,6 +187,17 @@ function test_sorted_deps() {
 )'
 }
 
+function test_noshorten_labels_flag() {
+  in='go_library(
+    name = "edit",
+)'
+  run "$in" --shorten_labels=false 'add deps //pkg:local' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = ["//pkg:local"],
+)'
+}
+
 function test_add_duplicate_label() {
   # "build" and ":build" labels are equivalent
   in='go_library(

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -529,9 +529,9 @@ func getStringValue(value string) string {
 // and shortens the label value if possible.
 func getStringExpr(value, pkg string) build.Expr {
 	if unquoted, triple, err := build.Unquote(value); err == nil {
-		return &build.StringExpr{Value: labels.ShortenLabel(unquoted, pkg), TripleQuote: triple}
+		return &build.StringExpr{Value: ShortenLabel(unquoted, pkg), TripleQuote: triple}
 	}
-	return &build.StringExpr{Value: labels.ShortenLabel(value, pkg)}
+	return &build.StringExpr{Value: ShortenLabel(value, pkg)}
 }
 
 func cmdCopy(opts *Options, env CmdEnvironment) (*build.File, error) {


### PR DESCRIPTION
#903 removed support of the `--shorten_labels` flag, however there are still few usages of it, and it should be restored.

At the same time, `ShortenLabel` was also used to compare labels, where 1. the flag shouldn't play any role, 2. it's not necessary because `labels.Equal` can correctly compare long and short labels.