### PR TITLE
Rename methods to avoid repetition

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -925,7 +925,7 @@ func rewrite(opts *Options, commandsForFile commandsForFile) *rewriteResult {
 		target := commands.target
 		commands := commands.commands
 		_, absPkg, rule := InterpretLabelForWorkspaceLocation(opts.RootDir, target)
-		if label := labels.ParseLabel(target); label.Package == stdinPackageName {
+		if label := labels.Parse(target); label.Package == stdinPackageName {
 			// Special-case: This is already absolute
 			absPkg = stdinPackageName
 		}
@@ -1102,7 +1102,7 @@ func appendCommands(opts *Options, commandMap map[string][]commandsForTarget, ar
 			}
 		}
 		var buildFiles []string
-		if label := labels.ParseLabel(target); label.Package == stdinPackageName {
+		if label := labels.Parse(target); label.Package == stdinPackageName {
 			buildFiles = []string{stdinPackageName}
 		} else {
 			buildFiles = targetExpressionToBuildFiles(opts.RootDir, target)

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -56,7 +56,7 @@ func isFile(path string) bool {
 // edit, the full package name, and the rule. It takes a workspace-rooted
 // directory to use.
 func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile string, pkg string, rule string) {
-	label := labels.ParseLabel(target)
+	label := labels.Parse(target)
 	repo := label.Repository
 	pkg = label.Package
 	rule = label.Target
@@ -1120,25 +1120,25 @@ func ReplaceLoad(stmts []build.Expr, location string, from, to []string) []build
 // ParseLabel parses a Blaze label (eg. //devtools/buildozer:rule), and returns
 // the repo name ("" for the main repo), package (with leading slashes trimmed)
 // and rule name (e.g. ["", "devtools/buildozer", "rule"]).
-// Deprecated; use labels.ParseLabel instead
+// Deprecated; use `labels.Parse` instead
 func ParseLabel(target string) (string, string, string) {
-	label := labels.ParseLabel(target)
+	label := labels.Parse(target)
 	return label.Repository, label.Package, label.Target
 }
 
 // ShortenLabel rewrites labels to use the canonical form (the form
 // recommended by build-style).
 // Doesn't do anything if `--shorten_label=false` flag is provided.
-// Use `labels.ShortenLabel` to shorten labels unconditionally.
+// Use `labels.Shorten` to shorten labels unconditionally.
 func ShortenLabel(label, pkg string) string {
 	if !ShortenLabelsFlag {
 		return label
 	}
-	return labels.ShortenLabel(label, pkg)
+	return labels.Shorten(label, pkg)
 }
 
 // LabelsEqual returns true if label1 and label2 are equal.
-// Deprecated; use labels.Equal instead
+// Deprecated; use `labels.Equal` instead
 func LabelsEqual(label1, label2, pkg string) bool {
 	return labels.Equal(label1, label2, pkg)
 }

--- a/edit/fix.go
+++ b/edit/fix.go
@@ -89,8 +89,8 @@ func shortenLabels(_ *build.File, r *build.Rule, pkg string) bool {
 		for _, li := range AllLists(e) {
 			for _, elem := range li.List {
 				str, ok := elem.(*build.StringExpr)
-				if ok && str.Value != labels.ShortenLabel(str.Value, pkg) {
-					str.Value = labels.ShortenLabel(str.Value, pkg)
+				if ok && str.Value != labels.Shorten(str.Value, pkg) {
+					str.Value = labels.Shorten(str.Value, pkg)
 					fixed = true
 				}
 			}

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -61,9 +61,9 @@ func (l Label) FormatRelative(pkg string) string {
 	return ":" + l.Target
 }
 
-// ParseLabel parses an absolute Bazel label (eg. //devtools/buildozer:rule)
+// Parse parses an absolute Bazel label (eg. //devtools/buildozer:rule)
 // and returns the corresponding Label object.
-func ParseLabel(target string) Label {
+func Parse(target string) Label {
 	label := Label{}
 	if strings.HasPrefix(target, "@") {
 		target = strings.TrimLeft(target, "@")
@@ -91,25 +91,25 @@ func ParseLabel(target string) Label {
 	return label
 }
 
-// ParseRelativeLabel parses a label `input` which may be absolute or relative.
+// ParseRelative parses a label `input` which may be absolute or relative.
 // If it's relative then it's considered to belong to `pkg`
-func ParseRelativeLabel(input, pkg string) Label {
+func ParseRelative(input, pkg string) Label {
 	if !strings.HasPrefix(input, "@") && !strings.HasPrefix(input, "//") {
 		return Label{Package: pkg, Target: strings.TrimLeft(input, ":")}
 	}
-	return ParseLabel(input)
+	return Parse(input)
 }
 
-// ShortenLabel rewrites labels to use the canonical form (the form
+// Shorten rewrites labels to use the canonical form (the form
 // recommended by build-style).
 // "//foo/bar:bar" => "//foo/bar", or ":bar" if the label belongs to pkg
-func ShortenLabel(input, pkg string) string {
+func Shorten(input, pkg string) string {
 	if !strings.HasPrefix(input, "//") && !strings.HasPrefix(input, "@") {
 		// It doesn't look like a long label, so we preserve it.
 		// Maybe it's not a label at all, e.g. a filename.
 		return input
 	}
-	label := ParseLabel(input)
+	label := Parse(input)
 	return label.FormatRelative(pkg)
 }
 
@@ -117,5 +117,5 @@ func ShortenLabel(input, pkg string) string {
 // takes care of the optional ":" prefix and differences between long-form
 // labels and local labels (relative to pkg).
 func Equal(label1, label2, pkg string) bool {
-	return ParseRelativeLabel(label1, pkg) == ParseRelativeLabel(label2, pkg)
+	return ParseRelative(label1, pkg) == ParseRelative(label2, pkg)
 }

--- a/labels/labels_test.go
+++ b/labels/labels_test.go
@@ -43,9 +43,9 @@ var parseLabelTests = []struct {
 
 func TestParseLabel(t *testing.T) {
 	for i, tt := range parseLabelTests {
-		l := ParseLabel(tt.in)
+		l := Parse(tt.in)
 		if l.Repository != tt.repo || l.Package != tt.pkg || l.Target != tt.target {
-			t.Errorf("%d. ParseLabel(%q) => (%q, %q, %q), want (%q, %q, %q)",
+			t.Errorf("%d. Parse(%q) => (%q, %q, %q), want (%q, %q, %q)",
 				i, tt.in, l.Repository, l.Package, l.Target, tt.repo, tt.pkg, tt.target)
 		}
 	}
@@ -80,9 +80,9 @@ var shortenLabelTests = []struct {
 
 func TestShortenLabel(t *testing.T) {
 	for i, tt := range shortenLabelTests {
-		result := ShortenLabel(tt.in, tt.pkg)
+		result := Shorten(tt.in, tt.pkg)
 		if result != tt.result {
-			t.Errorf("%d. ShortenLabel(%q, %q) => %q, want %q",
+			t.Errorf("%d. Shorten(%q, %q) => %q, want %q",
 				i, tt.in, tt.pkg, result, tt.result)
 		}
 	}

--- a/warn/warn_deprecated.go
+++ b/warn/warn_deprecated.go
@@ -61,7 +61,7 @@ func deprecatedFunctionWarning(f *build.File, fileReader *FileReader) []*LinterF
 		if !ok {
 			continue
 		}
-		label := labels.ParseRelativeLabel(load.Module.Value, f.Pkg)
+		label := labels.ParseRelative(load.Module.Value, f.Pkg)
 		if label.Repository != "" || label.Target == "" {
 			continue
 		}

--- a/warn/warn_macro.go
+++ b/warn/warn_macro.go
@@ -141,7 +141,7 @@ func analyzeFile(f *build.File) fileData {
 		if !ok {
 			continue
 		}
-		label := labels.ParseRelativeLabel(load.Module.Value, f.Pkg)
+		label := labels.ParseRelative(load.Module.Value, f.Pkg)
 		if label.Repository != "" || label.Target == "" {
 			continue
 		}


### PR DESCRIPTION
E.g. `labels.ParseLabel()` -> `labels.Parse()`.