### PR TITLE
Allow += on top level lists

### DIFF
--- a/warn/types.go
+++ b/warn/types.go
@@ -36,6 +36,7 @@ const (
 	Int
 	None
 	String
+	List
 )
 
 func (t Type) String() string {
@@ -50,6 +51,7 @@ func (t Type) String() string {
 		"int",
 		"none",
 		"string",
+		"list",
 	}[t]
 }
 
@@ -74,11 +76,15 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 			nodeType = String
 		case *build.DictExpr:
 			nodeType = Dict
+		case *build.ListExpr:
+			nodeType = List
 		case *build.LiteralExpr:
 			nodeType = Int
 		case *build.Comprehension:
 			if node.Curly {
 				nodeType = Dict
+			} else {
+				nodeType = List
 			}
 		case *build.CallExpr:
 			if ident, ok := (node.X).(*build.Ident); ok {
@@ -87,6 +93,8 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 					nodeType = Depset
 				case "dict":
 					nodeType = Dict
+				case "list":
+					nodeType = List
 				}
 			} else if dot, ok := (node.X).(*build.DotExpr); ok {
 				if result[dot.X] == CtxActions && dot.Name == "args" {

--- a/warn/types_test.go
+++ b/warn/types_test.go
@@ -76,10 +76,10 @@ d = dict:<{}>
 d2 = dict:<{foo: bar}>
 d3 = dict:<dict(**foo)>
 d4 = dict:<{k: v for k, v in foo}>
-dep = depset:<depset(items = [
+dep = depset:<depset(items = list:<[
     string:<s>,
     dict:<d>,
-])>
+]>)>
 foo = bar
 `)
 }

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -353,6 +353,7 @@ func TestRedefinedVariable(t *testing.T) {
 	checkFindings(t, "redefined-variable", `
 x = "old_value"
 x = "new_value"
+x[1] = "new"
 cc_library(name = x)`,
 		[]string{":2: Variable \"x\" has already been defined."},
 		scopeEverywhere)
@@ -370,6 +371,44 @@ def bar():
   y = "f"
   y = "g"`,
 		[]string{},
+		scopeEverywhere)
+
+	checkFindings(t, "redefined-variable", `
+x = [1, 2, 3]
+y = [a for a in b]
+z = list()
+n = 43
+
+x += something()
+y += something()
+z += something()
+n += something()
+x -= something()`,
+		[]string{
+			":9: Variable \"n\" has already been defined.",
+			":10: Variable \"x\" has already been defined.",
+		},
+		scopeEverywhere)
+
+	checkFindings(t, "redefined-variable", `
+x = [1, 2, 3]
+y = [a for a in b]
+z = list()
+
+a = something()
+b = something()
+c = something()
+d = something()
+e = something()
+
+a += x
+b += y
+c += z
+d += [42]
+e += foo`,
+		[]string{
+			":15: Variable \"e\" has already been defined.",
+		},
 		scopeEverywhere)
 }
 


### PR DESCRIPTION
The `redefined-variable` check disallows modifying top-level variables, however the `+=` operator on lists doesn't redefine them but just modifies them in-place, that should be allowed.