### PR TITLE
buildifier2: support lambda expressions

### DIFF
--- a/build/testdata/006.build.golden
+++ b/build/testdata/006.build.golden
@@ -22,3 +22,14 @@ l = lambda x, y, *args, **kwargs: f(
     *args,
     **kwargs
 )
+
+TriggerActionAfterProbe(
+    action = lambda State, response: None,
+    predicate = lambda State, response: all([
+        response["request"]["method"] == "GET",
+        response["request"]["url"].find("/posts/") != -1,
+        response["request"]["url"].endswith("/comments"),
+        response["status_code"] in range(200, 299),
+    ]),
+    probe = ("http", "response"),
+)

--- a/build/testdata/006.bzl.golden
+++ b/build/testdata/006.bzl.golden
@@ -13,3 +13,14 @@ two = (lambda x: x(x))(lambda z: lambda y: z)(1)(2)(3)
 make_one = lambda: 1
 
 l = lambda x, y, *args, **kwargs: f(y, key = x, *args, **kwargs)
+
+TriggerActionAfterProbe(
+    probe = ("http", "response"),
+    predicate = lambda State, response: all([
+        response["request"]["method"] == "GET",
+        response["request"]["url"].find("/posts/") != -1,
+        response["request"]["url"].endswith("/comments"),
+        response["status_code"] in range(200, 299),
+    ]),
+    action = lambda State, response: None,
+)

--- a/build/testdata/006.in
+++ b/build/testdata/006.in
@@ -11,3 +11,14 @@ two = (lambda x:x(x)) (lambda z:lambda y:z)( 1 ) ( 2 ) ( 3 )
 make_one = lambda: 1
 
 l = lambda x,y,*args,**kwargs:f(y,key=x,*args,**kwargs)
+
+TriggerActionAfterProbe(
+    probe = ("http", "response"),
+    predicate = lambda State, response: all([
+        response["request"]["method"] == "GET",
+        response["request"]["url"].find("/posts/") != -1,
+        response["request"]["url"].endswith("/comments"),
+        response["status_code"] in range(200, 299),
+    ]),
+    action = lambda State, response: None,
+)

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -21,6 +21,7 @@ limitations under the License.
 package convertast
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -267,6 +268,16 @@ func convExpr(e syntax.Expr) build.Expr {
 			Y:        convExpr(e.Y),
 			Comments: convComments(e.Comments()),
 		}
+	case *syntax.LambdaExpr:
+		return &build.LambdaExpr{
+			Comments: convComments(e.Comments()),
+			Function: build.Function{
+				Params: convExprs(e.Params),
+				Body:   []build.Expr{convExpr(e.Body)},
+			},
+		}
+	default:
+		panic(fmt.Sprintf("other expr: %T %+v", e, e))
 	}
-	panic("other expr")
+	panic("unreachable")
 }


### PR DESCRIPTION
Note that in my own usage of buildifier2 the example I provided gets `build.FormatString`-ed onto just one line:
```starlark
TriggerActionAfterProbe(probe = ("http", "response"), predicate = lambda State, response: all([response["request"]["method"] == "GET", response["request"]["url"].find("/posts/") != -1, response["request"]["url"].endswith("/comments"), response["status_code"] in range(200, 299)]), action = lambda State, response: None)
```
I wonder what's different with this test suite. And now writing all this I'm guessing either
* my code isn't being exercised by the tests, or
* the tests use different formatting settings
I'll look into it (any ideas though?)

Anyway, buildifier2 would crash without this clause.
