### PR TITLE
Allow multiple command files to be passed into buildozer

### DIFF
--- a/buildozer/main.go
+++ b/buildozer/main.go
@@ -29,16 +29,25 @@ import (
 	"github.com/bazelbuild/buildtools/tables"
 )
 
+type flagArray []string
+
+func (i *flagArray) String() string { return strings.Join(*i, ",") }
+func (i *flagArray) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 var (
 	buildVersion     = "redacted"
 	buildScmRevision = "redacted"
+
+	commandsFiles flagArray
 
 	version           = flag.Bool("version", false, "Print the version of buildozer")
 	stdout            = flag.Bool("stdout", false, "write changed BUILD file to stdout")
 	buildifier        = flag.String("buildifier", "", "format output using a specific buildifier binary. If empty, use built-in formatter")
 	parallelism       = flag.Int("P", 0, "number of cores to use for concurrent actions")
 	numio             = flag.Int("numio", 200, "number of concurrent actions")
-	commandsFile      = flag.String("f", "", "file name to read commands from, use '-' for stdin (format:|-separated command line arguments to buildozer, excluding flags)")
 	keepGoing         = flag.Bool("k", false, "apply all commands, even if there are failures")
 	filterRuleTypes   = stringList("types", "comma-separated list of rule types to change, the default empty list means all rules")
 	preferEOLComments = flag.Bool("eol-comments", true, "when adding a new comment, put it on the same line if possible")
@@ -68,6 +77,7 @@ func stringList(name, help string) func() []string {
 }
 
 func main() {
+	flag.Var(&commandsFiles, "f", "file name(s) to read commands from, use '-' for stdin (format:|-separated command line arguments to buildozer, excluding flags)")
 	flag.Parse()
 
 	if *version {
@@ -100,7 +110,7 @@ func main() {
 		Buildifier:        *buildifier,
 		Parallelism:       *parallelism,
 		NumIO:             *numio,
-		CommandsFile:      *commandsFile,
+		CommandsFiles:     commandsFiles,
 		KeepGoing:         *keepGoing,
 		FilterRuleTypes:   filterRuleTypes(),
 		PreferEOLComments: *preferEOLComments,

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -48,7 +48,7 @@ type Options struct {
 	Buildifier        string    // path to buildifier binary
 	Parallelism       int       // number of cores to use for concurrent actions
 	NumIO             int       // number of concurrent actions
-	CommandsFile      string    // file name to read commands from, use '-' for stdin (format:|-separated command line arguments to buildozer, excluding flags
+	CommandsFiles     []string  // file names to read commands from, use '-' for stdin (format:|-separated command line arguments to buildozer, excluding flags
 	KeepGoing         bool      // apply all commands, even if there are failures
 	FilterRuleTypes   []string  // list of rule types to change, empty means all
 	PreferEOLComments bool      // when adding a new comment, put it on the same line if possible
@@ -1123,16 +1123,18 @@ func appendCommands(opts *Options, commandMap map[string][]commandsForTarget, ar
 	}
 }
 
-func appendCommandsFromFile(opts *Options, commandsByFile map[string][]commandsForTarget, fileName string) {
-	var reader io.Reader
-	if opts.CommandsFile == stdinPackageName {
-		reader = os.Stdin
-	} else {
-		rc := file.OpenReadFile(opts.CommandsFile)
-		reader = rc
-		defer rc.Close()
+func appendCommandsFromFiles(opts *Options, commandsByFile map[string][]commandsForTarget) {
+	for _, fileName := range opts.CommandsFiles {
+		var reader io.Reader
+		if fileName == stdinPackageName {
+			reader = os.Stdin
+		} else {
+			rc := file.OpenReadFile(fileName)
+			reader = rc
+			defer rc.Close()
+		}
+		appendCommandsFromReader(opts, reader, commandsByFile)
 	}
-	appendCommandsFromReader(opts, reader, commandsByFile)
 }
 
 func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile map[string][]commandsForTarget) {
@@ -1200,8 +1202,8 @@ func Buildozer(opts *Options, args []string) int {
 		opts.ErrWriter = os.Stderr
 	}
 	commandsByFile := make(map[string][]commandsForTarget)
-	if opts.CommandsFile != "" {
-		appendCommandsFromFile(opts, commandsByFile, opts.CommandsFile)
+	if len(opts.CommandsFiles) > 0 {
+		appendCommandsFromFiles(opts, commandsByFile)
 	} else {
 		if len(args) == 0 {
 			Usage()


### PR DESCRIPTION
This updates buildozer to accept multiple command files, reading and executing the instructions in each of them. An example usage would be `buildozer -f file_1 -f file_2`. This should be backwards compatible with existing usages. 

It looks like `flag` doesn't support multiple instances of the same flag, so I've implemented a custom solution in `buildozer/main.go` [taken from StackOverflow](https://stackoverflow.com/questions/28322997/how-to-get-a-list-of-values-into-a-flag-in-golang). 