### PR TITLE
feat(buildifier): add buildifier_test

### DIFF
--- a/buildifier/buildifier.bzl
+++ b/buildifier/buildifier.bzl
@@ -1,0 +1,41 @@
+"""
+The module defines buildifier as a Bazel rule.
+"""
+
+load(
+    "//buildifier/internal:factory.bzl",
+    "buildifier_attr_factory",
+    "buildifier_impl_factory",
+)
+
+def _buildifier_impl(ctx):
+    return [buildifier_impl_factory(ctx)]
+
+_buildifier = rule(
+    implementation = _buildifier_impl,
+    attrs = buildifier_attr_factory(),
+    executable = True,
+)
+
+def buildifier(**kwargs):
+    """
+    Wrapper for the _buildifier rule. Adds 'manual' to the tags.
+
+    Args:
+      **kwargs: all parameters for _buildifier
+    """
+
+    tags = kwargs.get("tags", [])
+    if "manual" not in tags:
+        tags.append("manual")
+        kwargs["tags"] = tags
+    _buildifier(**kwargs)
+
+def _buildifier_test_impl(ctx):
+    return [buildifier_impl_factory(ctx, test_rule = True)]
+
+buildifier_test = rule(
+    implementation = _buildifier_test_impl,
+    attrs = buildifier_attr_factory(True),
+    test = True,
+)

--- a/buildifier/def.bzl
+++ b/buildifier/def.bzl
@@ -1,112 +1,12 @@
 """
-The module defines buildifier as a Bazel rule.
+This module is the public interface to buildifier rules
 """
 
-load("@bazel_skylib//lib:shell.bzl", "shell")
-
-def _buildifier_impl(ctx):
-    # Do not depend on defaults encoded in the binary.  Always use defaults set
-    # on attributes of the rule.
-    args = [
-        "-mode=%s" % ctx.attr.mode,
-        "-v=%s" % str(ctx.attr.verbose).lower(),
-    ]
-
-    if ctx.attr.lint_mode:
-        args.append("-lint=%s" % ctx.attr.lint_mode)
-    if ctx.attr.lint_warnings:
-        if not ctx.attr.lint_mode:
-            fail("Cannot pass 'lint_warnings' without a 'lint_mode'")
-        args.append("--warnings={}".format(",".join(ctx.attr.lint_warnings)))
-    if ctx.attr.multi_diff:
-        args.append("-multi_diff")
-    if ctx.attr.diff_command:
-        args.append("-diff_command=%s" % ctx.attr.diff_command)
-    if ctx.attr.add_tables:
-        args.append("-add_tables=%s" % ctx.file.add_tables.path)
-
-    exclude_patterns_str = ""
-    if ctx.attr.exclude_patterns:
-        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
-        exclude_patterns_str = " ".join(exclude_patterns)
-
-    out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
-    substitutions = {
-        "@@ARGS@@": shell.array_literal(args),
-        "@@BUILDIFIER_SHORT_PATH@@": shell.quote(ctx.executable._buildifier.short_path),
-        "@@EXCLUDE_PATTERNS@@": exclude_patterns_str,
-    }
-    ctx.actions.expand_template(
-        template = ctx.file._runner,
-        output = out_file,
-        substitutions = substitutions,
-        is_executable = True,
-    )
-    runfiles = ctx.runfiles(files = [ctx.executable._buildifier])
-    return [DefaultInfo(
-        files = depset([out_file]),
-        runfiles = runfiles,
-        executable = out_file,
-    )]
-
-_buildifier = rule(
-    implementation = _buildifier_impl,
-    attrs = {
-        "verbose": attr.bool(
-            doc = "Print verbose information on standard error",
-        ),
-        "mode": attr.string(
-            default = "fix",
-            doc = "Formatting mode",
-            values = ["check", "diff", "fix", "print_if_changed"],
-        ),
-        "lint_mode": attr.string(
-            doc = "Linting mode",
-            values = ["", "fix", "warn"],
-        ),
-        "lint_warnings": attr.string_list(
-            allow_empty = True,
-            doc = "all prefixed with +/- if you want to include in or exclude from the default set of warnings, or none prefixed with +/- if you want to override the default set, or 'all' for all avaliable warnings",
-        ),
-        "exclude_patterns": attr.string_list(
-            allow_empty = True,
-            doc = "A list of glob patterns passed to the find command. E.g. './vendor/*' to exclude the Go vendor directory",
-        ),
-        "diff_command": attr.string(
-            doc = "Command to use to show diff, with mode=diff. E.g. 'diff -u'",
-        ),
-        "multi_diff": attr.bool(
-            default = False,
-            doc = "Set to True if the diff command specified by the 'diff_command' can diff multiple files in the style of 'tkdiff'",
-        ),
-        "add_tables": attr.label(
-            mandatory = False,
-            doc = "path to JSON file with custom table definitions which will be merged with the built-in tables",
-            allow_single_file = True,
-        ),
-        "_buildifier": attr.label(
-            default = "@com_github_bazelbuild_buildtools//buildifier",
-            cfg = "host",
-            executable = True,
-        ),
-        "_runner": attr.label(
-            default = "@com_github_bazelbuild_buildtools//buildifier:runner.bash.template",
-            allow_single_file = True,
-        ),
-    },
-    executable = True,
+load(
+    ":buildifier.bzl",
+    _buildifier = "buildifier",
+    _buildifier_test = "buildifier_test",
 )
 
-def buildifier(**kwargs):
-    """
-    Wrapper for the _buildifier rule. Adds 'manual' to the tags.
-
-    Args:
-      **kwargs: all parameters for _buildifier
-    """
-
-    tags = kwargs.get("tags", [])
-    if "manual" not in tags:
-        tags.append("manual")
-        kwargs["tags"] = tags
-    _buildifier(**kwargs)
+buildifier = _buildifier
+buildifier_test = _buildifier_test

--- a/buildifier/internal/factory.bzl
+++ b/buildifier/internal/factory.bzl
@@ -1,0 +1,175 @@
+"""
+This module contains factory methods for simple rule and implementation generation
+"""
+
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+# buildifier: disable=print
+def _value_deprecation(ctx, attr, value):
+    """
+    Prints a deprecation message related to a specific value for an attr.
+
+    Args:
+      ctx:      The execution context
+      attr:     A String representing the attribute name
+      value:    The deprecated value
+    """
+    print("DEPRECATION NOTICE: value '%s' for attribute '%s' will be removed in the future. Migrate '%s' to buildifier_test." % (value, attr, ctx.label))
+
+# buildifier: disable=print
+def _attr_deprecation(ctx, attr):
+    """
+    Prints an attribute deprecation message.
+
+    Args:
+      ctx:      The execution context
+      attr:     A String representing the deprecated attribute name
+    """
+    print("DEPRECATION NOTICE: attribute '%s' will be removed in the future. Migrate '%s' to buildifier_test." % (attr, ctx.label))
+
+def buildifier_attr_factory(test_rule = False):
+    """
+    Helper macro to generate a struct of attrs for use in a rule() definition.
+
+    Args:
+      test_rule: Whether or not to generate attrs for a test rule.
+
+    Returns:
+      A dictionary of attributes relevant to the rule
+    """
+    attrs = {
+        "verbose": attr.bool(
+            doc = "Print verbose information on standard error",
+        ),
+        "mode": attr.string(
+            default = "fix",
+            doc = "Formatting mode",
+            values = ["check", "diff", "print_if_changed"] + ["fix"] if not test_rule else [],
+        ),
+        "lint_mode": attr.string(
+            doc = "Linting mode",
+            values = ["", "warn"] + ["fix"] if not test_rule else [],
+        ),
+        "lint_warnings": attr.string_list(
+            allow_empty = True,
+            doc = "all prefixed with +/- if you want to include in or exclude from the default set of warnings, or none prefixed with +/- if you want to override the default set, or 'all' for all avaliable warnings",
+        ),
+        "diff_command": attr.string(
+            doc = "Command to use to show diff, with mode=diff. E.g. 'diff -u'",
+        ),
+        "multi_diff": attr.bool(
+            default = False,
+            doc = "Set to True if the diff command specified by the 'diff_command' can diff multiple files in the style of 'tkdiff'",
+        ),
+        "add_tables": attr.label(
+            mandatory = False,
+            doc = "path to JSON file with custom table definitions which will be merged with the built-in tables",
+            allow_single_file = True,
+        ),
+        "_buildifier": attr.label(
+            default = "@com_github_bazelbuild_buildtools//buildifier",
+            cfg = "host",
+            executable = True,
+        ),
+        "_runner": attr.label(
+            default = "@com_github_bazelbuild_buildtools//buildifier:runner.bash.template",
+            allow_single_file = True,
+        ),
+    }
+
+    if test_rule:
+        attrs.update({
+            "srcs": attr.label_list(
+                allow_empty = False,
+                allow_files = [
+                    ".bazel",
+                    ".bzl",
+                    ".oss",
+                    ".sky",
+                    "BUILD",
+                    "WORKSPACE",
+                ],
+                doc = "A list of labels representing the starlark files to include in the test",
+            ),
+        })
+    else:
+        attrs.update({
+            "exclude_patterns": attr.string_list(
+                allow_empty = True,
+                doc = "A list of glob patterns passed to the find command. E.g. './vendor/*' to exclude the Go vendor directory",
+            ),
+        })
+
+    return attrs
+
+def buildifier_impl_factory(ctx, test_rule = False):
+    """
+    Helper macro to generate a buildifier or buildifier_test rule.
+
+    This macro does not depend on defaults encoded in the binary, instead
+    preferring to set explicit values for each flag.
+
+    Args:
+      ctx:          The execution context.
+      test_rule:    Whether or not to generate a test rule.
+
+    Returns:
+      A DefaultInfo provider
+    """
+
+    if not test_rule and ctx.attr.mode in ["check", "diff", "print_if_changed"]:
+        _value_deprecation(ctx, "mode", ctx.attr.mode)
+
+    args = [
+        "-mode=%s" % ctx.attr.mode,
+        "-v=%s" % str(ctx.attr.verbose).lower(),
+    ]
+
+    if ctx.attr.lint_mode:
+        args.append("-lint=%s" % ctx.attr.lint_mode)
+
+    if ctx.attr.lint_warnings:
+        if not ctx.attr.lint_mode:
+            fail("Cannot pass 'lint_warnings' without a 'lint_mode'")
+        args.append("--warnings={}".format(",".join(ctx.attr.lint_warnings)))
+
+    if ctx.attr.multi_diff:
+        args.append("-multi_diff")
+        if not test_rule:
+            _attr_deprecation(ctx, "multi_diff")
+
+    if ctx.attr.diff_command:
+        args.append("-diff_command=%s" % ctx.attr.diff_command)
+        if not test_rule:
+            _attr_deprecation(ctx, "diff_command")
+
+    if ctx.attr.add_tables:
+        args.append("-add_tables=%s" % ctx.file.add_tables.path)
+
+    exclude_patterns_str = ""
+    if ctx.attr.exclude_patterns:
+        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
+        exclude_patterns_str = " ".join(exclude_patterns)
+
+    out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
+    substitutions = {
+        "@@ARGS@@": shell.array_literal(args),
+        "@@BUILDIFIER_SHORT_PATH@@": shell.quote(ctx.executable._buildifier.short_path),
+        "@@EXCLUDE_PATTERNS@@": exclude_patterns_str,
+    }
+    ctx.actions.expand_template(
+        template = ctx.file._runner,
+        output = out_file,
+        substitutions = substitutions,
+        is_executable = True,
+    )
+
+    runfiles = [ctx.executable._buildifier]
+    if test_rule:
+        runfiles.extend(ctx.files.srcs)
+
+    return DefaultInfo(
+        files = depset([out_file]),
+        runfiles = ctx.runfiles(files = runfiles),
+        executable = out_file,
+    )

--- a/buildifier/runner.bash.template
+++ b/buildifier/runner.bash.template
@@ -3,22 +3,34 @@
 BUILDIFIER_SHORT_PATH=@@BUILDIFIER_SHORT_PATH@@
 ARGS=@@ARGS@@
 
+# Get the absolute path to the buildifier executable
 buildifier_short_path=$(readlink "$BUILDIFIER_SHORT_PATH")
-(cd "$BUILD_WORKSPACE_DIRECTORY" \
-     && find . \
-             -type f \
-             @@EXCLUDE_PATTERNS@@ \
-             \( -name '*.bzl' \
-                -o -name '*.sky' \
-                -o -name BUILD.bazel \
-                -o -name BUILD \
-                -o -name '*.BUILD' \
-                -o -name 'BUILD.*.bazel' \
-                -o -name 'BUILD.*.oss' \
-                -o -name WORKSPACE \
-                -o -name WORKSPACE.bazel \
-                -o -name WORKSPACE.oss \
-                -o -name 'WORKSPACE.*.bazel' \
-                -o -name 'WORKSPACE.*.oss' \) \
-             -print \
-        | xargs "$buildifier_short_path" "${ARGS[@]}")
+
+# Use TEST_WORKSPACE to determine if the script is being ran under a test
+if [ ! -z "${TEST_WORKSPACE+x}" ]; then
+  FIND_FILE_TYPE="l"
+else
+  # Change into the workspace directory if this is _not_ a test
+  if ! cd "$BUILD_WORKSPACE_DIRECTORY"; then
+    echo "Unable to change to workspace (BUILD_WORKSPACE_DIRECTORY: ${BUILD_WORKSPACE_DIRECTORY})"
+    exit 1
+  fi
+fi
+
+# Run buildifier on all starlark files
+find . \
+  -type "${FIND_FILE_TYPE:-f}" \
+  @@EXCLUDE_PATTERNS@@ \
+  \( -name '*.bzl' \
+    -o -name '*.sky' \
+    -o -name BUILD.bazel \
+    -o -name BUILD \
+    -o -name '*.BUILD' \
+    -o -name 'BUILD.*.bazel' \
+    -o -name 'BUILD.*.oss' \
+    -o -name WORKSPACE \
+    -o -name WORKSPACE.bazel \
+    -o -name WORKSPACE.oss \
+    -o -name 'WORKSPACE.*.bazel' \
+    -o -name 'WORKSPACE.*.oss' \
+  \) -print | xargs "$buildifier_short_path" "${ARGS[@]}"


### PR DESCRIPTION
```
This patch adds a `buildifier_test` rule, as well as a factory-based
workflow for generating both rules to reduce the burden of maintenance.

closes #928
```
---

This looks like a lot, but there are a few things to keep in mind:

* The `buildifier()` implementation has not been changed at all
* The factory-based approach taken here _really_ simplifies the burden of maintenance, as both the executable and test rules share basically, well, everything -- and without the factory-based approach, there'd be a lot of manual duplication.

---

Usage looks like this:


**`//foo:BUILD.bazel`**

```
STARLARK_FILE_GLOB = [
    "**/*.BUILD",
    "**/*.bzl",
    "**/*.sky",
    "**/BUILD",
    "**/BUILD.*.bazel",
    "**/BUILD.*.oss",
    "**/BUILD.bazel",
    "**/WORKSPACE",
    "**/WORKSPACE.*.bazel",
    "**/WORKSPACE.*.oss",
    "**/WORKSPACE.bazel",
    "*.BUILD",
    "*.bzl",
    "*.sky",
    "BUILD",
    "BUILD.*.bazel",
    "BUILD.*.oss",
    "BUILD.bazel",
    "WORKSPACE",
    "WORKSPACE.*.bazel",
    "WORKSPACE.*.oss",
    "WORKSPACE.bazel",
]

filegroup(
    name = "starlark_files",
    srcs = glob(STARLARK_FILE_GLOB),
)
```

**`//:BUILD.bazel`**

```
load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier_test")

buildifier_test(
    name = "check_starlark_format",
    size = "small",
    timeout = "short",
    srcs = [
        "//foo:starlark_files",
    ],
    mode = "check",
)
```

Then run the test: `bazel test //:check_starlark_format`.

---

Because the `glob` can't cross package boundaries the simplest approach is to define that same `filegroup` in each package. To make this easy and as simple as possible, I've created a convenience macro for my own use that I'd be happy to add into this repository. 

> I wasn't able to find a way to make the test break out of the sandbox in a similar way to how we use `$BUILD_WORKSPACE_DIRECTORY` with the executable rule, but suggestions for a consistent approach are welcome

It's pretty straightforward (in this case, my test lives at `//tools/buildifier:check_starlark_files`):

```
load("//lib/bazel:constants.bzl", "STARLARK_FILE_GLOB")

def buildifier_filegroup(name, visibility = []):
    """
    Convenience macro to a filegroup of starlark files for use with
    //tools/buildifier:check_starlark_format

    Args:
      name:        The name of the target. Must be "starlark_files".
      visibility:  The visibility of the generated target(s). Should not include //tools/buildifier:__pkg__.
    """

    # Require the user to define the name for easier scripting (especially via buildozer)
    if name != "starlark_files":
        fail("Attribute 'name' must be equal to: starlark_files")

    if "//tools/buildifier:__pkg" in visibility:
        fail("Attribute 'visibility' should not contain value: //tools/buildifier:__pkg__")

    native.filegroup(
        name = name,
        srcs = native.glob(STARLARK_FILE_GLOB),
        visibility = [
            "//tools/buildifier:__pkg__",
        ] + visibility,
    )
```

This simplifies the definition needed in each package to a measly:

```
buildifier_filegroup(name = "starlark_files")
```

---

I haven't yet added documentation for using this; want to get feedback and align on the implementation before writing the docs. **Please do not merge this before documentation has been added.**