### PR TITLE
Fix the uninitialized warning

### DIFF
--- a/warn/warn_control_flow.go
+++ b/warn/warn_control_flow.go
@@ -418,7 +418,7 @@ func collectLocalVariables(stmts []build.Expr) []*build.Ident {
 // terminated explicitly (by return or fail() statements) and a map of variables that are guaranteed
 // to be defined by `stmts`.
 func findUninitializedVariables(stmts []build.Expr, previouslyInitialized map[string]bool, callback func(*build.Ident)) (bool, map[string]bool) {
-	// Variables that are guaranteed to be de initialized
+	// Variables that are guaranteed to be initialized
 	locallyInitialized := make(map[string]bool) // in the local block of `stmts`
 	initialized := make(map[string]bool)        // anywhere before the current line
 	for key := range previouslyInitialized {
@@ -465,6 +465,10 @@ func findUninitializedVariables(stmts []build.Expr, previouslyInitialized map[st
 		case *build.ReturnStmt:
 			findUninitializedIdents(stmt, callback)
 			return true, locallyInitialized
+		case *build.BranchStmt:
+			if stmt.Token == "break" || stmt.Token == "continue" {
+				return true, locallyInitialized
+			}
 		case *build.ForStmt:
 			// Although loop variables are defined as local variables, buildifier doesn't know whether
 			// the collection will be empty or not.

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -582,6 +582,21 @@ def foo(x):
 	checkFindings(t, "uninitialized", `
 def foo(x):
   if bar:
+    t = 1
+  else:
+    for y in maybe_empty:  
+      return
+
+  print(t)
+`,
+		[]string{
+			":8: Variable \"t\" may not have been initialized.",
+		},
+		scopeEverywhere)
+
+	checkFindings(t, "uninitialized", `
+def foo(x):
+  if bar:
     for t in [2, 3]:
       pass
 
@@ -795,4 +810,22 @@ def f():
 			":7: Variable \"x\" may not have been initialized.",
 		},
 		scopeEverywhere)
+
+	checkFindings(t, "uninitialized", `
+def foo(x):
+  for y in x:
+    if foo:
+      break
+    elif bar:
+      continue
+    elif baz:
+      return
+    else:
+      z = 3
+    print(z)
+`,
+		[]string{},
+		scopeEverywhere)
+
+
 }


### PR DESCRIPTION
Don't warn if a variable is initialized everywhere but in if-branches that end with `break` or `continue`.