### PR TITLE
Avoid splitting lines with location references

### DIFF
--- a/edit/fix.go
+++ b/edit/fix.go
@@ -61,7 +61,7 @@ func splitStrings(list *build.ListExpr) bool {
 			all = append(all, e)
 			continue
 		}
-		if strings.Contains(str.Value, " ") && !strings.Contains(str.Value, "'\"") {
+		if strings.Contains(str.Value, " ") && !strings.Contains(str.Value, "'\"") && !strings.Contains(str.Value, "$(location") {
 			fixed = true
 			for i, substr := range strings.Fields(str.Value) {
 				item := &build.StringExpr{Value: substr}


### PR DESCRIPTION
Avoid splitting lines including `"$(location <target>)"` references; this can break variable resolution.

Addresses issue #937.