### PR TITLE
Do not warn about repeated loads in WORKSPACE file

### DIFF
--- a/warn/warn_control_flow.go
+++ b/warn/warn_control_flow.go
@@ -332,10 +332,13 @@ func unusedLoadWarning(f *build.File) []*LinterFinding {
 					load.To = append(load.To[:i], load.To[i+1:]...)
 					load.From = append(load.From[:i], load.From[i+1:]...)
 					i--
+                                	loadFindings = append(loadFindings, makeLinterFinding(to,
+                                        	fmt.Sprintf("Symbol %q has already been loaded on line %d. Please remove it.", to.Name, origin.line)))
+	                                continue
 				}
 
 				loadFindings = append(loadFindings, makeLinterFinding(to,
-					fmt.Sprintf("Symbol %q has already been loaded on line %d. Please remove it.", to.Name, origin.line)))
+					fmt.Sprintf("A different symbol %q has already been loaded on line %d. Please use a different local name.", to.Name, origin.line)))
 				continue
 			}
 			_, ok := symbols[to.Name]

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -422,7 +422,7 @@ load(":bar.bzl", "s1")
 foo(name = s1)`,
 		[]string{
 			":1: Loaded symbol \"s2\" is unused.",
-			":2: Symbol \"s1\" has already been loaded on line 1.",
+			":2: A different symbol \"s1\" has already been loaded on line 1.",
 		},
 		scopeEverywhere)
 
@@ -472,10 +472,10 @@ a(6)
 
 a(7)`,
 		[]string{
-			":3: Symbol \"a\" has already been loaded on line 1.",
+			":3: A different symbol \"a\" has already been loaded on line 1.",
 			":5: Symbol \"a\" has already been loaded on line 3.",
-			":7: Symbol \"a\" has already been loaded on line 5.",
-			":9: Symbol \"a\" has already been loaded on line 7.",
+			":7: A different symbol \"a\" has already been loaded on line 5.",
+			":9: A different symbol \"a\" has already been loaded on line 7.",
 			":11: Symbol \"a\" has already been loaded on line 9.",
 			":13: Symbol \"a\" has already been loaded on line 11.",
 		},


### PR DESCRIPTION
WORKSPACE files allow load() statements that are not at the top, and the imports can shadow previous ones.

This change restricts the 'symbol already loaded' warning to non-WORKSPACE files.