### PR TITLE
Add WORKSPACE.bazel delta to buildifier config

### DIFF
--- a/buildifier/README.md
+++ b/buildifier/README.md
@@ -104,6 +104,8 @@ http_archive(
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
+# If you use WORKSPACE.bazel, use the following line instead of the bare gazelle_dependencies():
+# gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 gazelle_dependencies()
 
 http_archive(


### PR DESCRIPTION
Documents the different gazelle_dependencies required when you use WORKSPACE.bazel instead of WORKSPACE.
The error one gets otherwise is somewhat cryptic.