### PR TITLE
Disable warnigns about native rules

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -605,7 +605,7 @@ UPPER_SNAKE_CASE, and providers should be UpperCamelCase ending with `Info`.
 
 The Android build rules should be loaded from Starlark.
 
-Update: the plan for disabling native rules
+Update: the plans for disabling native rules
 [have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
 at the moment it's not required to load Starlark rules.
 
@@ -632,7 +632,7 @@ as global symbols there.
 
 The CC build rules should be loaded from Starlark.
 
-Update: the plan for disabling native rules
+Update: the plans for disabling native rules
 [have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
 at the moment it's not required to load Starlark rules.
 
@@ -648,7 +648,7 @@ at the moment it's not required to load Starlark rules.
 
 The Java build rules should be loaded from Starlark.
 
-Update: the plan for disabling native rules
+Update: the plans for disabling native rules
 [have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
 at the moment it's not required to load Starlark rules.
 
@@ -675,7 +675,7 @@ It can silently modify the semantics of a BUILD file and makes it hard to mainta
 
 The Proto build rules should be loaded from Starlark.
 
-Update: the plan for disabling native rules
+Update: the plans for disabling native rules
 [have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
 at the moment it's not required to load Starlark rules.
 
@@ -691,7 +691,7 @@ at the moment it's not required to load Starlark rules.
 
 The Python build rules should be loaded from Starlark.
 
-Update: the plan for disabling native rules
+Update: the plans for disabling native rules
 [have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
 at the moment it's not required to load Starlark rules.
 

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -600,10 +600,14 @@ UPPER_SNAKE_CASE, and providers should be UpperCamelCase ending with `Info`.
   * Category name: `native-android`
   * Flag in Bazel: [`--incompatible_disable_native_android_rules`](https://github.com/bazelbuild/bazel/issues/8391)
   * Automatic fix: yes
+  * [Disabled by default](buildifier/README.md#linter)
   * [Suppress the warning](#suppress): `# buildifier: disable=native-android`
 
 The Android build rules should be loaded from Starlark.
-The native rules [will be disabled](https://github.com/bazelbuild/bazel/issues/8391).
+
+Update: the plan for disabling native rules
+[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
+at the moment it's not required to load Starlark rules.
 
 --------------------------------------------------------------------------------
 
@@ -623,10 +627,14 @@ as global symbols there.
   * Category name: `native-cc`
   * Flag in Bazel: [`--incompatible_load_cc_rules_from_bzl`](https://github.com/bazelbuild/bazel/issues/8743)
   * Automatic fix: yes
+  * [Disabled by default](buildifier/README.md#linter)
   * [Suppress the warning](#suppress): `# buildifier: disable=native-cc`
 
-The CC build rules should be loaded from Starlark. The native rules
-[will be disabled](https://github.com/bazelbuild/bazel/issues/8743).
+The CC build rules should be loaded from Starlark.
+
+Update: the plan for disabling native rules
+[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
+at the moment it's not required to load Starlark rules.
 
 --------------------------------------------------------------------------------
 
@@ -635,10 +643,14 @@ The CC build rules should be loaded from Starlark. The native rules
   * Category name: `native-java`
   * Flag in Bazel: [`--incompatible_load_java_rules_from_bzl`](https://github.com/bazelbuild/bazel/issues/8746)
   * Automatic fix: yes
+  * [Disabled by default](buildifier/README.md#linter)
   * [Suppress the warning](#suppress): `# buildifier: disable=native-java`
 
-The Java build rules should be loaded from Starlark. The native rules
-[will be disabled](https://github.com/bazelbuild/bazel/issues/8746).
+The Java build rules should be loaded from Starlark.
+
+Update: the plan for disabling native rules
+[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
+at the moment it's not required to load Starlark rules.
 
 --------------------------------------------------------------------------------
 
@@ -658,10 +670,14 @@ It can silently modify the semantics of a BUILD file and makes it hard to mainta
   * Category name: `native-proto`
   * Flag in Bazel: [`--incompatible_load_proto_rules_from_bzl`](https://github.com/bazelbuild/bazel/issues/8922)
   * Automatic fix: yes
+  * [Disabled by default](buildifier/README.md#linter)
   * [Suppress the warning](#suppress): `# buildifier: disable=native-proto`
 
-The Proto build rules should be loaded from Starlark. The native rules
-[will be disabled](https://github.com/bazelbuild/bazel/issues/8922).
+The Proto build rules should be loaded from Starlark.
+
+Update: the plan for disabling native rules
+[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
+at the moment it's not required to load Starlark rules.
 
 --------------------------------------------------------------------------------
 
@@ -670,10 +686,14 @@ The Proto build rules should be loaded from Starlark. The native rules
   * Category name: `native-py`
   * Flag in Bazel: [`--incompatible_load_python_rules_from_bzl`](https://github.com/bazelbuild/bazel/issues/9006)
   * Automatic fix: yes
+  * [Disabled by default](buildifier/README.md#linter)
   * [Suppress the warning](#suppress): `# buildifier: disable=native-py`
 
-The Python build rules should be loaded from Starlark. The native rules
-[will be disabled](https://github.com/bazelbuild/bazel/issues/9006).
+The Python build rules should be loaded from Starlark.
+
+Update: the plan for disabling native rules
+[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),
+at the moment it's not required to load Starlark rules.
 
 --------------------------------------------------------------------------------
 

--- a/warn/docs/warnings.textproto
+++ b/warn/docs/warnings.textproto
@@ -422,8 +422,10 @@ warnings: {
   name: "native-android"
   header: "All Android build rules should be loaded from Starlark"
   description:
-    "The Android build rules should be loaded from Starlark.\n"
-    "The native rules [will be disabled](https://github.com/bazelbuild/bazel/issues/8391)."
+    "The Android build rules should be loaded from Starlark.\n\n"
+    "Update: the plan for disabling native rules\n"
+    "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
+    "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_disable_native_android_rules"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/8391"
   autofix: true
@@ -442,8 +444,10 @@ warnings: {
   name: "native-cc"
   header: "All C++ build rules should be loaded from Starlark"
   description:
-    "The CC build rules should be loaded from Starlark. The native rules\n"
-    "[will be disabled](https://github.com/bazelbuild/bazel/issues/8743)."
+    "The CC build rules should be loaded from Starlark.\n\n"
+    "Update: the plan for disabling native rules\n"
+    "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
+    "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_cc_rules_from_bzl"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/8743"
   autofix: true
@@ -453,8 +457,10 @@ warnings: {
   name: "native-java"
   header: "All Java build rules should be loaded from Starlark"
   description:
-    "The Java build rules should be loaded from Starlark. The native rules\n"
-    "[will be disabled](https://github.com/bazelbuild/bazel/issues/8746)."
+    "The Java build rules should be loaded from Starlark.\n\n"
+    "Update: the plan for disabling native rules\n"
+    "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
+    "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_java_rules_from_bzl"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/8746"
   autofix: true
@@ -472,8 +478,10 @@ warnings: {
   name: "native-proto"
   header: "All Proto build rules and symbols should be loaded from Starlark"
   description:
-    "The Proto build rules should be loaded from Starlark. The native rules\n"
-    "[will be disabled](https://github.com/bazelbuild/bazel/issues/8922)."
+    "The Proto build rules should be loaded from Starlark.\n\n"
+    "Update: the plan for disabling native rules\n"
+    "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
+    "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_proto_rules_from_bzl"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/8922"
   autofix: true
@@ -483,8 +491,10 @@ warnings: {
   name: "native-py"
   header: "All Python build rules should be loaded from Starlark"
   description:
-    "The Python build rules should be loaded from Starlark. The native rules\n"
-    "[will be disabled](https://github.com/bazelbuild/bazel/issues/9006)."
+    "The Python build rules should be loaded from Starlark.\n\n"
+    "Update: the plan for disabling native rules\n"
+    "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
+    "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_python_rules_from_bzl"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/9006"
   autofix: true

--- a/warn/docs/warnings.textproto
+++ b/warn/docs/warnings.textproto
@@ -423,7 +423,7 @@ warnings: {
   header: "All Android build rules should be loaded from Starlark"
   description:
     "The Android build rules should be loaded from Starlark.\n\n"
-    "Update: the plan for disabling native rules\n"
+    "Update: the plans for disabling native rules\n"
     "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
     "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_disable_native_android_rules"
@@ -445,7 +445,7 @@ warnings: {
   header: "All C++ build rules should be loaded from Starlark"
   description:
     "The CC build rules should be loaded from Starlark.\n\n"
-    "Update: the plan for disabling native rules\n"
+    "Update: the plans for disabling native rules\n"
     "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
     "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_cc_rules_from_bzl"
@@ -458,7 +458,7 @@ warnings: {
   header: "All Java build rules should be loaded from Starlark"
   description:
     "The Java build rules should be loaded from Starlark.\n\n"
-    "Update: the plan for disabling native rules\n"
+    "Update: the plans for disabling native rules\n"
     "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
     "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_java_rules_from_bzl"
@@ -479,7 +479,7 @@ warnings: {
   header: "All Proto build rules and symbols should be loaded from Starlark"
   description:
     "The Proto build rules should be loaded from Starlark.\n\n"
-    "Update: the plan for disabling native rules\n"
+    "Update: the plans for disabling native rules\n"
     "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
     "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_proto_rules_from_bzl"
@@ -492,7 +492,7 @@ warnings: {
   header: "All Python build rules should be loaded from Starlark"
   description:
     "The Python build rules should be loaded from Starlark.\n\n"
-    "Update: the plan for disabling native rules\n"
+    "Update: the plans for disabling native rules\n"
     "[have been postponed](https://groups.google.com/g/bazel-discuss/c/XNvpWcge4AE/m/aJ-aQzszAwAJ),\n"
     "at the moment it's not required to load Starlark rules."
   bazel_flag: "--incompatible_load_python_rules_from_bzl"

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -186,6 +186,11 @@ var MultiFileWarningMap = map[string]func(f *build.File, fileReader *FileReader)
 var nonDefaultWarnings = map[string]bool{
 	"out-of-order-load":   true, // load statements should be sorted by their labels
 	"unsorted-dict-items": true, // dict items should be sorted
+	"native-android":      true, // disables native android rules
+	"native-cc":           true, // disables native cc rules
+	"native-java":         true, // disables native java rules
+	"native-proto":        true, // disables native proto rules
+	"native-py":           true, // disables native python rules
 }
 
 // fileWarningWrapper is a wrapper that converts a file warning function to a generic function.


### PR DESCRIPTION
It's not clear whether it will be forced to manually load Starlark rules instead of using native rules for android, cc, java, proto, and python. The corresponding warnings are therefore not enabled by default anymore. It's still possible to use them explicitly in buildifier by specifying the required warning categories with the `--warnings` flag, e.g. `--warnings=native-cc,native-java` or `--warnings=+native-android,+native-py` to use all default warnings and some of non-default.

Fixes #923.