### PR TITLE
Fix backward compatibility of Buildozer API

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1384,7 +1384,7 @@ function test_rule_print_comment() {
   in='# Hello
 cc_library(name = "a")'
   run "$in" 'print_comment' //pkg:a
-  assert_output 'Hello  '
+  assert_output 'Hello'
 }
 
 function test_rule_print_comment_with_suffix_and_after() {

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -158,8 +158,12 @@ func cmdPrintComment(opts *Options, env CmdEnvironment) (*build.File, error) {
 	case 0: // Print rule comment.
 		env.output.Fields = []*apipb.Output_Record_Field{
 			{Value: &apipb.Output_Record_Field_Text{commentsText(env.Rule.Call.Comments.Before)}},
-			{Value: &apipb.Output_Record_Field_Text{commentsText(env.Rule.Call.Comments.Suffix)}},
-			{Value: &apipb.Output_Record_Field_Text{commentsText(env.Rule.Call.Comments.After)}},
+		}
+		if text := commentsText(env.Rule.Call.Comments.Suffix); text != "" {
+			env.output.Fields = append(env.output.Fields, &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{text}})
+		}
+		if text := commentsText(env.Rule.Call.Comments.After); text != "" {
+			env.output.Fields = append(env.output.Fields, &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{text}})
 		}
 	case 1: // Print attribute comment.
 		attr := env.Rule.AttrDefn(env.Args[0])


### PR DESCRIPTION
Only yield suffix and after-comments if they exist.

Fix for #958.