### PR TITLE
fix(buildifier): default buildifier_test to "diff" mode

### DIFF
--- a/buildifier/internal/factory.bzl
+++ b/buildifier/internal/factory.bzl
@@ -42,7 +42,7 @@ def buildifier_attr_factory(test_rule = False):
             doc = "Print verbose information on standard error",
         ),
         "mode": attr.string(
-            default = "fix",
+            default = "fix" if not test_rule else "diff",
             doc = "Formatting mode",
             values = ["check", "diff", "print_if_changed"] + ["fix"] if not test_rule else [],
         ),


### PR DESCRIPTION
This commit changes the default value passed to the buildifier tool via
the `-mode` argument from `fix` to `diff` when defining a
`buildifier_test` target. This is necessary, as `fix` attempts to format
the files, which fails due to attempting to open and operator on files
in a read-only sandbox.

Given that `fix` is not an available value for the `mode` attribute to
the `buildifier_test` rule when manually specified, it makes sense to
remove it.

closes #971