### PR TITLE
Allow mixing command files with label lists

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -19,9 +19,12 @@ buildozer [OPTIONS] ['command args' | -f FILE ] label-list
 ```
 
 Here, `label-list` is a space-separated list of Bazel labels, for example
-`//path/to/pkg1:rule1 //path/to/pkg2:rule2`. Buildozer reads commands from
-`FILE` (`-` for stdin (format: `|`-separated command line arguments to buildozer,
-excluding flags))
+`//path/to/pkg1:rule1 //path/to/pkg2:rule2`.
+
+When `-f FILE` is used, buildozer reads commands from `FILE` (`-` for stdin).
+Format: lines of `|`-separated sets of commands and labels (`command args|label|label...`).
+When the label is a single '*', then the command will be applied to all
+elements of label-list from the command line.
 
 You should specify at least one command and one target. Buildozer will execute
 all commands on all targets. Commands are executed in order, files are processed

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -1126,7 +1126,7 @@ func appendCommands(opts *Options, commandMap map[string][]commandsForTarget, ar
 	}
 }
 
-func appendCommandsFromFiles(opts *Options, commandsByFile map[string][]commandsForTarget) {
+func appendCommandsFromFiles(opts *Options, commandsByFile map[string][]commandsForTarget, labels []string) {
 	for _, fileName := range opts.CommandsFiles {
 		var reader io.Reader
 		if fileName == stdinPackageName {
@@ -1136,11 +1136,11 @@ func appendCommandsFromFiles(opts *Options, commandsByFile map[string][]commands
 			reader = rc
 			defer rc.Close()
 		}
-		appendCommandsFromReader(opts, reader, commandsByFile)
+		appendCommandsFromReader(opts, reader, commandsByFile, labels)
 	}
 }
 
-func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile map[string][]commandsForTarget) {
+func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile map[string][]commandsForTarget, labels []string) {
 	r := bufio.NewReader(reader)
 	atEOF := false
 	for !atEOF {
@@ -1158,7 +1158,12 @@ func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile ma
 			continue
 		}
 		args := strings.Split(line, "|")
-		appendCommands(opts, commandsByFile, args)
+		if args[1] == "*" {
+			cmd := append([]string{args[0]}, labels...)
+			appendCommands(opts, commandsByFile, cmd)
+		} else {
+			appendCommands(opts, commandsByFile, args)
+		}
 	}
 }
 
@@ -1206,7 +1211,7 @@ func Buildozer(opts *Options, args []string) int {
 	}
 	commandsByFile := make(map[string][]commandsForTarget)
 	if len(opts.CommandsFiles) > 0 {
-		appendCommandsFromFiles(opts, commandsByFile)
+		appendCommandsFromFiles(opts, commandsByFile, args)
 	} else {
 		if len(args) == 0 {
 			Usage()

--- a/edit/buildozer_command_file_test.go
+++ b/edit/buildozer_command_file_test.go
@@ -26,7 +26,7 @@ import (
 func TestEmptyCommandFileContainsNoCommands(t *testing.T) {
 	reader := strings.NewReader("")
 	commandsByBuildFile := make(map[string][]commandsForTarget)
-	appendCommandsFromReader(NewOpts(), reader, commandsByBuildFile)
+	appendCommandsFromReader(NewOpts(), reader, commandsByBuildFile, []string{})
 	t.Logf("Read commands:\n%s", prettyFormat(commandsByBuildFile))
 
 	if len(commandsByBuildFile) != 0 {
@@ -132,7 +132,7 @@ func TestLongLineInCommandFileParsesAsOneCommand(t *testing.T) {
 func parseCommandFile(fileContent string, t *testing.T) []parsedCommand {
 	reader := strings.NewReader(fileContent)
 	commandsByBuildFile := make(map[string][]commandsForTarget)
-	appendCommandsFromReader(NewOpts(), reader, commandsByBuildFile)
+	appendCommandsFromReader(NewOpts(), reader, commandsByBuildFile, []string{})
 	t.Logf("Read commands:\n%s", prettyFormat(commandsByBuildFile))
 	return extractCommands(commandsByBuildFile)
 }


### PR DESCRIPTION
Fixes for #357.

If a line in the command file includes a '*' as the label, that will
expand to the full list of labels from the command line.

For example with the file `cmd.dozer`
```
remove compatible_with //buildenv/target:foo|*
remove compatible_with //buildenv/target:bar|//other_pkg:*
```
then this invocation
```
buildozer -f cmd.dozer //my_pkg/foo/... //biz/bang:__pkg__
```
would be equivalent to
```
'remove compatible_with //buildenv/target:foo' //my_pkg/foo/... //biz/bang:__pkg__
'remove compatible_with //buildenv/target:bar' //other_pkg:*
```