### PR TITLE
Bug fix: add size check on split of "cmd|*" syntax.

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -1145,7 +1145,7 @@ func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile ma
 			continue
 		}
 		args := strings.Split(line, "|")
-		if args[1] == "*" {
+		if len(args) > 1 && args[1] == "*" {
 			cmd := append([]string{args[0]}, labels...)
 			appendCommands(opts, commandsByFile, cmd)
 		} else {


### PR DESCRIPTION
Fixes an index error when detecting the buildozer command file syntax `command|*`.
This can occur when a command file is used with no label-list.