### PR TITLE
Add the ability to control env variables for buildifier execution

### DIFF
--- a/edit/default_buildifier.go
+++ b/edit/default_buildifier.go
@@ -3,6 +3,7 @@ package edit
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/bazelbuild/buildtools/build"

--- a/edit/default_buildifier.go
+++ b/edit/default_buildifier.go
@@ -33,6 +33,10 @@ func (b *defaultBuildifier) Buildify(opts *Options, f *build.File) ([]byte, erro
 	stderr := bytes.NewBuffer(nil)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	cmd.Env = append(
+        	os.Environ(),
+	        // Custom environment variables
+	)
 	err := cmd.Run()
 	if stderr.Len() > 0 {
 		return nil, fmt.Errorf("%s", stderr.Bytes())


### PR DESCRIPTION
This might be handy to have around if buildifier needs a custom environment.