### PR TITLE
Make buildifier sort named arguments of all calls.

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -267,13 +267,10 @@ func fixLabels(f *File) {
 }
 
 // callName returns the name of the rule being called by call.
-// If the call is not to a literal rule name, callName returns "".
+// If the call is not to a literal rule name or a dot expression, callName
+// returns "".
 func callName(call *CallExpr) string {
-	rule, ok := call.X.(*Ident)
-	if !ok {
-		return ""
-	}
-	return rule.Name
+	return (&Rule{call, ""}).Kind()
 }
 
 // sortCallArgs sorts lists of named arguments to a call.

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -288,7 +288,7 @@ func sortCallArgs(f *File) {
 		}
 		rule := callName(call)
 		if rule == "" {
-			return
+			rule = "<complex rule kind>"
 		}
 
 		// Find the tail of the argument list with named arguments.

--- a/build/testdata/024.build.golden
+++ b/build/testdata/024.build.golden
@@ -4,8 +4,8 @@
 str.rewrite(".", "/")
 
 str.rewrite(
-    before = ".",
     after = "/",
+    before = ".",
 )
 
 x = (1, 2, 3)

--- a/build/testdata/068.build.golden
+++ b/build/testdata/068.build.golden
@@ -1,0 +1,38 @@
+# Test sorting of call arguments.
+
+foo(
+    name = "t",
+    a = 0,
+    z = 1,
+)
+
+foo.bar.baz(
+    name = "x",
+    a = 3,
+    b = 1,
+    c = 0,
+    d = 2,
+)
+
+baz(
+    name = "y",
+    c = foo.bar(
+        "positional1",
+        42,
+        a = 3,
+        b = 1,
+        c = 0,
+        d = 2,
+    ),
+)
+
+foo.bar(
+    a = 2,
+    z = 1,
+).bar(
+    name = "z",
+    a = 3,
+    b = 1,
+    c = 0,
+    d = 2,
+)

--- a/build/testdata/068.bzl.golden
+++ b/build/testdata/068.bzl.golden
@@ -1,0 +1,38 @@
+# Test sorting of call arguments.
+
+foo(
+    name = "t",
+    z = 1,
+    a = 0,
+)
+
+foo.bar.baz(
+    name = "x",
+    c = 0,
+    b = 1,
+    d = 2,
+    a = 3,
+)
+
+baz(
+    name = "y",
+    c = foo.bar(
+        "positional1",
+        42,
+        c = 0,
+        b = 1,
+        d = 2,
+        a = 3,
+    ),
+)
+
+foo.bar(
+    z = 1,
+    a = 2,
+).bar(
+    name = "z",
+    c = 0,
+    b = 1,
+    d = 2,
+    a = 3,
+)

--- a/build/testdata/068.in
+++ b/build/testdata/068.in
@@ -1,0 +1,38 @@
+# Test sorting of call arguments.
+
+foo(
+    name = "t",
+    z = 1,
+    a = 0,
+)
+
+foo.bar.baz(
+    name = "x",
+    c = 0,
+    b = 1,
+    d = 2,
+    a = 3,
+)
+
+baz(
+    name = "y",
+    c = foo.bar(
+        "positional1",
+        42,
+        c = 0,
+        b = 1,
+        d = 2,
+        a = 3,
+    )
+)
+
+foo.bar(
+    z = 1,
+    a = 2,
+).bar(
+    name = "z",
+    c = 0,
+    b = 1,
+    d = 2,
+    a = 3,
+)


### PR DESCRIPTION
Currently buildifer sorts named arguments only when the called function is a literal. This change allows the called function to be any expression, e.g. `foo.bar(a=1,b=2)` or `foo().bar(a=1,b=2)`.