### PR TITLE
Account for breaking change in rules_nodejs 3.0

### DIFF
--- a/buildifier/npm/BUILD.bazel
+++ b/buildifier/npm/BUILD.bazel
@@ -45,6 +45,9 @@ pkg_npm(
     srcs = [
         "package.json",
     ],
+    substitutions = {
+        "0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
+    },
     deps = [
         "LICENSE",
         "buildifier.js",

--- a/buildozer/npm/BUILD.bazel
+++ b/buildozer/npm/BUILD.bazel
@@ -65,6 +65,9 @@ pkg_npm(
     srcs = [
         "package.json",
     ],
+    substitutions = {
+        "0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
+    },
     deps = [
         "LICENSE",
         "buildozer.js",


### PR DESCRIPTION
We now must explicitly list the substitutions we want to make in the npm package contents, to get the stamp var

Fixes #1002