### PR TITLE
feat(buildozer): add 'path' attr to print command

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -216,6 +216,7 @@ There are some special attributes in the `print` command:
   * `rule`: the entire rule definition
   * `startline`: the line number on which the rule begins in the BUILD file
   * `endline`: the line number on which the rule ends in the BUILD file
+  * `path`: the absolute path to the BUILD file that contains the rules
 
 #### Examples
 

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -341,6 +341,8 @@ func cmdPrint(opts *Options, env CmdEnvironment) (*build.File, error) {
 			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Number{int32(env.Rule.Call.ListStart.Line)}}
 		} else if str == "endline" {
 			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Number{int32(env.Rule.Call.End.Pos.Line)}}
+		} else if str == "path" {
+			fields[i] = &apipb.Output_Record_Field{Value: &apipb.Output_Record_Field_Text{env.File.Path}}
 		} else if value == nil {
 			fmt.Fprintf(opts.ErrWriter, "rule \"//%s:%s\" has no attribute \"%s\"\n",
 				env.Pkg, env.Rule.Name(), str)


### PR DESCRIPTION
Adds a `path` attribute to the existing `print` command, allow printing of the absolute path the BUILD file that contains the current rule. 

This can be useful when using buildozer's `print` feature to get a lot of data programmatically from BUILD files and using a glob pattern (eg `buildozer 'print srcs deps' //foo:%some_rule`) and it would be useful to get the corresponding file path back to the BUILD file without parsing and calculating it from the label, and taking into account `BUILD.bazel` vs `BUILD` etc.