### PR TITLE
Update buildifier setup via Bazel

### DIFF
--- a/buildifier/README.md
+++ b/buildifier/README.md
@@ -89,10 +89,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+    sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
     ],
 )
 
@@ -100,14 +100,14 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(version = "1.16.5")
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
     ],
 )
 
@@ -119,8 +119,11 @@ gazelle_dependencies()
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    sha256 = "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
+    strip_prefix = "protobuf-3.13.0",
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
+    ],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -129,8 +132,11 @@ protobuf_deps()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+    sha256 = "d49976b0b1e81146d79072f10cabe6634afcd318b1bd86b0102d5967121c43c1",
+    strip_prefix = "buildtools-4.2.0",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.0.tar.gz",
+    ],
 )
 ```
 


### PR DESCRIPTION
This updates `buildifier/README.md` to update the setup via Bazel.
This is because when I set up Bazel's WORKSPACE according to the documentation, `bazel build` failed in my M1 Mac Mini (macOS 11.6). It seems rules_go  needs to be updated. Please see the actual error message below.
It seems better to specify the same versions of rules_go, bazel-gazelle, and protobuf as `WORKSPACE`.
Also, I think it is good to specify the release version for buildtools (i.e., buildtools-4.2.0) instead of master.

```
$ uname -v
Darwin Kernel Version 20.6.0: Mon Aug 30 06:12:20 PDT 2021; root:xnu-7195.141.6~3/RELEASE_ARM64_T8101
$ sw_vers -productVersion
11.6
$ bazel --version
bazel 4.2.1
$ bazel run //:buildifier
DEBUG: Rule 'com_google_protobuf' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "0aa210b9451691067c4e3c3f507dcf7a12a9d23917b70868962fd798951b2b30"
DEBUG: Repository com_google_protobuf instantiated at:
  /Volumes/work/github/buildifier-test/WORKSPACE:35:13: in <toplevel>
Repository rule http_archive defined at:
  /private/var/tmp/_bazel_t/afaf13d357964991af9533f6b95f7f93/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
ERROR: While resolving toolchains for target @com_github_bazelbuild_buildtools//buildifier:buildifier: no matching toolchains found for types @io_bazel_rules_go//go:toolchain
ERROR: Analysis of target '//:buildifier' failed; build aborted: no matching toolchains found for types @io_bazel_rules_go//go:toolchain
INFO: Elapsed time: 0.082s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
```