### PR TITLE
Add mailmap to correct author names and email addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,20 @@
+<adamjernst@me.com> <adamjernst@fb.com>
+<alexeagle@angular.io> <eagle@post.harvard.edu>
+<bucjac@gmail.com> <buchgr@google.com>
+<dawagner@gmail.com> <dwagnerhall@twitter.com>
+<pbethe@google.com> <pmbethe09@users.noreply.github.com>
+<pbethe@google.com> <pmbethe@gmail.com>
+<rodrigoq@google.com> <overdrigzed@gmail.com>
+<swolchok@fb.com> <scott@wolchok.org>
+<tomlu@google.com> <tomas.lundell@gmail.com>
+<vladmos@google.com> <m@fulc.ru>
+<vladmos@google.com> <vladmos@gmail.com>
+<vladmos@google.com> <vladmos@users.noreply.github.com>
+Advay Mengle <advay-github@holvonix.com>
+Artem Zinnatullin <ceo@artemzin.com>
+Benjamin Denhartog <ben@sudoforge.com>
+Benjamin Denhartog <ben@sudoforge.com> <3893293+sudoforge@users.noreply.github.com>
+Carmi Grushko <carmi@google.com> <carmi.grushko@gmail.com>
+Kristina Chodorow <k.chodorow@gmail.com> <kchodorow@google.com>
+Kristina Chodorow <k.chodorow@gmail.com> Kristina
+Tim Peut <38146286+timpeut@users.noreply.github.com>


### PR DESCRIPTION
```
This commit adds a .mailmap at the root of the repository in order to
map author names and email addresses to a canonical format (e.g.
combining duplicates, removing non-name strings). When different
email identities existed for the same author, the information from the
most recent commit made by the author was selected.

This plays nicely with `git-shortlog`, and `git-log` with the
`--use-mailmap` option (alternatively, specify `log.mailmap = True` in
your git configuration) [0].

[0]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-logmailmap
```