### PR TITLE
Don't release a binary called 'buildifier'

### DIFF
--- a/release/github.sh
+++ b/release/github.sh
@@ -48,11 +48,6 @@ for tool in "buildifier" "buildozer" "unused_deps"; do
   upload_file "$BIN_DIR/$tool-windows_amd64.exe" "$tool-windows-amd64.exe"
 done
 
-# For compatibility with Bazel CI, remove after
-# https://github.com/bazelbuild/continuous-integration/issues/1089
-# has been resolved.
-upload_file "$BIN_DIR/buildifier-linux_amd64" "buildifier"
-
 rm -rf $BIN_DIR
 
 echo "The draft release is available at $RELEASE_URL"


### PR DESCRIPTION
The GitHub release process used to upload a file called just `buildifier` which was equivalent to `buildifier-linux-amd64` for compatibility with Bazel CI. It's name is ambiguous and may confuse the users.

Now the CI script for buildifier is able to recognize `buildifier-linux-amd64`, it's safe to stop uploading `buildifier`: https://github.com/bazelbuild/continuous-integration/blob/643090d5d188789bd906d6d988717bc5a64ec9c6/buildifier/buildifier.py#L156

See also https://github.com/bazelbuild/continuous-integration/pull/1245

cc @fweikert