### PR TITLE
Fix the bzl-visibility warning for files in a javatests/ directory

### DIFF
--- a/warn/warn_visibility.go
+++ b/warn/warn_visibility.go
@@ -65,7 +65,7 @@ func bzlVisibilityWarning(f *build.File) []*LinterFinding {
 		}
 
 		if strings.HasPrefix(path, chunks[0]) ||
-			strings.HasPrefix(strings.Replace(path, "/javatest/", "/java/", 1), chunks[0]) {
+			strings.HasPrefix(strings.Replace(path, "/javatests/", "/java/", 1), chunks[0]) {
 			continue
 		}
 

--- a/warn/warn_visibility_test.go
+++ b/warn/warn_visibility_test.go
@@ -92,13 +92,13 @@ load("@repo//test/external:module.bzl", "baz")
 }
 
 func TestBzlVisibilityJavatest(t *testing.T) {
-	defer setUpTestPackage("foo/javatest/bar")()
+	defer setUpTestPackage("foo/javatests/bar")()
 
 	checkFindings(t, "bzl-visibility", `
 load("//foo/java/bar/internal/baz:module.bzl", "foo")
 load("//foo/java/bar/private/baz:module.bzl", "bar")
-load("//foo/javatest/bar/internal/baz:module.bzl", "foo1")
-load("//foo/javatest/bar/private/baz:module.bzl", "bar1")
+load("//foo/javatests/bar/internal/baz:module.bzl", "foo1")
+load("//foo/javatests/bar/private/baz:module.bzl", "bar1")
 
 foo()
 bar()


### PR DESCRIPTION
The special case handling is already implemented but for `javatest` instead of `javatests`.

bzl-visibility shouldn't warn about imports from internal folders inside the parallel `java/` if the current file is inside `javatests/`.