### PR TITLE
Fix panic on nil-nodes

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -109,6 +109,9 @@ func leaveAlone(stk []Expr, final Expr) bool {
 // hasComment reports whether x is marked with a comment that
 // after being converted to lower case, contains the specified text.
 func hasComment(x Expr, text string) bool {
+	if x == nil {
+		return false
+	}
 	for _, com := range x.Comment().Before {
 		if strings.Contains(strings.ToLower(com.Token), text) {
 			return true


### PR DESCRIPTION
Buildifier's linter may add no-op nil nodes to the AST (they may be useful in suggestions). Such nodes should not cause NPEs.