### PR TITLE
Support MODULE.bazel files

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -42,6 +42,8 @@ const (
 	TypeWorkspace
 	// TypeBzl represents .bzl files
 	TypeBzl
+	//TypeModule represents MODULE.bazel files
+	TypeModule
 )
 
 func (t FileType) String() string {
@@ -54,6 +56,8 @@ func (t FileType) String() string {
 		return "WORKSPACE"
 	case TypeBzl:
 		return ".bzl"
+	case TypeModule:
+		return "MODULE.bazel"
 	}
 	return "unknown"
 }
@@ -78,6 +82,18 @@ func ParseWorkspace(filename string, data []byte) (*File, error) {
 	f, err := in.parse()
 	if f != nil {
 		f.Type = TypeWorkspace
+	}
+	return f, err
+}
+
+// ParseModule parses a file, marks it as a MODULE.bazel file and returns the corresponding parse tree.
+//
+// The filename is used only for generating error messages.
+func ParseModule(filename string, data []byte) (*File, error) {
+	in := newInput(filename, data)
+	f, err := in.parse()
+	if f != nil {
+		f.Type = TypeModule
 	}
 	return f, err
 }
@@ -114,6 +130,9 @@ func getFileType(filename string) FileType {
 	if strings.HasSuffix(basename, ".oss") {
 		basename = basename[:len(basename)-4]
 	}
+	if basename == "module.bazel" {
+		return TypeModule
+	}
 	ext := filepath.Ext(basename)
 	switch ext {
 	case ".bzl":
@@ -141,6 +160,8 @@ func Parse(filename string, data []byte) (*File, error) {
 		return ParseBuild(filename, data)
 	case TypeWorkspace:
 		return ParseWorkspace(filename, data)
+	case TypeModule:
+		return ParseModule(filename, data)
 	case TypeBzl:
 		return ParseBzl(filename, data)
 	}

--- a/build/lex_test.go
+++ b/build/lex_test.go
@@ -48,6 +48,10 @@ func TestIsBuildFilename(t *testing.T) {
 		"workspace.bazel":     TypeWorkspace,
 		"workspace.bzl":       TypeBzl,
 		"foo.bar":             TypeDefault,
+		"MODULE.bazel":        TypeModule,
+		"module.bazel":        TypeModule,
+		"module.bzl":          TypeBzl,
+		"MODULE":              TypeDefault,
 	}
 	for name, fileType := range cases {
 		res := getFileType(name)

--- a/build/print.go
+++ b/build/print.go
@@ -72,6 +72,17 @@ type printer struct {
 	needsNewLine bool      // true if the next statement needs a new line before it
 }
 
+// formattingMode returns the current file formatting mode.
+// Can be only TypeBuild or TypeDefault.
+func (p *printer) formattingMode() FileType {
+	switch p.fileType {
+	case TypeBuild, TypeWorkspace, TypeModule:
+		return TypeBuild
+	default: // TypeDefault, TypeBzl
+		return TypeDefault
+	}
+}
+
 // printf prints to the buffer.
 func (p *printer) printf(format string, args ...interface{}) {
 	fmt.Fprintf(p, format, args...)
@@ -235,10 +246,13 @@ func (p *printer) compactStmt(s1, s2 Expr) bool {
 	} else if isLoad(s1) || isLoad(s2) {
 		// Load statements should be separated from anything else
 		return false
+	} else if p.fileType == TypeModule && isBazelDep(s1) && isBazelDep(s2) {
+		// bazel_dep statements in MODULE files should be compressed
+		return true
 	} else if isCommentBlock(s1) || isCommentBlock(s2) {
 		// Standalone comment blocks shouldn't be attached to other statements
 		return false
-	} else if (p.fileType == TypeBuild || p.fileType == TypeWorkspace) && p.level == 0 {
+	} else if (p.formattingMode() == TypeBuild) && p.level == 0 {
 		// Top-level statements in a BUILD or WORKSPACE file
 		return false
 	} else if isFunctionDefinition(s1) || isFunctionDefinition(s2) {
@@ -256,6 +270,17 @@ func (p *printer) compactStmt(s1, s2 Expr) bool {
 func isLoad(x Expr) bool {
 	_, ok := x.(*LoadStmt)
 	return ok
+}
+
+func isBazelDep(x Expr) bool {
+	call, ok := x.(*CallExpr)
+	if !ok {
+		return false
+	}
+	if ident, ok := call.X.(*Ident); ok && ident.Name == "bazel_dep" {
+		return true
+	}
+	return false
 }
 
 // isCommentBlock reports whether x is a comment block node.
@@ -577,9 +602,14 @@ func (p *printer) expr(v Expr, outerPrec int) {
 		p.seq("()", &v.Start, &[]Expr{v.X}, &v.End, modeParen, false, v.ForceMultiLine)
 
 	case *CallExpr:
+		forceCompact := v.ForceCompact
+		if p.fileType == TypeModule && isBazelDep(v) {
+			start, end := v.Span()
+			forceCompact = start.Line == end.Line
+		}
 		addParen(precSuffix)
 		p.expr(v.X, precSuffix)
-		p.seq("()", &v.ListStart, &v.List, &v.End, modeCall, v.ForceCompact, v.ForceMultiLine)
+		p.seq("()", &v.ListStart, &v.List, &v.End, modeCall, forceCompact, v.ForceMultiLine)
 
 	case *LoadStmt:
 		addParen(precSuffix)
@@ -770,7 +800,7 @@ func (p *printer) useCompactMode(start *Position, list *[]Expr, end *End, mode s
 	// In the Default and .bzl printing modes try to keep the original printing style.
 	// Non-top-level statements and lists of arguments of a function definition
 	// should also keep the original style regardless of the mode.
-	if (p.level != 0 || p.fileType == TypeDefault || p.fileType == TypeBzl || mode == modeDef) && mode != modeLoad {
+	if (p.level != 0 || p.formattingMode() == TypeDefault || mode == modeDef) && mode != modeLoad {
 		// If every element (including the brackets) ends on the same line where the next element starts,
 		// use the compact mode, otherwise use multiline mode.
 		// If an node's line number is 0, it means it doesn't appear in the original file,

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -68,8 +68,8 @@ func Rewrite(f *File) {
 // Each rewrite function can be either applied for BUILD files, other files (such as .bzl),
 // or all files.
 const (
-	scopeDefault = TypeDefault | TypeBzl     // .bzl and generic Starlark files
-	scopeBuild   = TypeBuild | TypeWorkspace // BUILD and WORKSPACE files
+	scopeDefault = TypeDefault | TypeBzl                  // .bzl and generic Starlark files
+	scopeBuild   = TypeBuild | TypeWorkspace | TypeModule // BUILD, WORKSPACE, and MODULE files
 	scopeBoth    = scopeDefault | scopeBuild
 )
 

--- a/build/syntax.go
+++ b/build/syntax.go
@@ -194,8 +194,8 @@ func (x *Ident) asString() *StringExpr {
 // An TypedIdent represents an identifier with type annotation: "foo: int".
 type TypedIdent struct {
 	Comments
-	Ident   *Ident
-	Type    Expr
+	Ident *Ident
+	Type  Expr
 }
 
 // Span returns the start and end positions of the node

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -48,6 +48,7 @@ echo -e "not valid +" > test_dir/foo.bar
 mkdir test_dir/workspace  # name of a starlark file, but a directory
 mkdir test_dir/.git  # contents should be ignored
 echo -e "a+b" > test_dir/.git/git.bzl
+echo -e "module(name='my-module',version='1.0')\nbazel_dep(name='rules_cc',version='0.0.1')\nbazel_dep(name='protobuf',version='3.19.0')" > test_dir/MODULE.bazel
 
 cp test_dir/foo.bar golden/foo.bar
 cp test_dir/subdir/build golden/build
@@ -79,6 +80,16 @@ load(":foo.bzl", "foo")
 foo(tags = ["b", "a"], srcs = ["d", "c"])
 EOF
 
+cat > golden/MODULE.bazel.golden <<EOF
+module(
+    name = "my-module",
+    version = "1.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.1")
+bazel_dep(name = "protobuf", version = "3.19.0")
+EOF
+
 diff test_dir/BUILD golden/BUILD.golden
 diff test_dir/test.bzl golden/test.bzl.golden
 diff test_dir/subdir/test.bzl golden/test.bzl.golden
@@ -89,6 +100,7 @@ diff test2.bzl golden/test.bzl.golden
 diff stdout golden/test.bzl.golden
 diff test_dir/test.bzl.out golden/test.bzl.golden
 diff test_dir/.git/git.bzl golden/git.bzl
+diff test_dir/MODULE.bazel golden/MODULE.bazel.golden
 
 # Test run on a directory without -r
 "$buildifier" test_dir || ret=$?

--- a/buildifier/utils/flags.go
+++ b/buildifier/utils/flags.go
@@ -24,11 +24,11 @@ import (
 // ValidateInputType validates the value of --type
 func ValidateInputType(inputType *string) error {
 	switch *inputType {
-	case "build", "bzl", "workspace", "default", "auto":
+	case "build", "bzl", "workspace", "default", "module", "auto":
 		return nil
 
 	default:
-		return fmt.Errorf("unrecognized input type %s; valid types are build, bzl, workspace, default, auto", *inputType)
+		return fmt.Errorf("unrecognized input type %s; valid types are build, bzl, workspace, default, module, auto", *inputType)
 	}
 }
 

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -37,8 +37,8 @@ func isStarlarkFile(name string) bool {
 
 	switch ext {
 	case ".bazel", ".oss":
-		// BUILD.bazel or BUILD.foo.bazel should be treated as Starlark files, same for WORSKSPACE
-		return strings.HasPrefix(name, "BUILD.") || strings.HasPrefix(name, "WORKSPACE.")
+		// BUILD.bazel or BUILD.foo.bazel should be treated as Starlark files, same for WORSKSPACE and MODULE
+		return strings.HasPrefix(name, "BUILD.") || strings.HasPrefix(name, "WORKSPACE.") || strings.HasPrefix(name, "MODULE.")
 	}
 
 	return name == "BUILD" || name == "WORKSPACE"
@@ -91,6 +91,8 @@ func GetParser(inputType string) func(filename string, data []byte) (*build.File
 		return build.Parse
 	case "workspace":
 		return build.ParseWorkspace
+	case "module":
+		return build.ParseModule
 	default:
 		return build.ParseDefault
 	}

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -35,8 +35,10 @@ var functionsWithPositionalArguments = map[string]bool{
 }
 
 func constantGlobWarning(f *build.File) []*LinterFinding {
-	if f.Type == build.TypeDefault {
-		// Only applicable to Bazel files
+	switch f.Type {
+	case build.TypeBuild, build.TypeWorkspace, build.TypeBzl:
+	default:
+		// Not applicable
 		return nil
 	}
 
@@ -123,7 +125,7 @@ func nativePackageWarning(f *build.File) []*LinterFinding {
 }
 
 func duplicatedNameWarning(f *build.File) []*LinterFinding {
-	if f.Type == build.TypeBzl || f.Type == build.TypeDefault {
+	if f.Type != build.TypeBuild && f.Type != build.TypeWorkspace {
 		// Not applicable to .bzl files.
 		return nil
 	}

--- a/warn/warn_bazel_test.go
+++ b/warn/warn_bazel_test.go
@@ -30,7 +30,7 @@ cc_library(srcs =
 )`,
 		[]string{`:1: Glob pattern "foo.cc" has no wildcard`,
 			`:6: Glob pattern "test.cpp" has no wildcard`},
-		scopeBazel)
+		scopeBuild|scopeBzl|scopeWorkspace)
 }
 
 func TestNativeInBuildFiles(t *testing.T) {

--- a/warn/warn_control_flow.go
+++ b/warn/warn_control_flow.go
@@ -214,7 +214,7 @@ func noEffectWarning(f *build.File) []*LinterFinding {
 // unusedVariableCheck checks for unused variables inside a given node `stmt` (either *build.File or
 // *build.DefStmt) and reports unused and already defined variables.
 func unusedVariableCheck(f *build.File, stmts []build.Expr, findings []*LinterFinding) []*LinterFinding {
-	if f.Type == build.TypeDefault || f.Type == build.TypeBzl {
+	if f.Type != build.TypeBuild && f.Type != build.TypeWorkspace {
 		// Not applicable to .bzl files, unused symbols may be loaded and used in other files.
 		return findings
 	}

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -129,8 +129,8 @@ func packageOnTopWarning(f *build.File) []*LinterFinding {
 }
 
 func loadOnTopWarning(f *build.File) []*LinterFinding {
-	if f.Type == build.TypeWorkspace {
-		// Not applicable to WORKSPACE files
+	if f.Type == build.TypeWorkspace || f.Type == build.TypeModule{
+		// Not applicable to WORKSPACE or MODULE files
 		return nil
 	}
 

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -31,8 +31,9 @@ const (
 	scopeBzl        = build.TypeBzl
 	scopeWorkspace  = build.TypeWorkspace
 	scopeDefault    = build.TypeDefault
-	scopeEverywhere = scopeBuild | scopeBzl | scopeWorkspace | scopeDefault
-	scopeBazel      = scopeBuild | scopeBzl | scopeWorkspace
+	scopeModule     = build.TypeModule
+	scopeEverywhere = scopeBuild | scopeBzl | scopeWorkspace | scopeDefault | scopeModule
+	scopeBazel      = scopeBuild | scopeBzl | scopeWorkspace | scopeModule
 )
 
 // A global FileReader object that can be used by tests. If a test redefines it it must
@@ -82,6 +83,8 @@ func getFilename(fileType build.FileType) string {
 		return "WORKSPACE"
 	case build.TypeBzl:
 		return "test_file.bzl"
+	case build.TypeModule:
+		return "MODULE.bazel"
 	default:
 		return "test_file.strlrk"
 	}
@@ -182,6 +185,7 @@ func checkFindingsAndFix(t *testing.T, category, input, output string, expected 
 		build.TypeBuild,
 		build.TypeWorkspace,
 		build.TypeBzl,
+		build.TypeModule,
 	}
 
 	for _, fileType := range fileTypes {


### PR DESCRIPTION
Bazel 5.0 comes with experimental support of MODULE.bazel files, buildifier should support them.

https://docs.bazel.build/versions/5.0.0/bzlmod.html

Fixes #1031