### PR TITLE
Add support for options specified in `//:.bazelrc.user`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,10 @@
 build:release -c opt --stamp --workspace_status_command="$PWD/status.py"
+
+################################################################################
+# User bazel configuration
+################################################################################
+
+# Load from the local configuration file, if it exists. This needs to be the
+# *last* statement in the root configuration file, as the local configuration
+# file should be able to overwrite flags from the root configuration.
+try-import %workspace%/.bazelrc.user

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 .ijwb
 *.iml
+/.bazelrc.user


### PR DESCRIPTION
```
Add support for options specified in `//:.bazelrc.user`

With this change, users can specify options for Bazel in a configuration
file at `//:.bazelrc.user`. The options specified in this file will
be merged with options specified in `//:.bazelrc`. Because this
`//:.bazelrc.user` file is loaded at the end of `//:.bazelrc`, options
specified in the former will override those set in the latter.
```