### PR TITLE
Updated linter warnings to support nested functions

### DIFF
--- a/warn/warn_bazel_operation.go
+++ b/warn/warn_bazel_operation.go
@@ -144,7 +144,7 @@ func depsetIterationWarning(f *build.File) []*LinterFinding {
 
 func overlyNestedDepsetWarning(f *build.File) []*LinterFinding {
 	var findings []*LinterFinding
-	build.WalkStatements(f, func(expr build.Expr, stack []build.Expr) {
+	build.WalkStatements(f, func(expr build.Expr, stack []build.Expr) (err error) {
 		// Are we inside a for-loop?
 		isForLoop := false
 		for _, e := range stack {
@@ -189,6 +189,7 @@ func overlyNestedDepsetWarning(f *build.File) []*LinterFinding {
 				return
 			}
 		}
+		return
 	})
 	return findings
 }

--- a/warn/warn_naming.go
+++ b/warn/warn_naming.go
@@ -91,7 +91,7 @@ func isUpperSnakeCase(name string) bool {
 func nameConventionsWarning(f *build.File) []*LinterFinding {
 	var findings []*LinterFinding
 
-	build.WalkStatements(f, func(stmt build.Expr, stack []build.Expr) {
+	build.WalkStatements(f, func(stmt build.Expr, stack []build.Expr) (err error) {
 		// looking for provider declaration statements: `xxx = provider()`
 		// note that the code won't trigger on complex assignments, such as `x, y = foo, provider()`
 		binary, ok := stmt.(*build.AssignExpr)
@@ -109,6 +109,7 @@ func nameConventionsWarning(f *build.File) []*LinterFinding {
 				makeLinterFinding(ident,
 					fmt.Sprintf(`Variable name "%s" should be lower_snake_case (for variables), UPPER_SNAKE_CASE (for constants), or UpperCamelCase ending with 'Info' (for providers).`, ident.Name)))
 		}
+		return
 	})
 
 	return findings


### PR DESCRIPTION
Some linter warning were written when nested functions were not allowed in Starlark, and don't handle them properly, producing either false positive or false negative findings. The full list of affected linter warnings is too large for one commit, this commit doesn't fix the docstring-related warnings and the warnings about unused, uninitialised, or re-initialised variables, that will be implemented in subsequent commits.

Partially fixes #926