### PR TITLE
Update buildozer README.md to use go install

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -9,7 +9,7 @@ standard commands.
 1. Build a binary and put it into your $GOPATH/bin:
 
 ```bash
-go get github.com/bazelbuild/buildtools/buildozer
+go install github.com/bazelbuild/buildtools/buildozer@latest
 ```
 
 ## Usage


### PR DESCRIPTION
```
$ go get github.com/bazelbuild/buildtools/buildozer
go: downloading github.com/bazelbuild/buildtools v0.0.0-20220202150306-c9322a8b4e4b
go: downloading github.com/golang/protobuf v1.4.3
go: downloading google.golang.org/protobuf v1.25.0
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Same fix as #1020