### PR TITLE
Allow brackets to describe function arguments in docstrings

### DIFF
--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -307,7 +307,7 @@ func functionDocstringArgsWarning(f *build.File) []*LinterFinding {
 			if name == "" {
 				continue
 			}
-			name = op + name // *args or **kwargs
+			name = op + name  // *args or **kwargs
 			paramNames[name] = true
 			if _, ok := info.args[name]; !ok {
 				notDocumentedArguments = append(notDocumentedArguments, name)

--- a/warn/warn_docstring.go
+++ b/warn/warn_docstring.go
@@ -103,7 +103,7 @@ func countLeadingSpaces(s string) int {
 	return spaces
 }
 
-var argRegex = regexp.MustCompile(`^ *(\*?\*?\w*)( *\([\w\ ,]+\))?:`)
+var argRegex = regexp.MustCompile(`^ *(\*?\*?\w*)( *\([\w\ ,<>\[\]]+\))?:`)
 
 // parseFunctionDocstring parses a function docstring and returns a docstringInfo object containing
 // the parsed information about the function, its arguments and its return value.
@@ -307,7 +307,7 @@ func functionDocstringArgsWarning(f *build.File) []*LinterFinding {
 			if name == "" {
 				continue
 			}
-			name = op + name  // *args or **kwargs
+			name = op + name // *args or **kwargs
 			paramNames[name] = true
 			if _, ok := info.args[name]; !ok {
 				notDocumentedArguments = append(notDocumentedArguments, name)

--- a/warn/warn_docstring_test.go
+++ b/warn/warn_docstring_test.go
@@ -394,10 +394,10 @@ def f(x, y, z = None, *args, **kwargs):
    """This is a function.
 
    Args:
-    x: x
+    x (Map[string, int]): x
     y (deprecated, mutable): y
     z: z
-    *args: the args
+    *args (List<string>): the args
     **kwargs: the kwargs
    """
    pass


### PR DESCRIPTION
Allow the usage of brackets (both square and angled) inside the parentheses used to describe function arguments in docstrings. This allows concise descriptions like

```py
def foo(ctx, files):
    """
    Args:
        ctx (Context): the Starlark context
        files (List<File>): a list of files used to do (...)
        mapping (Map[string, int]): a mapping for the (...)
    """
    pass
```

I opened https://github.com/bazelbuild/buildtools/issues/916 but no one responded there so I'm just going to open this PR to address that issue and hope I have better luck here

Fixes: https://github.com/bazelbuild/buildtools/issues/916