### PR TITLE
buildozer: implement --output_json

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1055,6 +1055,13 @@ java_library(name = "b")'
   assert_output '//pkg:b java_library'
 }
 
+function test_print_label_json() {
+  in='package()
+java_library(name = "b")'
+  run --output_json "$in" 'print label kind' '//pkg:*'
+  assert_output '{"records":[{"fields":[{"text":"//pkg:b"},{"text":"java_library"}]}]}'
+}
+
 function test_print_label_ellipsis() {
   mkdir -p "ellipsis_test/foo/bar"
   echo 'java_library(name = "test")' > "ellipsis_test/BUILD"

--- a/buildozer/main.go
+++ b/buildozer/main.go
@@ -55,6 +55,7 @@ var (
 	quiet             = flag.Bool("quiet", false, "suppress informational messages")
 	editVariables     = flag.Bool("edit-variables", false, "For attributes that simply assign a variable (e.g. hdrs = LIB_HDRS), edit the build variable instead of appending to the attribute.")
 	isPrintingProto   = flag.Bool("output_proto", false, "output serialized devtools.buildozer.Output protos instead of human-readable strings.")
+	isPrintingJson    = flag.Bool("output_json", false, "output serialized devtools.buildozer.Output json instead of human-readable strings.")
 	tablesPath        = flag.String("tables", "", "path to JSON file with custom table definitions which will replace the built-in tables")
 	addTablesPath     = flag.String("add_tables", "", "path to JSON file with custom table definitions which will be merged with the built-in tables")
 
@@ -118,6 +119,7 @@ func main() {
 		Quiet:             *quiet,
 		EditVariables:     *editVariables,
 		IsPrintingProto:   *isPrintingProto,
+		IsPrintingJson:    *isPrintingJson,
 	}
 	os.Exit(edit.Buildozer(opts, flag.Args()))
 }

--- a/buildozer/test_common.sh
+++ b/buildozer/test_common.sh
@@ -14,13 +14,20 @@ function set_up() {
 # Runs buildozer, including saving the log and error messages, by sending the
 # BUILD file contents ($1) to STDIN.
 function run() {
+  options=(--buildifier=)
+  while [[ "$1" == --* ]]; 
+  do
+    options+=("$1")
+    shift
+  done
+
   input="$1"
   shift
   mkdir -p "$PKG"
 
   pwd
   echo "$input" > "$PKG/BUILD"
-  run_with_current_workspace "$buildozer --buildifier=" "$@"
+  run_with_current_workspace "$buildozer ${options[*]}" "$@"
 }
 
 # Runs buildozer, including saving the log and error messages.

--- a/edit/BUILD.bazel
+++ b/edit/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//lang:go_default_library",
         "//tables:go_default_library",
         "//wspace:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )


### PR DESCRIPTION
Allow users to consume the structured output format in json.