### PR TITLE
Fix symbols considered unused when referenced as types

### DIFF
--- a/warn/warn_control_flow.go
+++ b/warn/warn_control_flow.go
@@ -578,6 +578,7 @@ func unusedLoadWarning(f *build.File) []*LinterFinding {
 	})
 
 	symbols := edit.UsedSymbols(f)
+	types := edit.UsedTypes(f)
 	for stmtIndex := 0; stmtIndex < len(f.Stmt); stmtIndex++ {
 		originalLoad, ok := f.Stmt[stmtIndex].(*build.LoadStmt)
 		if !ok {
@@ -620,6 +621,10 @@ func unusedLoadWarning(f *build.File) []*LinterFinding {
 				continue
 			}
 			_, ok := symbols[to.Name]
+			if !ok {
+				// Fallback to verify if the symbol is used as a type.
+				_, ok = types[to.Name]
+			}
 			if !ok && !edit.ContainsComments(originalLoad, "@unused") && !edit.ContainsComments(to, "@unused") && !edit.ContainsComments(from, "@unused") {
 				// The loaded symbol is not used and is not protected by a special "@unused" comment
 				load.To = append(load.To[:i], load.To[i+1:]...)

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -805,6 +805,58 @@ x = "unused"`, `
 x = "unused"`,
 		[]string{":1: Loaded symbol \"x\" is unused."},
 		scopeEverywhere)
+
+	checkFindings(t, "load", `
+load(
+  ":f.bzl",
+   "s1",
+)
+
+def test(x: s1):
+  pass
+`,
+		[]string{},
+		scopeEverywhere)
+	checkFindings(t, "load", `
+load(
+  ":f.bzl",
+  "s1",
+  "s2",
+)
+
+def test(x: s1) -> List[s2]:
+  pass
+`,
+		[]string{},
+		scopeEverywhere)
+	checkFindingsAndFix(t, "load", `
+load(
+  ":f.bzl",
+  "s1",
+  "s2",
+)
+
+load(
+  ":s.bzl",
+  "s3",
+)
+
+def test(x: s1) -> List[s2]:
+  pass
+`, `
+load(
+  ":f.bzl",
+  "s1",
+  "s2",
+)
+
+def test(x: s1) -> List[s2]:
+  pass
+`,
+		[]string{
+			":9: Loaded symbol \"s3\" is unused.",
+		},
+		scopeEverywhere)
 }
 
 func TestUninitializedVariable(t *testing.T) {


### PR DESCRIPTION
This fix is trying to address the issue of symbols considered unused when imported and used as types only

Example:

```
load(
  ":f.bzl",
  "s1",
  "s2",
)
def test(x: s1) -> List[s2]:
  pass
```

The PR removes the need for using the `# @unused` directive.