### PR TITLE
Prevent FormatString from crashing on nil input

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -46,6 +46,11 @@ func Format(f *File) []byte {
 
 // FormatString returns the string form of the given expression.
 func FormatString(x Expr) string {
+	// Expr is an interface and can be nil
+	if x == nil {
+		return ""
+	}
+
 	fileType := TypeBuild // for compatibility
 	if file, ok := x.(*File); ok {
 		fileType = file.Type


### PR DESCRIPTION
`build.FormatString` may be called with nil argument if buildifier is used as a library, it shouldn't crash in such cases.