### PR TITLE
Don't sort nil arguments of function calls

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -957,6 +957,11 @@ func reorderArguments(f *File) {
 			return
 		}
 		compare := func(i, j int) bool {
+			// Keep nil nodes at their place. They are no-op for the formatter but can
+			// be useful for the linter which expects them to not move.
+			if call.List[i] == nil || call.List[j] == nil {
+				return false
+			}
 			return argumentType(call.List[i]) < argumentType(call.List[j])
 		}
 		if !sort.SliceIsSorted(call.List, compare) {


### PR DESCRIPTION
Linter may use nil nodes to temporarily apply a fix (e.g. to apply a fix where a function argument is removed, format the file, get the diff and roll the fix back). Temporary fixes expect rewrites to be no-op, however that's not the case with nil-arguments which can be re-sorted differently.