### PR TITLE
Improve type inference for int/float/str/bool(...) expressions

### DIFF
--- a/warn/types.go
+++ b/warn/types.go
@@ -55,6 +55,7 @@ func (t Type) String() string {
 		"none",
 		"string",
 		"list",
+		"float",
 	}[t]
 }
 
@@ -98,6 +99,14 @@ func detectTypes(f *build.File) map[build.Expr]Type {
 		case *build.CallExpr:
 			if ident, ok := (node.X).(*build.Ident); ok {
 				switch ident.Name {
+				case "bool":
+					nodeType = Bool
+				case "int":
+					nodeType = Int
+				case "float":
+					nodeType = Float
+				case "str":
+					nodeType = String
 				case "depset":
 					nodeType = Depset
 				case "dict":

--- a/warn/types_test.go
+++ b/warn/types_test.go
@@ -61,8 +61,15 @@ func checkTypes(t *testing.T, input, output string) {
 
 func TestTypes(t *testing.T) {
 	checkTypes(t, `
+b = True
+b2 = bool("hello")
+i = 3
+i2 = int(1.2)
+f = 1.2
+f2 = float(3)
 s = "string"
 s2 = s
+s3 = str(42)
 d = {}
 d2 = {foo: bar}
 d3 = dict(**foo)
@@ -70,8 +77,15 @@ d4 = {k: v for k, v in foo}
 dep = depset(items=[s, d])
 foo = bar
 `, `
+b = bool:<True>
+b2 = bool:<bool(string:<"hello">)>
+i = int:<3>
+i2 = int:<int(float:<1.2>)>
+f = float:<1.2>
+f2 = float:<float(int:<3>)>
 s = string:<"string">
 s2 = string:<s>
+s3 = string:<str(int:<42>)>
 d = dict:<{}>
 d2 = dict:<{foo: bar}>
 d3 = dict:<dict(**foo)>

--- a/warn/warn_operation_test.go
+++ b/warn/warn_operation_test.go
@@ -21,9 +21,9 @@ import "testing"
 func TestIntegerDivision(t *testing.T) {
 	checkFindingsAndFix(t, "integer-division", `
 a = 1
-b = 2
+b = int(2.3)
 c = 1.0
-d = 2.0
+d = float(2)
 
 e = a / b
 f = a / c
@@ -36,9 +36,9 @@ c /= a
 c /= d
 `, `
 a = 1
-b = 2
+b = int(2.3)
 c = 1.0
-d = 2.0
+d = float(2)
 
 e = a // b
 f = a / c


### PR DESCRIPTION
This makes the integer division check more accurate when these expressions are involved.