### PR TITLE
buildifier(feature): .buildifier.json config file

### DIFF
--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -83,6 +83,7 @@ go_library(
     },
     deps = [
         "//build:go_default_library",
+        "//buildifier/config:go_default_library",
         "//buildifier/utils:go_default_library",
         "//differ:go_default_library",
         "//tables:go_default_library",

--- a/buildifier/config/BUILD.bazel
+++ b/buildifier/config/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "validation.go",
+    ],
+    importpath = "github.com/bazelbuild/buildtools/buildifier/config",
+    visibility = ["//buildifier:__pkg__"],
+    deps = [
+        "//tables:go_default_library",
+        "//warn:go_default_library",
+        "//wspace:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    embed = [":go_default_library"],
+)

--- a/buildifier/config/config.go
+++ b/buildifier/config/config.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/buildtools/tables"
+	"github.com/bazelbuild/buildtools/warn"
+	"github.com/bazelbuild/buildtools/wspace"
+)
+
+const buildifierJSONFilename = ".buildifier.json"
+
+// New constructs a Config with default values.
+func New() *Config {
+	return &Config{
+		InputType: "auto",
+	}
+}
+
+// FindConfigPath locates the nearest buildifier configuration file.  First
+// tries the value of the BUILDIFIER_CONFIG environment variable.  If no
+// environment variable is defined, The configuration file will be resolved
+// starting from the process cwd and searching up the file tree until a config
+// file is (or isn't) found.
+func FindConfigPath(rootDir string) string {
+	if filename, ok := os.LookupEnv("BUILDIFIER_CONFIG"); ok {
+		return filename
+	}
+	if rootDir == "" {
+		rootDir, _ = os.Getwd() // best-effort, ignore error
+	}
+	dirname, err := wspace.Find(
+		rootDir,
+		map[string]func(os.FileInfo) bool{
+			buildifierJSONFilename: func(fi os.FileInfo) bool {
+				return fi.Mode()&os.ModeType == 0
+			},
+		},
+	)
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dirname, buildifierJSONFilename)
+}
+
+// Config is used to configure buildifier
+type Config struct {
+	// InputType determines the input file type: build (for BUILD files), bzl
+	// (for .bzl files), workspace (for WORKSPACE files), default (for generic
+	// Starlark files) or auto (default, based on the filename)
+	InputType string `json:"type,omitempty"`
+	// Format sets the diagnostics format: text or json (default text)
+	Format string `json:"format,omitempty"`
+	// Mode determines the formatting mode: check, diff, or fix (default fix)
+	Mode string `json:"mode,omitempty"`
+	// DiffMode is an alias for
+	DiffMode bool `json:"diffMode,omitempty"`
+	// Lint determines the lint mode: off, warn, or fix (default off)
+	Lint string `json:"lint,omitempty"`
+	// Warnings is a comma-separated list of warning identifiers used in the lint mode or "all"
+	Warnings string `json:"warnings,omitempty"`
+	// WarningsList is the a list of of warnings (alternative to comma-separated warnings string)
+	WarningsList []string `json:"warningsList,omitempty"`
+	// Recursive instructs buildifier to find starlark files recursively
+	Recursive bool `json:"recursive,omitempty"`
+	// Verbose instructs buildifier to output verbose diagnostics
+	Verbose bool `json:"verbose,omitempty"`
+	// DiffCommand is the command to run when the formatting mode is diff
+	// (default uses the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY
+	// environment variables to create the diff command)
+	DiffCommand string `json:"diffCommand,omitempty"`
+	// MultiDiff means the command specified by the -diff_command flag can diff
+	// multiple files in the style of tkdiff (default false)
+	MultiDiff bool `json:"multiDiff,omitempty"`
+	// TablesPath is the path to JSON file with custom table definitions that
+	// will replace the built-in tables
+	TablesPath string `json:"tables,omitempty"`
+	// AddTablesPath path to JSON file with custom table definitions which will be merged with the built-in tables
+	AddTablesPath string `json:"addTables,omitempty"`
+	// WorkspaceRelativePath - assume BUILD file has this path relative to the workspace directory
+	WorkspaceRelativePath string `json:"path,omitempty"`
+	// DisableRewrites configures the list of buildifier rewrites to disable
+	DisableRewrites ArrayFlags `json:"buildifier_disable,omitempty"`
+	// AllowSort specifies additional sort contexts to treat as safe
+	AllowSort ArrayFlags `json:"allowsort,omitempty"`
+
+	// Help is true if the -h flag is set
+	Help bool `json:"-"`
+	// Version is true if the -v flag is set
+	Version bool `json:"-"`
+	// ConfigPath is the path to this config
+	ConfigPath string `json:"-"`
+	// LintWarnings is the final validated list of Lint/Fix warnings
+	LintWarnings []string `json:"-"`
+}
+
+// LoadFile unmarshals JSON file from the ConfigPath field.
+func (c *Config) LoadFile() error {
+	file, err := os.Open(c.ConfigPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return c.LoadReader(file)
+}
+
+// LoadReader unmarshals JSON data from the given reader.
+func (c *Config) LoadReader(in io.Reader) error {
+	data, err := ioutil.ReadAll(in)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+	if err := json.Unmarshal(data, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FlagSet returns a flag.FlagSet that can be used to override the config.
+func (c *Config) FlagSet(name string, errorHandling flag.ErrorHandling) *flag.FlagSet {
+	flags := flag.NewFlagSet(name, errorHandling)
+
+	flags.BoolVar(&c.Help, "help", false, "print usage information")
+	flags.BoolVar(&c.Version, "version", false, "print the version of buildifier")
+	flags.BoolVar(&c.Verbose, "v", c.Verbose, "print verbose information to standard error")
+	flags.BoolVar(&c.DiffMode, "d", c.DiffMode, "alias for -mode=diff")
+	flags.BoolVar(&c.Recursive, "r", c.Recursive, "find starlark files recursively")
+	flags.BoolVar(&c.MultiDiff, "multi_diff", c.MultiDiff, "the command specified by the -diff_command flag can diff multiple files in the style of tkdiff (default false)")
+	flags.StringVar(&c.Mode, "mode", c.Mode, "formatting mode: check, diff, or fix (default fix)")
+	flags.StringVar(&c.Format, "format", c.Format, "diagnostics format: text or json (default text)")
+	flags.StringVar(&c.DiffCommand, "diff_command", c.DiffCommand, "command to run when the formatting mode is diff (default uses the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables to create the diff command)")
+	flags.StringVar(&c.Lint, "lint", c.Lint, "lint mode: off, warn, or fix (default off)")
+	flags.StringVar(&c.Warnings, "warnings", c.Warnings, "comma-separated warnings used in the lint mode or \"all\"")
+	flags.StringVar(&c.WorkspaceRelativePath, "path", c.WorkspaceRelativePath, "assume BUILD file has this path relative to the workspace directory")
+	flags.StringVar(&c.TablesPath, "tables", c.TablesPath, "path to JSON file with custom table definitions which will replace the built-in tables")
+	flags.StringVar(&c.AddTablesPath, "add_tables", c.AddTablesPath, "path to JSON file with custom table definitions which will be merged with the built-in tables")
+	flags.StringVar(&c.InputType, "type", c.InputType, "Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), default (for generic Starlark files) or auto (default, based on the filename)")
+	flags.StringVar(&c.ConfigPath, "config", "", "path to .buildifier.json config file")
+	flags.Var(&c.AllowSort, "allowsort", "additional sort contexts to treat as safe")
+	flags.Var(&c.DisableRewrites, "buildifier_disable", "list of buildifier rewrites to disable")
+
+	return flags
+}
+
+// Validate checks that the input type, format, and lint modes are correctly
+// set.  It computes the final set of warnings used for linting.  The tables
+// package is configured as a side-effect.
+func (c *Config) Validate(args []string) error {
+	if err := validateInputType(&c.InputType); err != nil {
+		return err
+	}
+
+	if err := validateFormat(&c.Format, &c.Mode); err != nil {
+		return err
+	}
+
+	if err := validateModes(&c.Mode, &c.Lint, &c.DiffMode); err != nil {
+		return err
+	}
+
+	// If the path flag is set, must only be formatting a single file.
+	// It doesn't make sense for multiple files to have the same path.
+	if (c.WorkspaceRelativePath != "" || c.Mode == "print_if_changed") && len(args) > 1 {
+		return fmt.Errorf("can only format one file when using -path flag or -mode=print_if_changed")
+	}
+
+	if c.TablesPath != "" {
+		if err := tables.ParseAndUpdateJSONDefinitions(c.TablesPath, false); err != nil {
+			return fmt.Errorf("failed to parse %s for -tables: %w", c.TablesPath, err)
+		}
+	}
+
+	if c.AddTablesPath != "" {
+		if err := tables.ParseAndUpdateJSONDefinitions(c.AddTablesPath, true); err != nil {
+			return fmt.Errorf("failed to parse %s for -add_tables: %w", c.AddTablesPath, err)
+		}
+	}
+
+	warningsList := c.WarningsList
+	if c.Warnings != "" {
+		warningsList = append(warningsList, c.Warnings)
+	}
+	warnings := strings.Join(warningsList, ",")
+	lintWarnings, err := validateWarnings(&warnings, &warn.AllWarnings, &warn.DefaultWarnings)
+	if err != nil {
+		return err // TODO(pcj) return nil?
+	}
+	c.LintWarnings = lintWarnings
+
+	return nil
+}
+
+// String renders the config as a formatted JSON string and satisfies the
+// Stringer interface.
+func (c *Config) String() string {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		log.Panicf("config marshal json: %v", err)
+	}
+	return string(data)
+}
+
+// ArrayFlags is a string slice that satisfies the flag.Value interface
+type ArrayFlags []string
+
+// String implements part of the flag.Value interface
+func (i *ArrayFlags) String() string {
+	return strings.Join(*i, ",")
+}
+
+// Set implements part of the flag.Value interface
+func (i *ArrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+// Example creates an sample configuration file for the -config=example flag.
+func Example() *Config {
+	c := New()
+	c.InputType = "auto"
+	c.Mode = "fix"
+	c.Lint = "fix"
+	c.WarningsList = warn.AllWarnings
+	return c
+}

--- a/buildifier/config/config_test.go
+++ b/buildifier/config/config_test.go
@@ -1,0 +1,518 @@
+/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func ExampleNew() {
+	c := New()
+	fmt.Print(c.String())
+	// Output:
+	// {
+	//   "type": "auto"
+	// }
+}
+
+func ExampleExample() {
+	c := Example()
+	fmt.Print(c.String())
+	// Output:
+	// {
+	//   "type": "auto",
+	//   "mode": "fix",
+	//   "lint": "fix",
+	//   "warningsList": [
+	//     "attr-cfg",
+	//     "attr-license",
+	//     "attr-non-empty",
+	//     "attr-output-default",
+	//     "attr-single-file",
+	//     "build-args-kwargs",
+	//     "bzl-visibility",
+	//     "confusing-name",
+	//     "constant-glob",
+	//     "ctx-actions",
+	//     "ctx-args",
+	//     "deprecated-function",
+	//     "depset-items",
+	//     "depset-iteration",
+	//     "depset-union",
+	//     "dict-concatenation",
+	//     "dict-method-named-arg",
+	//     "duplicated-name",
+	//     "filetype",
+	//     "function-docstring",
+	//     "function-docstring-args",
+	//     "function-docstring-header",
+	//     "function-docstring-return",
+	//     "git-repository",
+	//     "http-archive",
+	//     "integer-division",
+	//     "keyword-positional-params",
+	//     "list-append",
+	//     "load",
+	//     "load-on-top",
+	//     "module-docstring",
+	//     "name-conventions",
+	//     "native-android",
+	//     "native-build",
+	//     "native-cc",
+	//     "native-java",
+	//     "native-package",
+	//     "native-proto",
+	//     "native-py",
+	//     "no-effect",
+	//     "out-of-order-load",
+	//     "output-group",
+	//     "overly-nested-depset",
+	//     "package-name",
+	//     "package-on-top",
+	//     "positional-args",
+	//     "print",
+	//     "provider-params",
+	//     "redefined-variable",
+	//     "repository-name",
+	//     "return-value",
+	//     "rule-impl-return",
+	//     "same-origin-load",
+	//     "skylark-comment",
+	//     "skylark-docstring",
+	//     "string-iteration",
+	//     "uninitialized",
+	//     "unnamed-macro",
+	//     "unreachable",
+	//     "unsorted-dict-items",
+	//     "unused-variable"
+	//   ]
+	// }
+}
+
+func ExampleFlagSet() {
+	c := New()
+	flags := c.FlagSet("buildifier", flag.ExitOnError)
+	flags.VisitAll(func(f *flag.Flag) {
+		fmt.Printf("%s: %s (%q)\n", f.Name, f.Usage, f.DefValue)
+	})
+	// Output:
+	// add_tables: path to JSON file with custom table definitions which will be merged with the built-in tables ("")
+	// allowsort: additional sort contexts to treat as safe ("")
+	// buildifier_disable: list of buildifier rewrites to disable ("")
+	// config: path to .buildifier.json config file ("")
+	// d: alias for -mode=diff ("false")
+	// diff_command: command to run when the formatting mode is diff (default uses the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables to create the diff command) ("")
+	// format: diagnostics format: text or json (default text) ("")
+	// help: print usage information ("false")
+	// lint: lint mode: off, warn, or fix (default off) ("")
+	// mode: formatting mode: check, diff, or fix (default fix) ("")
+	// multi_diff: the command specified by the -diff_command flag can diff multiple files in the style of tkdiff (default false) ("false")
+	// path: assume BUILD file has this path relative to the workspace directory ("")
+	// r: find starlark files recursively ("false")
+	// tables: path to JSON file with custom table definitions which will replace the built-in tables ("")
+	// type: Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), default (for generic Starlark files) or auto (default, based on the filename) ("auto")
+	// v: print verbose information to standard error ("false")
+	// version: print the version of buildifier ("false")
+	// warnings: comma-separated warnings used in the lint mode or "all" ("")
+}
+
+func ExampleFlagSet_parse() {
+	c := New()
+	flags := c.FlagSet("buildifier", flag.ExitOnError)
+	flags.Parse([]string{
+		"--add_tables=/path/to/add_tables.json",
+		"--allowsort=proto_library.deps",
+		"--allowsort=proto_library.srcs",
+		"--buildifier_disable=unsafesort",
+		"--config=/path/to/.buildifier.json",
+		"-d",
+		"--diff_command=diff",
+		"--format=json",
+		"--help",
+		"--lint=fix",
+		"--mode=fix",
+		"--multi_diff=true",
+		"--path=pkg/foo",
+		"-r",
+		"--tables=/path/to/tables.json",
+		"--type=default",
+		"-v",
+		"--version",
+		"--warnings=+print,-no-effect",
+	})
+	fmt.Println("help:", c.Help)
+	fmt.Println("version:", c.Version)
+	fmt.Println("configPath:", c.ConfigPath)
+	fmt.Print(c.String())
+	// Output:
+	// help: true
+	// version: true
+	// configPath: /path/to/.buildifier.json
+	// {
+	//   "type": "default",
+	//   "format": "json",
+	//   "mode": "fix",
+	//   "diffMode": true,
+	//   "lint": "fix",
+	//   "warnings": "+print,-no-effect",
+	//   "recursive": true,
+	//   "verbose": true,
+	//   "diffCommand": "diff",
+	//   "multiDiff": true,
+	//   "tables": "/path/to/tables.json",
+	//   "addTables": "/path/to/add_tables.json",
+	//   "path": "pkg/foo",
+	//   "buildifier_disable": [
+	//     "unsafesort"
+	//   ],
+	//   "allowsort": [
+	//     "proto_library.deps",
+	//     "proto_library.srcs"
+	//   ]
+	// }
+}
+
+func TestValidate(t *testing.T) {
+	for name, tc := range map[string]struct {
+		options      string
+		args         string
+		wantErr      error
+		wantMode     string   // optional
+		wantLint     string   // optional
+		wantWarnings []string // optional
+	}{
+		"mode not set":          {wantMode: "fix"},
+		"mode check":            {options: "--mode=check", wantMode: "check"},
+		"mode diff":             {options: "--mode=diff", wantMode: "diff"},
+		"mode d":                {options: "-d", wantMode: "diff"},
+		"mode d error":          {options: "--mode=diff -d", wantErr: fmt.Errorf("cannot specify both -d and -mode flags")},
+		"mode fix":              {options: "--mode=fix", wantMode: "fix"},
+		"mode print_if_changed": {options: "--mode=print_if_changed", wantMode: "print_if_changed"},
+		"mode error":            {options: "--mode=foo", wantErr: fmt.Errorf("unrecognized mode foo; valid modes are check, diff, fix, print_if_changed")},
+		"lint not set":          {wantLint: "off"},
+		"lint off":              {options: "--lint=off", wantLint: "off"},
+		"lint warn":             {options: "--lint=warn", wantLint: "warn"},
+		"lint fix":              {options: "--lint=fix", wantLint: "fix"},
+		"lint fix error":        {options: "--lint=fix --mode=check", wantErr: fmt.Errorf("--lint=fix is only compatible with --mode=fix")},
+		"format mode error":     {options: "--mode=fix --format=text", wantErr: fmt.Errorf("cannot specify --format without --mode=check")},
+		"format text":           {options: "--mode=check --format=text"},
+		"format json":           {options: "--mode=check --format=json"},
+		"format error":          {options: "--mode=check --format=foo", wantErr: fmt.Errorf("unrecognized format foo; valid types are text, json")},
+		"type build":            {options: "--type=build"},
+		"type bzl":              {options: "--type=bzl"},
+		"type workspace":        {options: "--type=workspace"},
+		"type default":          {options: "--type=default"},
+		"type module":           {options: "--type=module"},
+		"type auto":             {options: "--type=auto"},
+		"type error":            {options: "--type=foo", wantErr: fmt.Errorf("unrecognized input type foo; valid types are build, bzl, workspace, default, module, auto")},
+		"warnings all": {options: "--warnings=all", wantWarnings: []string{
+			"attr-cfg",
+			"attr-license",
+			"attr-non-empty",
+			"attr-output-default",
+			"attr-single-file",
+			"build-args-kwargs",
+			"bzl-visibility",
+			"confusing-name",
+			"constant-glob",
+			"ctx-actions",
+			"ctx-args",
+			"deprecated-function",
+			"depset-items",
+			"depset-iteration",
+			"depset-union",
+			"dict-concatenation",
+			"dict-method-named-arg",
+			"duplicated-name",
+			"filetype",
+			"function-docstring",
+			"function-docstring-args",
+			"function-docstring-header",
+			"function-docstring-return",
+			"git-repository",
+			"http-archive",
+			"integer-division",
+			"keyword-positional-params",
+			"list-append",
+			"load",
+			"load-on-top",
+			"module-docstring",
+			"name-conventions",
+			"native-android",
+			"native-build",
+			"native-cc",
+			"native-java",
+			"native-package",
+			"native-proto",
+			"native-py",
+			"no-effect",
+			"out-of-order-load",
+			"output-group",
+			"overly-nested-depset",
+			"package-name",
+			"package-on-top",
+			"positional-args",
+			"print",
+			"provider-params",
+			"redefined-variable",
+			"repository-name",
+			"return-value",
+			"rule-impl-return",
+			"same-origin-load",
+			"skylark-comment",
+			"skylark-docstring",
+			"string-iteration",
+			"uninitialized",
+			"unnamed-macro",
+			"unreachable",
+			"unsorted-dict-items",
+			"unused-variable",
+		}},
+		"warnings default": {options: "--warnings=default", wantWarnings: []string{
+			"attr-cfg",
+			"attr-license",
+			"attr-non-empty",
+			"attr-output-default",
+			"attr-single-file",
+			"build-args-kwargs",
+			"bzl-visibility",
+			"confusing-name",
+			"constant-glob",
+			"ctx-actions",
+			"ctx-args",
+			"deprecated-function",
+			"depset-items",
+			"depset-iteration",
+			"depset-union",
+			"dict-concatenation",
+			"dict-method-named-arg",
+			"duplicated-name",
+			"filetype",
+			"function-docstring",
+			"function-docstring-args",
+			"function-docstring-header",
+			"function-docstring-return",
+			"git-repository",
+			"http-archive",
+			"integer-division",
+			"keyword-positional-params",
+			"list-append",
+			"load",
+			"load-on-top",
+			"module-docstring",
+			"name-conventions",
+			// "native-android",
+			"native-build",
+			// "native-cc",
+			// "native-java",
+			"native-package",
+			// "native-proto",
+			// "native-py",
+			"no-effect",
+			// "out-of-order-load",
+			"output-group",
+			"overly-nested-depset",
+			"package-name",
+			"package-on-top",
+			"positional-args",
+			"print",
+			"provider-params",
+			"redefined-variable",
+			"repository-name",
+			"return-value",
+			"rule-impl-return",
+			"same-origin-load",
+			"skylark-comment",
+			"skylark-docstring",
+			"string-iteration",
+			"uninitialized",
+			"unnamed-macro",
+			"unreachable",
+			// "unsorted-dict-items",
+			"unused-variable",
+		}},
+		"warnings plus/minus": {options: "--warnings=+out-of-order-load,-print,-deprecated-function", wantWarnings: []string{
+			"attr-cfg",
+			"attr-license",
+			"attr-non-empty",
+			"attr-output-default",
+			"attr-single-file",
+			"build-args-kwargs",
+			"bzl-visibility",
+			"confusing-name",
+			"constant-glob",
+			"ctx-actions",
+			"ctx-args",
+			// "deprecated-function",
+			"depset-items",
+			"depset-iteration",
+			"depset-union",
+			"dict-concatenation",
+			"dict-method-named-arg",
+			"duplicated-name",
+			"filetype",
+			"function-docstring",
+			"function-docstring-args",
+			"function-docstring-header",
+			"function-docstring-return",
+			"git-repository",
+			"http-archive",
+			"integer-division",
+			"keyword-positional-params",
+			"list-append",
+			"load",
+			"load-on-top",
+			"module-docstring",
+			"name-conventions",
+			// "native-android",
+			"native-build",
+			// "native-cc",
+			// "native-java",
+			"native-package",
+			// "native-proto",
+			// "native-py",
+			"no-effect",
+			"output-group",
+			"overly-nested-depset",
+			"package-name",
+			"package-on-top",
+			"positional-args",
+			// "print",
+			"provider-params",
+			"redefined-variable",
+			"repository-name",
+			"return-value",
+			"rule-impl-return",
+			"same-origin-load",
+			"skylark-comment",
+			"skylark-docstring",
+			"string-iteration",
+			"uninitialized",
+			"unnamed-macro",
+			"unreachable",
+			// "unsorted-dict-items",
+			"unused-variable",
+			"out-of-order-load",
+		}},
+		"warnings error": {options: "--warnings=out-of-order-load,-print,-deprecated-function", wantErr: fmt.Errorf(`warning categories with modifiers ("+" or "-") can't be mixed with raw warning categories`)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := New()
+			flags := c.FlagSet("buildifier", flag.ExitOnError)
+			flags.Parse(strings.Fields(tc.options))
+			got := c.Validate(strings.Fields(tc.args))
+			if tc.wantMode != "" && tc.wantMode != c.Mode {
+				t.Fatalf("--mode mismatch: want %v, got %v", tc.wantMode, c.Mode)
+			}
+			if tc.wantLint != "" && tc.wantLint != c.Lint {
+				t.Fatalf("--lint mismatch: want %v, got %v", tc.wantLint, c.Lint)
+			}
+			if len(tc.wantWarnings) > 0 {
+				if len(tc.wantWarnings) != len(c.LintWarnings) {
+					t.Fatalf("--warnings mismatch: want %v, got %v", tc.wantWarnings, c.LintWarnings)
+				}
+				for i, wantWarning := range tc.wantWarnings {
+					gotWarning := c.LintWarnings[i]
+					if wantWarning != gotWarning {
+						t.Errorf("warning mismatch at list position %d: want %s, got %s", i, wantWarning, gotWarning)
+					}
+				}
+			}
+			if tc.wantErr == nil && got == nil {
+				return
+			}
+			if tc.wantErr == nil && got != nil {
+				t.Fatalf("unexpected error: %v", got)
+			}
+			if tc.wantErr != nil && got == nil {
+				t.Fatalf("expected error did not occur: %v", tc.wantErr)
+			}
+			if tc.wantErr.Error() != got.Error() {
+				t.Fatalf("error mismatch: want %v, got %v", tc.wantErr.Error(), got.Error())
+			}
+		})
+	}
+}
+
+func TestFindConfigPath(t *testing.T) {
+	for name, tc := range map[string]struct {
+		files map[string]string
+		env   map[string]string
+		want  string
+	}{
+		"no-config-file": {
+			want: "",
+		},
+		"default": {
+			files: map[string]string{
+				".buildifier.json": "{}",
+			},
+			want: ".buildifier.json",
+		},
+		"BUILDIFIER_CONFIG-override": {
+			env: map[string]string{
+				"BUILDIFIER_CONFIG": ".buildifier2.json",
+			},
+			want: ".buildifier2.json",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range tc.env {
+				os.Setenv(k, v)
+			}
+
+			tmp, err := ioutil.TempDir("", name+"*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmp)
+
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Log("tmp:", tmp)
+
+			for rel, content := range tc.files {
+				dir := filepath.Join(tmp, filepath.Dir(rel))
+				if dir != "." {
+					if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+						t.Fatal(err)
+					}
+				}
+				filename := filepath.Join(dir, rel)
+				if err := ioutil.WriteFile(filename, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := FindConfigPath(tmp)
+			got = strings.TrimPrefix(got, tmp)
+			got = strings.TrimPrefix(got, "/")
+
+			if tc.want != got {
+				t.Errorf("FindConfigPath: want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/buildifier/config/validation.go
+++ b/buildifier/config/validation.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package config
 
 import (
 	"fmt"
 	"strings"
 )
 
-// ValidateInputType validates the value of --type
-func ValidateInputType(inputType *string) error {
+// validateInputType validates the value of --type
+func validateInputType(inputType *string) error {
 	switch *inputType {
 	case "build", "bzl", "workspace", "default", "module", "auto":
 		return nil
@@ -32,8 +32,8 @@ func ValidateInputType(inputType *string) error {
 	}
 }
 
-// ValidateFormat validates the value of --format
-func ValidateFormat(format, mode *string) error {
+// validateFormat validates the value of --format
+func validateFormat(format, mode *string) error {
 	switch *format {
 	case "":
 		return nil
@@ -59,8 +59,8 @@ func isRecognizedMode(validModes []string, mode string) bool {
 	return false
 }
 
-// ValidateModes validates flags --mode, --lint, and -d
-func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) error {
+// validateModes validates flags --mode, --lint, and -d
+func validateModes(mode, lint *string, dflag *bool) error {
 	if *dflag {
 		if *mode != "" {
 			return fmt.Errorf("cannot specify both -d and -mode flags")
@@ -70,7 +70,6 @@ func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) e
 
 	// Check mode.
 	validModes := []string{"check", "diff", "fix", "print_if_changed"}
-	validModes = append(validModes, additionalModes...)
 
 	if *mode == "" {
 		*mode = "fix"
@@ -98,8 +97,8 @@ func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) e
 	return nil
 }
 
-// ValidateWarnings validates the value of the --warnings flag
-func ValidateWarnings(warnings *string, allWarnings, defaultWarnings *[]string) ([]string, error) {
+// validateWarnings validates the value of the --warnings flag
+func validateWarnings(warnings *string, allWarnings, defaultWarnings *[]string) ([]string, error) {
 
 	// Check lint warnings
 	var warningsList []string

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -34,7 +34,7 @@ buildifier="$(rlocation "$buildifier")"
 buildifier2="$(rlocation "$buildifier2")"
 
 touch WORKSPACE.bazel
-rm -r test_dir || true
+[[ -d test_dir ]] && rm -r test_dir
 mkdir -p test_dir/subdir
 mkdir -p golden
 INPUT="load(':foo.bzl', 'foo'); foo(tags=['b', 'a'],srcs=['d', 'c'])"  # formatted differently in build and bzl modes
@@ -45,6 +45,7 @@ echo -e "$INPUT" > test_dir/subdir/build  # lowercase, should be ignored by -r
 echo -e "$INPUT" > test.bzl  # outside the test_dir directory
 echo -e "$INPUT" > test2.bzl  # outside the test_dir directory
 echo -e "not valid +" > test_dir/foo.bar
+echo -e '{ "type": "build" }' > test_dir/.buildifier.test.json # demonstrate config file works by overridding input type to format a bzl file as a BUILD file.
 mkdir test_dir/workspace  # name of a starlark file, but a directory
 mkdir test_dir/.git  # contents should be ignored
 echo -e "a+b" > test_dir/.git/git.bzl
@@ -126,6 +127,8 @@ cp test_dir/.git/git.bzl golden/git.bzl
 "$buildifier" -r test_dir
 "$buildifier" test.bzl
 "$buildifier" --path=foo.bzl test2.bzl
+"$buildifier" --config=test_dir/.buildifier.test.json < test_dir/test.bzl > test_dir/test.bzl.BUILD.out
+"$buildifier" --config=example > test_dir/.buildifier.example.json
 "$buildifier2" test_dir/test.bzl > test_dir/test.bzl.out
 
 cat > golden/BUILD.golden <<EOF
@@ -142,6 +145,7 @@ foo(
     ],
 )
 EOF
+
 cat > golden/test.bzl.golden <<EOF
 load(":foo.bzl", "foo")
 
@@ -238,9 +242,81 @@ bazel_dep(name = "weird_dep", version = "3.19.0", dev_dependency = "True" == "Tr
 bazel_dep(name = "yet_another_prod_dep", version = "3.19.0")
 EOF
 
+cat > golden/.buildifier.example.json <<EOF
+{
+  "type": "auto",
+  "mode": "fix",
+  "lint": "fix",
+  "warningsList": [
+    "attr-cfg",
+    "attr-license",
+    "attr-non-empty",
+    "attr-output-default",
+    "attr-single-file",
+    "build-args-kwargs",
+    "bzl-visibility",
+    "confusing-name",
+    "constant-glob",
+    "ctx-actions",
+    "ctx-args",
+    "deprecated-function",
+    "depset-items",
+    "depset-iteration",
+    "depset-union",
+    "dict-concatenation",
+    "dict-method-named-arg",
+    "duplicated-name",
+    "filetype",
+    "function-docstring",
+    "function-docstring-args",
+    "function-docstring-header",
+    "function-docstring-return",
+    "git-repository",
+    "http-archive",
+    "integer-division",
+    "keyword-positional-params",
+    "list-append",
+    "load",
+    "load-on-top",
+    "module-docstring",
+    "name-conventions",
+    "native-android",
+    "native-build",
+    "native-cc",
+    "native-java",
+    "native-package",
+    "native-proto",
+    "native-py",
+    "no-effect",
+    "out-of-order-load",
+    "output-group",
+    "overly-nested-depset",
+    "package-name",
+    "package-on-top",
+    "positional-args",
+    "print",
+    "provider-params",
+    "redefined-variable",
+    "repository-name",
+    "return-value",
+    "rule-impl-return",
+    "same-origin-load",
+    "skylark-comment",
+    "skylark-docstring",
+    "string-iteration",
+    "uninitialized",
+    "unnamed-macro",
+    "unreachable",
+    "unsorted-dict-items",
+    "unused-variable"
+  ]
+}
+EOF
+
 diff test_dir/BUILD golden/BUILD.golden
 diff test_dir/test.bzl golden/test.bzl.golden
 diff test_dir/subdir/test.bzl golden/test.bzl.golden
+diff test_dir/test.bzl.BUILD.out golden/BUILD.golden
 diff test_dir/subdir/build golden/build
 diff test_dir/foo.bar golden/foo.bar
 diff test.bzl golden/test.bzl.golden
@@ -249,6 +325,7 @@ diff stdout golden/test.bzl.golden
 diff test_dir/test.bzl.out golden/test.bzl.golden
 diff test_dir/.git/git.bzl golden/git.bzl
 diff test_dir/MODULE.bazel golden/MODULE.bazel.golden
+diff test_dir/.buildifier.example.json golden/.buildifier.example.json
 
 # Test run on a directory without -r
 "$buildifier" test_dir || ret=$?

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -4,12 +4,11 @@ go_library(
     name = "go_default_library",
     srcs = [
         "diagnostics.go",
-        "flags.go",
         "tempfile.go",
         "utils.go",
     ],
     importpath = "github.com/bazelbuild/buildtools/buildifier/utils",
-    visibility = ["//buildifier:__pkg__"],
+    visibility = ["//buildifier:__subpackages__"],
     deps = [
         "//build:go_default_library",
         "//warn:go_default_library",

--- a/wspace/workspace.go
+++ b/wspace/workspace.go
@@ -29,6 +29,20 @@ import (
 const workspaceFile = "WORKSPACE"
 const buildFile = "BUILD"
 
+// IsRegularFile returns true if the path refers to a regular file after
+// following symlinks.
+func IsRegularFile(path string) bool {
+	path, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}
+
 func isFile(fi os.FileInfo) bool {
 	return fi.Mode()&os.ModeType == 0
 }
@@ -65,7 +79,7 @@ func FindWorkspaceRoot(rootDir string) (root string, rest string) {
 	if err != nil {
 		return "", ""
 	}
-	if root, err = find(wd, repoRootFiles); err != nil {
+	if root, err = Find(wd, repoRootFiles); err != nil {
 		return "", ""
 	}
 	if len(wd) == len(root) {
@@ -74,9 +88,9 @@ func FindWorkspaceRoot(rootDir string) (root string, rest string) {
 	return root, wd[len(root)+1:]
 }
 
-// find searches from the given dir and up for the file that satisfies a condition of `rootFiles`
+// Find searches from the given dir and up for the file that satisfies a condition of `rootFiles`
 // returning the directory containing it, or an error if none found in the tree.
-func find(dir string, rootFiles map[string]func(os.FileInfo) bool) (string, error) {
+func Find(dir string, rootFiles map[string]func(os.FileInfo) bool) (string, error) {
 	if dir == "" || dir == "/" || dir == "." || (len(dir) == 3 && strings.HasSuffix(dir, ":\\")) {
 		return "", os.ErrNotExist
 	}
@@ -87,7 +101,7 @@ func find(dir string, rootFiles map[string]func(os.FileInfo) bool) (string, erro
 			return "", err
 		}
 	}
-	return find(filepath.Dir(dir), rootFiles)
+	return Find(filepath.Dir(dir), rootFiles)
 }
 
 // FindRepoBuildFiles parses the WORKSPACE to find BUILD files for non-Bazel
@@ -143,11 +157,11 @@ func relPath(base, target string) (string, error) {
 // Returns empty strings if no WORKSPACE file is found.
 func SplitFilePath(filename string) (workspaceRoot, pkg, label string) {
 	dir := filepath.Dir(filename)
-	workspaceRoot, err := find(dir, repoRootFiles)
+	workspaceRoot, err := Find(dir, repoRootFiles)
 	if err != nil {
 		return "", "", ""
 	}
-	packageRoot, err := find(dir, packageRootFiles)
+	packageRoot, err := Find(dir, packageRootFiles)
 	if err != nil || !strings.HasPrefix(packageRoot, workspaceRoot) {
 		// No BUILD file or it's outside of the workspace. Shouldn't happen,
 		// but assume it's in the workspace root.


### PR DESCRIPTION
- Add new package `github.com/bazelbuild/buildtools/buildifier/config`
- Refactor flags from `buildifier.go` into the `Config` struct.
- Refactor `buildifier.go` to use a `type buildifier struct` initialized with a `Config`.
- Move `github.com/bazelbuild/buildtools/buildifier/edit.isFile` to `github.com/bazelbuild/buildtools/buildifier/wspace.IsRegularFile`
- Move `github.com/bazelbuild/buildtools/buildifier/utils.ValidateInputType` to `github.com/bazelbuild/buildtools/buildifier/config.validateInputType` (and similar functions)
- Add new convention of `{WORKSPACE_DIR}/.buildifier.json` where the config file can optionally exist.
- Add new environment variable `BUILDIFIER_CONFIG` that can override location of config file.
- Add new flag `-config` that can specify location of config file.
- Add new behavior `-config=example` that will print a sample JSON config initialized with `warn.AllWarnings` to stdout.
- Add new validation tests of the flag combinations.
- Add integration tests

Fixes #479