### PR TITLE
Update README.md with updated installation command

### DIFF
--- a/unused_deps/README.md
+++ b/unused_deps/README.md
@@ -10,7 +10,7 @@ prunings.
 Build a binary and put it into your $GOPATH/bin:
 
 ```bash
-go get github.com/bazelbuild/buildtools/unused_deps
+go install github.com/bazelbuild/buildtools/unused_deps@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Using `go get github.com/bazelbuild/buildtools/unused_deps` as per the existing documentation, results in:
```
go: go.mod file not found in current directory or any parent directory.
'go get' is no longer supported outside a module.
To build and install a command, use 'go install' with a version,
like 'go install example.com/cmd@latest'
For more information, see https://golang.org/doc/go-get-install-deprecation
or run 'go help get' or 'go help install'.
```
replacing it with `go install github.com/bazelbuild/buildtools/unused_deps@latest` works and installs the latest version

Suggesting the change as it could help others.