### PR TITLE
Support deleting wildcard attrs

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -90,7 +90,8 @@ Buildozer supports the following commands(`'command args'`):
     new rule at the end of the BUILD file (before/after `<relative_rule>`). The
     identifier `__pkg__` can be used to position rules relative to package().
   * `print <attr(s)>`
-  * `remove <attr>`: Removes attribute `attr`.
+  * `remove <attr>`: Removes attribute `attr`. The wildcard `*` matches all
+    attributes except `name`.
   * `remove <attr> <value(s)>`: Removes `value(s)` from the list `attr`. The
     wildcard `*` matches all attributes. Lists containing none of the `value(s)` are
     not modified.

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -229,6 +229,18 @@ function test_remove_last_dep() {
   assert_equals 'go_library(name = "edit")'
 }
 
+function test_remove_all_attrs() {
+  run "$one_dep" 'remove *' '//pkg:edit'
+  assert_equals 'go_library(name = "edit")'
+}
+
+function test_remove_all_attrs_none() {
+  ERROR=3 run "$no_deps" 'remove *' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+)'
+}
+
 function test_remove_dep() {
   run "$two_deps" 'remove deps //buildifier:build' '//pkg:edit'
   assert_equals 'go_library(

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -379,8 +379,23 @@ func attrKeysForPattern(rule *build.Rule, pattern string) []string {
 
 func cmdRemove(opts *Options, env CmdEnvironment) (*build.File, error) {
 	if len(env.Args) == 1 { // Remove the attribute
-		if env.Rule.DelAttr(env.Args[0]) != nil {
-			return env.File, nil
+		if env.Args[0] == "*" {
+			didDelete := false
+			for _, attr := range env.Rule.AttrKeys() {
+				if attr == "name" {
+					continue
+				}
+				if env.Rule.DelAttr(attr) != nil {
+					didDelete = true
+				}
+			}
+			if didDelete {
+				return env.File, nil
+			}
+		} else {
+			if env.Rule.DelAttr(env.Args[0]) != nil {
+				return env.File, nil
+			}
 		}
 	} else { // Remove values in the attribute.
 		fixed := false


### PR DESCRIPTION
When e.g. changing a rule type from http_archive to git_repository, it can be useful to remove all attributes before populating new ones.

Effectively this supports "delete and replace", without needing to work out where the replacement rule needs inserting into the file.