### PR TITLE
Add remove_if_equal command to buildozer

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -97,6 +97,8 @@ Buildozer supports the following commands(`'command args'`):
     not modified.
   * `remove_comment <attr>? <value>?`: Removes the comment attached to the rule,
     an attribute, or a specific value in a list.
+  * `remove_if_equal <attr> <value>`: Removes the attribute `attr` if its value
+    is equal to `value`.
   * `rename <old_attr> <new_attr>`: Rename the `old_attr` to `new_attr` which must
     not yet exist.
   * `replace <attr> <old_value> <new_value>`: Replaces `old_value` with `new_value`

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -447,6 +447,42 @@ function test_remove_package_attribute() {
   [ $(wc -c < "$root/pkg/BUILD") -eq 0 ] || fail "Expected empty file"
 }
 
+function test_remove_if_equal_label() {
+  in='go_library(
+    name = "edit",
+    shared_library = ":local",  # Suffix comment.
+)'
+  run "$in" 'remove_if_equal shared_library :local' '//pkg:edit'
+  assert_equals 'go_library(name = "edit")'
+}
+
+function test_remove_if_equal_ident() {
+  in='go_library(
+    name = "edit",
+    flag = True,
+)'
+  run "$in" 'remove_if_equal flag True' '//pkg:edit'
+  assert_equals 'go_library(name = "edit")'
+}
+
+function test_remove_if_equal_string() {
+  in='go_library(
+    name = "edit",
+    flag = "True",
+)'
+  run "$in" 'remove_if_equal flag True' '//pkg:edit'
+  assert_equals 'go_library(name = "edit")'
+}
+
+function test_remove_if_equal_string_attr_string() {
+  in='go_library(
+    name = "edit",
+    toolchain = "something",
+)'
+  run "$in" 'remove_if_equal toolchain something' '//pkg:edit'
+  assert_equals 'go_library(name = "edit")'
+}
+
 function test_move_last_dep() {
   run "$one_dep" 'move deps runtime_deps //buildifier:build' '//pkg:edit'
   assert_equals 'go_library(

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -456,6 +456,27 @@ function test_remove_if_equal_label() {
   assert_equals 'go_library(name = "edit")'
 }
 
+function test_remove_if_equal_label_does_not_match() {
+  in='go_library(
+    name = "edit",
+    shared_library = ":local",  # Suffix comment.
+)'
+  ERROR=3 run "$in" 'remove_if_equal shared_library :global' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    shared_library = ":local",  # Suffix comment.
+)'
+}
+
+function test_remove_if_equal_label_full_path() {
+  in='go_library(
+    name = "edit",
+    shared_library = ":local",  # Suffix comment.
+)'
+  run "$in" 'remove_if_equal shared_library //pkg:local' '//pkg:edit'
+  assert_equals 'go_library(name = "edit")'
+}
+
 function test_remove_if_equal_ident() {
   in='go_library(
     name = "edit",
@@ -465,6 +486,18 @@ function test_remove_if_equal_ident() {
   assert_equals 'go_library(name = "edit")'
 }
 
+function test_remove_if_equal_ident_does_not_match() {
+  in='go_library(
+    name = "edit",
+    flag = True,
+)'
+  ERROR=3 run "$in" 'remove_if_equal flag False' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    flag = True,
+)'
+}
+
 function test_remove_if_equal_string() {
   in='go_library(
     name = "edit",
@@ -472,6 +505,18 @@ function test_remove_if_equal_string() {
 )'
   run "$in" 'remove_if_equal flag True' '//pkg:edit'
   assert_equals 'go_library(name = "edit")'
+}
+
+function test_remove_if_equal_string_does_not_match() {
+  in='go_library(
+    name = "edit",
+    flag = "False",
+)'
+  ERROR=3 run "$in" 'remove_if_equal flag True' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    flag = "False",
+)'
 }
 
 function test_remove_if_equal_string_attr_string() {


### PR DESCRIPTION
I've left open the structure to removing more complex expressions, but trigger an error in all but the more basic cases.  I wasn't sure what sort of behavior this type of command should have in more complex cases.

I generate a comparison function up-front, which does a lot of virtual switching on types as there didn't seem to be a way to genericly compare expressions.  I've used getAttrValueExpr, however, this does make for a little weirdness in trying to handle the case of strings versus identifiers.  The test case with `"True"` versus `True` tries to demonstrate why identifiers are compared to both string and identifiers.

I assume this will seem incomplete in some respects, but I was putting this up for initial feedback on the approach as well as what would be expected in the test coverage.

Fixes #105