### PR TITLE
fix fix.go to stop creating empty package() decls.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,7 @@ go_repository(
     version = "v0.0.0-20200203144150-6677ee5c7211",
 )
 
+
 http_archive(
     name = "com_google_protobuf",
     sha256 = "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
@@ -44,6 +45,12 @@ http_archive(
     urls = [
         "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
     ],
+)
+
+go_repository(
+    name = "com_github_google_go_cmp",
+    importpath = "github.com/google/go-cmp",
+    tag = "v0.5.9",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,6 @@ go_repository(
     version = "v0.0.0-20200203144150-6677ee5c7211",
 )
 
-
 http_archive(
     name = "com_google_protobuf",
     sha256 = "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",

--- a/edit/BUILD.bazel
+++ b/edit/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//wspace:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_google_go_cmp//cmp"
     ],
 )
 

--- a/edit/BUILD.bazel
+++ b/edit/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "//wspace:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_google_go_cmp//cmp"
+        "@com_github_google_go_cmp//cmp",
     ],
 )
 

--- a/edit/fix.go
+++ b/edit/fix.go
@@ -31,10 +31,11 @@ import (
 // It splits options strings that contain a space. This change
 // should be safe as Blaze is splitting those strings, but we will
 // eventually get rid of this misfeature.
-//   eg. it converts from:
-//     copts = ["-Dfoo -Dbar"]
-//   to:
-//     copts = ["-Dfoo", "-Dbar"]
+//
+//	eg. it converts from:
+//	  copts = ["-Dfoo -Dbar"]
+//	to:
+//	  copts = ["-Dfoo", "-Dbar"]
 func splitOptionsWithSpaces(_ *build.File, r *build.Rule, _ string) bool {
 	var attrToRewrite = []string{
 		"copts",
@@ -101,12 +102,11 @@ func shortenLabels(_ *build.File, r *build.Rule, pkg string) bool {
 
 // removeVisibility removes useless visibility attributes.
 func removeVisibility(f *build.File, r *build.Rule, pkg string) bool {
-	pkgDecl := PackageDeclaration(f)
-	defaultVisibility := pkgDecl.AttrStrings("default_visibility")
-
 	// If no default_visibility is given, it is implicitly private.
-	if len(defaultVisibility) == 0 {
-		defaultVisibility = []string{"//visibility:private"}
+	defaultVisibility := []string{"//visibility:private"}
+	pkgDecl := ExistingPackageDeclaration(f)
+	if pkgDecl != nil {
+		defaultVisibility = pkgDecl.AttrStrings("default_visibility")
 	}
 
 	visibility := r.AttrStrings("visibility")
@@ -126,15 +126,15 @@ func removeVisibility(f *build.File, r *build.Rule, pkg string) bool {
 
 // removeTestOnly removes the useless testonly attributes.
 func removeTestOnly(f *build.File, r *build.Rule, pkg string) bool {
-	pkgDecl := PackageDeclaration(f)
+	pkgDecl := ExistingPackageDeclaration(f)
 
 	def := strings.HasSuffix(r.Kind(), "_test") || r.Kind() == "test_suite"
 	if !def {
-		if pkgDecl.Attr("default_testonly") == nil {
+		if pkgDecl != nil && pkgDecl.Attr("default_testonly") == nil {
 			def = strings.HasPrefix(pkg, "javatests/")
-		} else if pkgDecl.AttrLiteral("default_testonly") == "1" {
+		} else if pkgDecl != nil && pkgDecl.AttrLiteral("default_testonly") == "1" {
 			def = true
-		} else if pkgDecl.AttrLiteral("default_testonly") != "0" {
+		} else if pkgDecl != nil && pkgDecl.AttrLiteral("default_testonly") != "0" {
 			// Non-literal value: it's not safe to do a change.
 			return false
 		}
@@ -308,7 +308,8 @@ func mergeLiteralLists(_ *build.File, r *build.Rule, _ string) bool {
 
 // usePlusEqual replaces uses of extend and append with the += operator.
 // e.g. foo.extend(bar)  =>  foo += bar
-//      foo.append(bar)  =>  foo += [bar]
+//
+//	foo.append(bar)  =>  foo += [bar]
 func usePlusEqual(f *build.File) bool {
 	fixed := false
 	for i, stmt := range f.Stmt {
@@ -426,7 +427,7 @@ func movePackageDeclarationToTheTop(f *build.File) bool {
 	return true
 }
 
-// moveToPackage is an auxilliary function used by moveLicensesAndDistribs.
+// moveToPackage is an auxiliary function used by moveLicensesAndDistribs.
 // The function shouldn't appear more than once in the file (depot cleanup has
 // been done).
 func moveToPackage(f *build.File, attrname string) bool {


### PR DESCRIPTION
Several places in fix.go called 'PackageDeclaration' instead of 'ExistingPackageDeclaration'. This would add an empty package declaration if none was present.
