### PR TITLE
new_git_repository deprecation.

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -463,10 +463,10 @@ the function returns a value, it should be described.
   * [Suppress the warning](#suppress): `# buildifier: disable=git-repository`
 
 Native `git_repository` and `new_git_repository` functions are removed.
-Please use the Starlark versions instead:
+Please use the Starlark version instead:
 
 ```python
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 ```
 
 --------------------------------------------------------------------------------

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -479,7 +479,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
   * [Suppress the warning](#suppress): `# buildifier: disable=http-archive`
 
 Native `http_archive` function is removed.
-Please use the Starlark versions instead:
+Please use the Starlark version instead:
 
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/warn/docs/warnings.textproto
+++ b/warn/docs/warnings.textproto
@@ -311,7 +311,7 @@ warnings: {
     "Native `git_repository` and `new_git_repository` functions are removed.\n"
     "Please use the Starlark versions instead:\n\n"
     "```python\n"
-    "load(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"git_repository\", \"new_git_repository\")\n"
+    "load(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"git_repository\")\n"
     "```"
   bazel_flag: "--incompatible_remove_native_git_repository"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/6569"

--- a/warn/docs/warnings.textproto
+++ b/warn/docs/warnings.textproto
@@ -309,7 +309,7 @@ warnings: {
   header: "Function `git_repository` is not global anymore"
   description:
     "Native `git_repository` and `new_git_repository` functions are removed.\n"
-    "Please use the Starlark versions instead:\n\n"
+    "Please use the Starlark version instead:\n\n"
     "```python\n"
     "load(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"git_repository\")\n"
     "```"
@@ -323,7 +323,7 @@ warnings: {
   header: "Function `http_archive` is not global anymore"
   description:
     "Native `http_archive` function is removed.\n"
-    "Please use the Starlark versions instead:\n\n"
+    "Please use the Starlark version instead:\n\n"
     "```python\n"
     "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")\n"
     "```"

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -328,10 +328,11 @@ def macro():
 
 def macro():
     git_repository(foo, bar)
+    new_git_repository(foo, bar)
 `, `
 """My file"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 def macro():
     git_repository(foo, bar)
@@ -354,7 +355,7 @@ def macro():
 `, `
 """My file"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 def macro():
     git_repository(foo, bar)

--- a/warn/warn_bazel_api_test.go
+++ b/warn/warn_bazel_api_test.go
@@ -328,11 +328,10 @@ def macro():
 
 def macro():
     git_repository(foo, bar)
-    new_git_repository(foo, bar)
 `, `
 """My file"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def macro():
     git_repository(foo, bar)
@@ -355,7 +354,7 @@ def macro():
 `, `
 """My file"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def macro():
     git_repository(foo, bar)

--- a/wspace/workspace.go
+++ b/wspace/workspace.go
@@ -92,10 +92,11 @@ func find(dir string, rootFiles map[string]func(os.FileInfo) bool) (string, erro
 
 // FindRepoBuildFiles parses the WORKSPACE to find BUILD files for non-Bazel
 // external repositories, specifically those defined by one of these rules:
-//   new_local_repository(), new_git_repository(), new_http_archive()
+//   new_local_repository(), git_repository(), new_http_archive()
 func FindRepoBuildFiles(root string) (map[string]string, error) {
 	ws := filepath.Join(root, workspaceFile)
 	kinds := []string{
+		"git_repository",
 		"new_local_repository",
 		"new_git_repository",
 		"new_http_archive",

--- a/wspace/workspace.go
+++ b/wspace/workspace.go
@@ -92,7 +92,7 @@ func find(dir string, rootFiles map[string]func(os.FileInfo) bool) (string, erro
 
 // FindRepoBuildFiles parses the WORKSPACE to find BUILD files for non-Bazel
 // external repositories, specifically those defined by one of these rules:
-//   new_local_repository(), git_repository(), new_http_archive()
+//   git_repository(), new_local_repository(), new_http_archive()
 func FindRepoBuildFiles(root string) (map[string]string, error) {
 	ws := filepath.Join(root, workspaceFile)
 	kinds := []string{

--- a/wspace/workspace_test.go
+++ b/wspace/workspace_test.go
@@ -83,7 +83,7 @@ new_local_repository(
     name = "c",
     build_file = "c.BUILD",
 )
-git_repository(
+new_git_repository(
     name = "d",
     build_file = "d.BUILD",
 )
@@ -107,6 +107,7 @@ new_http_archive(
 		"a": filepath.Join(tmp, "a.BUILD"),
 		"b": filepath.Join(tmp, "b.BUILD"),
 		"c": filepath.Join(tmp, "c.BUILD"),
+		"d": filepath.Join(tmp, "d.BUILD"),
 		"f": filepath.Join(tmp, "third_party/f.BUILD"),
 	}
 	if !reflect.DeepEqual(files, expected) {

--- a/wspace/workspace_test.go
+++ b/wspace/workspace_test.go
@@ -71,7 +71,7 @@ func TestFindRepoBuildfiles(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 	workspace := []byte(`
-new_git_repository(
+git_repository(
     name = "a",
     build_file = "a.BUILD",
 )
@@ -87,7 +87,7 @@ git_repository(
     name = "d",
     build_file = "d.BUILD",
 )
-new_git_repository(
+git_repository(
     name = "e",
     build_file_content = "n/a",
 )


### PR DESCRIPTION
- Stop advising people to use `new_git_repository`
- Fix workspace tests to account for both being equivalent now.

This is only part of the deprecation.  We need an entirely new feature to rewrite new_git_repository as git_repository. I'm leaving that for someone else.  It's not obvious that we should just do it, because then buildifier would only work for bazel >= 6.x. So what we really need is for buildifier to understand bazel versions, or be tracked by LTS.  For now, I am happy to stop advising people to use the deprecated version.

https://github.com/bazelbuild/bazel/issues/16823