### PR TITLE
Support repo-absolute file paths in buildozer

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -19,7 +19,10 @@ buildozer [OPTIONS] ['command args' | -f FILE ] label-list
 ```
 
 Here, `label-list` is a space-separated list of Bazel labels, for example
-`//path/to/pkg1:rule1 //path/to/pkg2:rule2`.
+`//path/to/pkg1:rule1 relative/path/to/pkg2:rule2`. In addition to the Bazel
+label syntax for specifying a package, Buildozer also allows the package part to
+refer to a BUILD-like file, for example `//WORKSPACE:all` or
+`toolchains/BUILD.tpl:host_toolchain`.
 
 When `-f FILE` is used, buildozer reads commands from `FILE` (`-` for stdin).
 Format: lines of `|`-separated sets of commands and labels (`command args|label|label...`).

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -73,13 +73,20 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 
 	defaultBuildFileName := "BUILD"
 	if strings.HasPrefix(target, "//") {
+		pkgPath := filepath.Join(rootDir, pkg)
+		if isFile(pkgPath) {
+			// allow operation on other files like WORKSPACE
+			buildFile = pkgPath
+			pkg = filepath.Dir(pkg)
+			return
+		}
 		for _, buildFileName := range BuildFileNames {
-			buildFile = filepath.Join(rootDir, pkg, buildFileName)
+			buildFile = filepath.Join(pkgPath, buildFileName)
 			if isFile(buildFile) {
 				return
 			}
 		}
-		buildFile = filepath.Join(rootDir, pkg, defaultBuildFileName)
+		buildFile = filepath.Join(pkgPath, defaultBuildFileName)
 		return
 	}
 	if isFile(pkg) {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -21,6 +21,7 @@ package edit
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -73,11 +74,11 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 
 	defaultBuildFileName := "BUILD"
 	if strings.HasPrefix(target, "//") {
-		pkgPath := filepath.Join(rootDir, pkg)
+		pkgPath := filepath.Join(rootDir, filepath.FromSlash(pkg))
 		if isFile(pkgPath) {
 			// allow operation on other files like WORKSPACE
 			buildFile = pkgPath
-			pkg = filepath.Dir(pkg)
+			pkg = path.Dir(pkg)
 			return
 		}
 		for _, buildFileName := range BuildFileNames {
@@ -89,10 +90,10 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 		buildFile = filepath.Join(pkgPath, defaultBuildFileName)
 		return
 	}
-	if isFile(pkg) {
+	if isFile(filepath.FromSlash(pkg)) {
 		// allow operation on other files like WORKSPACE
 		buildFile = pkg
-		pkg = filepath.Join(relativePath, filepath.Dir(pkg))
+		pkg = filepath.Join(relativePath, filepath.FromSlash(path.Dir(pkg)))
 		return
 	}
 
@@ -108,7 +109,7 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 		buildFile = filepath.Join(pkg, defaultBuildFileName)
 	}
 
-	pkg = filepath.Join(relativePath, pkg)
+	pkg = filepath.Join(relativePath, filepath.FromSlash(pkg))
 	return
 }
 


### PR DESCRIPTION
In addition to the pseudo-label syntax for relative file paths (e.g. `WORKSPACE` or `toolchains/BUILD.tpl`), also support absolute labels (e.g. `//WORKSPACE` or `//toolchains/BUILD.tpl`).

Also documents the syntax for files in the README.

Fixes #314