### PR TITLE
Format module overrides

### DIFF
--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -90,6 +90,10 @@ use_repo(
     b = "b",
     a = "c",
 )
+bazel_dep(name="foo",version="1.0")
+git_override(module_name="foo",remote="foo.git",commit="1234567890")
+bazel_dep(name="bar",version="1.0")
+archive_override(module_name="not_bar",integrity="sha256-1234567890")
 # do not sort
 use_repo(go_deps, "b", "b", "a")
 use_repo(
@@ -188,6 +192,20 @@ use_repo(
     a = "c",
     b = "b",
     c = "a",
+)
+
+bazel_dep(name = "foo", version = "1.0")
+git_override(
+    module_name = "foo",
+    commit = "1234567890",
+    remote = "foo.git",
+)
+
+bazel_dep(name = "bar", version = "1.0")
+
+archive_override(
+    module_name = "not_bar",
+    integrity = "sha256-1234567890",
 )
 
 # do not sort

--- a/tables/tables.go
+++ b/tables/tables.go
@@ -165,25 +165,30 @@ var SortableAllowlist = map[string]bool{}
 // will change, perhaps swapping in a separate table for each call,
 // derived from the order used in the Build Encyclopedia.
 var NamePriority = map[string]int{
-	"name":              -99,
-	"bazel_dep.version": -98, // for MODULE.bazel
-	"module.version":    -98, // for MODULE.bazel
-	"gwt_name":          -98,
-	"package_name":      -97,
-	"visible_node_name": -96, // for boq_initial_css_modules and boq_jswire_test_suite
-	"size":              -95,
-	"timeout":           -94,
-	"testonly":          -93,
-	"src":               -92,
-	"srcdir":            -91,
-	"srcs":              -90,
-	"out":               -89,
-	"outs":              -88,
-	"hdrs":              -87,
-	"has_services":      -86, // before api versions, for proto
-	"include":           -85, // before exclude, for glob
-	"of":                -84, // for check_dependencies
-	"baseline":          -83, // for searchbox_library
+	"name":                                  -99,
+	"archive_override.module_name":          -99, // for MODULE.bazel
+	"git_override.module_name":              -99, // for MODULE.bazel
+	"local_path_override.module_name":       -99, // for MODULE.bazel
+	"multiple_version_override.module_name": -99, // for MODULE.bazel
+	"single_version_override.module_name":   -99, // for MODULE.bazel
+	"bazel_dep.version":                     -98, // for MODULE.bazel
+	"module.version":                        -98, // for MODULE.bazel
+	"gwt_name":                              -98,
+	"package_name":                          -97,
+	"visible_node_name":                     -96, // for boq_initial_css_modules and boq_jswire_test_suite
+	"size":                                  -95,
+	"timeout":                               -94,
+	"testonly":                              -93,
+	"src":                                   -92,
+	"srcdir":                                -91,
+	"srcs":                                  -90,
+	"out":                                   -89,
+	"outs":                                  -88,
+	"hdrs":                                  -87,
+	"has_services":                          -86, // before api versions, for proto
+	"include":                               -85, // before exclude, for glob
+	"of":                                    -84, // for check_dependencies
+	"baseline":                              -83, // for searchbox_library
 	// All others sort here, at 0.
 	"destdir":        1,
 	"exports":        2,
@@ -273,6 +278,15 @@ var ProtoNativeSymbols = []string{
 
 // ProtoLoadPath is the load path for the Starlark Proto Rules.
 var ProtoLoadPath = "@rules_proto//proto:defs.bzl"
+
+// IsModuleOverride contains the names of all Bzlmod module overrides available in MODULE.bazel.
+var IsModuleOverride = map[string]bool{
+	"archive_override":          true,
+	"git_override":              true,
+	"local_path_override":       true,
+	"multiple_version_override": true,
+	"single_version_override":   true,
+}
 
 // OverrideTables allows a user of the build package to override the special-case rules. The user-provided tables replace the built-in tables.
 func OverrideTables(labelArg, denylist, listArg, sortableListArg, sortDenylist, sortAllowlist map[string]bool, namePriority map[string]int, stripLabelLeadingSlashes, shortenAbsoluteLabelsToRelative bool) {


### PR DESCRIPTION
Module overrides are grouped together with the `bazel_dep` they override and have their `module_name` argument sorted first.