### PR TITLE
Don't warn about unused 'name' arguments

### DIFF
--- a/warn/warn_control_flow.go
+++ b/warn/warn_control_flow.go
@@ -430,9 +430,12 @@ func unusedVariableCheck(f *build.File, root build.Expr) (map[string]bool, []*Li
 				// Function parameters are defined in the current scope.
 				if ident, _ := build.GetParamIdent(param); ident != nil {
 					definedSymbols[ident.Name] = ident
-					if strings.HasPrefix(ident.Name, "_") || edit.ContainsComments(param, "@unused") {
+					if ident.Name == "name" || strings.HasPrefix(ident.Name, "_") || edit.ContainsComments(param, "@unused") {
 						// Don't warn about function arguments if they start with "_"
-						// or explicitly marked with @unused
+						// or explicitly marked with @unused.
+						// Also don't warn about unused "name" arguments, it could be a
+						// macro where such argument is encouraged (by `unnamed-macro`)
+						// even if not used.
 						suppressedWarnings[ident.Name] = true
 					}
 				}

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -638,6 +638,19 @@ foo()
 			":2: Variable \"x\" is unused.",
 		},
 		scopeEverywhere)
+
+	checkFindings(t, "unused-variable", `
+def foo(
+    name,
+    x):
+  pass
+
+foo()
+`,
+		[]string{
+			":3: Variable \"x\" is unused.",
+		},
+		scopeEverywhere)
 }
 
 func TestRedefinedVariable(t *testing.T) {

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -645,10 +645,19 @@ def foo(
     x):
   pass
 
+
+def bar(
+    name = "",
+    y = 3):
+  pass
+
+
 foo()
+bar()
 `,
 		[]string{
 			":3: Variable \"x\" is unused.",
+			":9: Variable \"y\" is unused.",
 		},
 		scopeEverywhere)
 }


### PR DESCRIPTION
https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unnamed-macro explicitly encourages all macros to have `name` arguments even if they're not used. `unused-variable` shouldn't warn about such parameters.