### PR TITLE
Preserve loads if they're different

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1970,6 +1970,14 @@ load(":bar.bzl", "bar")  # bar
 load(":qux.bzl", "qux")
 # after
 
+foobar()
+
+load(":somewhere_else.bzl", "foobar")
+
+foobar()
+
+load(":somewhere_else.bzl", "foobar")
+
 foobar()' 'fix unusedLoads' 'pkg/BUILD'
   assert_equals '# TODO: refactor
 
@@ -1982,6 +1990,12 @@ load(":baz.bzl", "baz")  # this is @unused
 
 # before
 # after
+
+foobar()
+
+load(":somewhere_else.bzl", "foobar")
+
+foobar()
 
 foobar()'
 }


### PR DESCRIPTION
WORKSPACE files currently allow shadowing loads (see https://github.com/bazelbuild/bazel/issues/17480), i.e. the following is valid:

```starlark
load("//:one.bzl", "fn")

fn()

load("//:two.bzl", "fn")

fn()
```

Currently buildozer removes the second load because the symbol was already loaded. This is incorrect - removing the second load changes the behaviour of this file.

Instead, only delete a load of the last time it was loaded was from the same place.