### PR TITLE
Shorten labels within complex expressions

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -428,6 +428,10 @@ func (x namedArgs) Less(i, j int) bool {
 
 // sortStringLists sorts lists of string literals used as specific rule arguments.
 func sortStringLists(f *File, w *Rewriter) {
+	sortStringList := func(x *Expr) {
+		SortStringList(*x)
+	}
+
 	Walk(f, func(e Expr, stk []Expr) {
 		switch v := e.(type) {
 		case *CallExpr:
@@ -456,8 +460,8 @@ func sortStringLists(f *File, w *Rewriter) {
 					continue
 				}
 				if w.IsSortableListArg[key.Name] ||
-					w.SortableAllowlist[context] ||
-					(!disabled("unsafesort") && allowedSort(context)) {
+						w.SortableAllowlist[context] ||
+						(!disabled("unsafesort") && allowedSort(context)) {
 					if doNotSort(as) {
 						deduplicateStringList(as.RHS)
 					} else {
@@ -566,11 +570,6 @@ func SortStringList(x Expr) {
 	}
 
 	list.List = sortStringExprs(list.List)
-}
-
-// sortStringList is similar to SortStringList but takes a pointer to the Expr
-func sortStringList(x *Expr) {
-	SortStringList(*x)
 }
 
 // findAndModifyStrings finds and modifies string lists with a callback

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -262,6 +262,33 @@ func fixLabels(f *File, w *Rewriter) {
 		}
 	}
 
+	// Join and shorten labels within a container of labels (which can be a single
+	// label, e.g. a single string expression or a concatenation of them).
+	// Gracefully finish if the argument is of a different type.
+	fixLabelsWithinAContainer := func(e *Expr) {
+		if list, ok := (*e).(*ListExpr); ok {
+			for i := range list.List {
+				if leaveAlone1(list.List[i]) {
+					continue
+				}
+				joinLabel(&list.List[i])
+				shortenLabel(list.List[i])
+			}
+		}
+		if set, ok := (*e).(*SetExpr); ok {
+			for i := range set.List {
+				if leaveAlone1(set.List[i]) {
+					continue
+				}
+				joinLabel(&set.List[i])
+				shortenLabel(set.List[i])
+			}
+		} else {
+			joinLabel(e)
+			shortenLabel(*e)
+		}
+	}
+
 	Walk(f, func(v Expr, stk []Expr) {
 		switch v := v.(type) {
 		case *CallExpr:
@@ -283,27 +310,8 @@ func fixLabels(f *File, w *Rewriter) {
 				if leaveAlone1(as.RHS) {
 					continue
 				}
-				if list, ok := as.RHS.(*ListExpr); ok {
-					for i := range list.List {
-						if leaveAlone1(list.List[i]) {
-							continue
-						}
-						joinLabel(&list.List[i])
-						shortenLabel(list.List[i])
-					}
-				}
-				if set, ok := as.RHS.(*SetExpr); ok {
-					for i := range set.List {
-						if leaveAlone1(set.List[i]) {
-							continue
-						}
-						joinLabel(&set.List[i])
-						shortenLabel(set.List[i])
-					}
-				} else {
-					joinLabel(&as.RHS)
-					shortenLabel(as.RHS)
-				}
+
+				findAndModifyStrings(&as.RHS, fixLabelsWithinAContainer)
 			}
 		}
 	})
@@ -420,8 +428,8 @@ func (x namedArgs) Less(i, j int) bool {
 
 // sortStringLists sorts lists of string literals used as specific rule arguments.
 func sortStringLists(f *File, w *Rewriter) {
-	Walk(f, func(v Expr, stk []Expr) {
-		switch v := v.(type) {
+	Walk(f, func(e Expr, stk []Expr) {
+		switch v := e.(type) {
 		case *CallExpr:
 			if f.Type == TypeDefault || f.Type == TypeBzl {
 				// Rule parameters, not applicable to .bzl or default file types
@@ -453,7 +461,7 @@ func sortStringLists(f *File, w *Rewriter) {
 					if doNotSort(as) {
 						deduplicateStringList(as.RHS)
 					} else {
-						FindAndSortStringLists(as.RHS)
+						findAndModifyStrings(&as.RHS, sortStringList)
 					}
 				}
 			}
@@ -463,7 +471,7 @@ func sortStringLists(f *File, w *Rewriter) {
 			}
 			// "keep sorted" comment on x = list forces sorting of list.
 			if keepSorted(v) {
-				FindAndSortStringLists(v.RHS)
+				findAndModifyStrings(&v.RHS, sortStringList)
 			}
 		case *KeyValueExpr:
 			if disabled("unsafesort") {
@@ -471,7 +479,7 @@ func sortStringLists(f *File, w *Rewriter) {
 			}
 			// "keep sorted" before key: list also forces sorting of list.
 			if keepSorted(v) {
-				FindAndSortStringLists(v.Value)
+				findAndModifyStrings(&v.Value, sortStringList)
 			}
 		case *ListExpr:
 			if disabled("unsafesort") {
@@ -479,7 +487,7 @@ func sortStringLists(f *File, w *Rewriter) {
 			}
 			// "keep sorted" comment above first list element also forces sorting of list.
 			if len(v.List) > 0 && (keepSorted(v) || keepSorted(v.List[0])) {
-				FindAndSortStringLists(v)
+				findAndModifyStrings(&e, sortStringList)
 			}
 		}
 	})
@@ -560,20 +568,27 @@ func SortStringList(x Expr) {
 	list.List = sortStringExprs(list.List)
 }
 
-// FindAndSortStringLists finds and sorts string lists recursively within
-// the given statement. It doesn't sort all string lists it can find, but only
-// top-level lists, lists that are parts of concatenated expressions and lists
-// within select statements.
-func FindAndSortStringLists(x Expr) {
-	switch x := x.(type) {
-	case *ListExpr:
-		SortStringList(x)
+// sortStringList is similar to SortStringList but takes a pointer to the Expr
+func sortStringList(x *Expr) {
+	SortStringList(*x)
+}
+
+// findAndModifyStrings finds and modifies string lists with a callback
+// function recursively within  the given expression. It doesn't touch all
+// string lists it can find, but only top-level lists, lists that are parts of
+// concatenated expressions and lists within select statements.
+// It calls the callback on the root node and on all relevant inner lists.
+// The callback function should gracefully return if called with not appropriate
+// arguments.
+func findAndModifyStrings(x *Expr, callback func(*Expr)) {
+	callback(x)
+	switch x := (*x).(type) {
 	case *BinaryExpr:
 		if x.Op != "+" {
 			return
 		}
-		FindAndSortStringLists(x.X)
-		FindAndSortStringLists(x.Y)
+		findAndModifyStrings(&x.X, callback)
+		findAndModifyStrings(&x.Y, callback)
 	case *CallExpr:
 		if ident, ok := x.X.(*Ident); !ok || ident.Name != "select" {
 			return
@@ -586,7 +601,7 @@ func FindAndSortStringLists(x Expr) {
 			return
 		}
 		for _, kv := range dict.List {
-			FindAndSortStringLists(kv.Value)
+			findAndModifyStrings(&kv.Value, callback)
 		}
 	}
 }

--- a/build/testdata/070.build.golden
+++ b/build/testdata/070.build.golden
@@ -4,8 +4,8 @@ foo(
         "aaa",
         "bbb",
     ] + CONSTANT + [
-        "ccc",
-        "ddd",
+        "//ccc",
+        "//ddd",
     ],
     data = [
         "iii",
@@ -23,8 +23,8 @@ foo(
     }),
     deps = select({
         "bar": [
-            "eee",
-            "ggg",
+            "//eee",
+            "//ggg",
         ],
     }) + [
         "fff",

--- a/build/testdata/070.bzl.golden
+++ b/build/testdata/070.bzl.golden
@@ -1,8 +1,8 @@
 foo(
     name = "foo",
-    srcs = ["bbb", "aaa"] + CONSTANT + ["ddd", "ccc"],
+    srcs = ["bbb", "aaa"] + CONSTANT + ["//ddd:ddd", "//ccc:ccc"],
     deps = select({
-        "bar": ["ggg", "eee"],
+        "bar": ["//ggg:ggg", "//eee:eee"],
     }) + ["hhh", "fff"],
     data = ["jjj", "iii"] + bar(["not", "sortable", "arguments"]) + non_select({
         "baz": ["not", "sortable", "arguments"],

--- a/build/testdata/070.in
+++ b/build/testdata/070.in
@@ -1,8 +1,8 @@
 foo(
   name='foo',
-  srcs=['bbb', 'aaa'] + CONSTANT + ['ddd', 'ccc'],
+  srcs=['bbb', 'aaa'] + CONSTANT + ['//ddd:ddd', '//ccc:ccc'],
   deps=select({
-    'bar': ['ggg', 'eee'],
+    'bar': ['//ggg:ggg', '//eee:eee'],
   }) + ['hhh', 'fff'],
   data=['jjj', 'iii']+bar(['not', 'sortable', 'arguments'])+non_select({
     'baz': ['not', 'sortable', 'arguments'],


### PR DESCRIPTION
If buildifier shortens labels within a single list of labels, it should also short them if the value of the argument is a complex statement such as a concatenation of lists, select statements and other nodes.

This is similar to #1143 but focuses on shortening and joining labels rather than sorting them.