### PR TITLE
Add external repo support to unused_deps.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,8 @@ var (
 	ExtraActionFileNameHelp = "When specified, just prints suspected unused deps."
 	// DefaultBinDir is used to query for Bazel's bazel-bin directory.
 	DefaultBinDir = "bazel-bin"
+	// DefaultOutputBase is used to query for Bazel's output base directory.
+	DefaultOutputBase = "output_base"
 	// DefaultOutputPath is used to query for Bazel's bazel-out directory.
 	DefaultOutputPath = "output_path"
 	// DefaultExtraBuildFlags is internal-only

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -1007,7 +1007,7 @@ func rewrite(opts *Options, commandsForFile commandsForFile) *rewriteResult {
 	for _, commands := range commandsForFile.commands {
 		target := commands.target
 		commands := commands.commands
-		_, absPkg, rule := InterpretLabelForWorkspaceLocation(opts.RootDir, target)
+		_, _, absPkg, rule := InterpretLabelForWorkspaceLocation(opts.RootDir, target)
 		if label := labels.Parse(target); label.Package == stdinPackageName {
 			// Special-case: This is already absolute
 			absPkg = stdinPackageName
@@ -1093,7 +1093,7 @@ var EditFile = func(fi os.FileInfo, name string) error {
 // Given a target, whose package may contain a trailing "/...", returns all
 // existing BUILD file paths which match the package.
 func targetExpressionToBuildFiles(rootDir string, target string) []string {
-	file, _, _ := InterpretLabelForWorkspaceLocation(rootDir, target)
+	file, _, _, _ := InterpretLabelForWorkspaceLocation(rootDir, target)
 	if rootDir == "" {
 		var err error
 		if file, err = filepath.Abs(file); err != nil {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -41,9 +41,9 @@ var (
 // InterpretLabelForWorkspaceLocation returns the name of the BUILD file to
 // edit, the full package name, and the rule. It takes a workspace-rooted
 // directory to use.
-func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile string, pkg string, rule string) {
+func InterpretLabelForWorkspaceLocation(root, target string) (buildFile, repo, pkg, rule string) {
 	label := labels.Parse(target)
-	repo := label.Repository
+	repo = label.Repository
 	pkg = label.Package
 	rule = label.Target
 	rootDir, relativePath := wspace.FindWorkspaceRoot(root)
@@ -51,7 +51,7 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 		files, err := wspace.FindRepoBuildFiles(rootDir)
 		if err == nil {
 			if buildFile, ok := files[repo]; ok {
-				return buildFile, pkg, rule
+				return buildFile, repo, pkg, rule
 			}
 		}
 		// TODO(rodrigoq): report error for other repos
@@ -100,7 +100,7 @@ func InterpretLabelForWorkspaceLocation(root string, target string) (buildFile s
 
 // InterpretLabel returns the name of the BUILD file to edit, the full
 // package name, and the rule. It uses the pwd for resolving workspace file paths.
-func InterpretLabel(target string) (buildFile string, pkg string, rule string) {
+func InterpretLabel(target string) (buildFile string, repo string, pkg string, rule string) {
 	return InterpretLabelForWorkspaceLocation("", target)
 }
 

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -756,7 +756,7 @@ func runTestInterpretLabelForWorkspaceLocation(t *testing.T, buildFileName strin
 		{tmp, "//a/b", filepath.Join(tmp, "a", "b", buildFileName), "a/b", "b"},
 		{tmp, "//a/b:b", filepath.Join(tmp, "a", "b", buildFileName), "a/b", "b"},
 	} {
-		buildFile, pkg, rule := InterpretLabelForWorkspaceLocation(tc.inputRoot, tc.inputTarget)
+		buildFile, _, pkg, rule := InterpretLabelForWorkspaceLocation(tc.inputRoot, tc.inputTarget)
 		if buildFile != tc.expectedBuildFile || pkg != tc.expectedPkg || rule != tc.expectedRule {
 			t.Errorf("InterpretLabelForWorkspaceLocation(%q, %q) = %q, %q, %q; want %q, %q, %q", tc.inputRoot, tc.inputTarget, buildFile, pkg, rule, tc.expectedBuildFile, tc.expectedPkg, tc.expectedRule)
 		}


### PR DESCRIPTION
External repo targets can be passed as arguments to unused_deps and unused external repo dependencies are detected.

When an external repo BUILD file needs to be edited to remove an unused dependency, the generated buildozer command will need some postprocessing.  The unused_deps utility does not know the file system location of the BUILD file, just its external repo label.