### PR TITLE
Treat unknown files as BUILD files

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -1045,6 +1045,10 @@ func rewrite(opts *Options, commandsForFile commandsForFile) *rewriteResult {
 	if err != nil {
 		return &rewriteResult{file: name, errs: []error{err}}
 	}
+	if f.Type == build.TypeDefault {
+		// Buildozer is unable to infer the file type, fall back to BUILD by default.
+		f.Type = build.TypeBuild
+	}
 	f.WorkspaceRoot, f.Pkg, f.Label = wspace.SplitFilePath(name)
 
 	vars := map[string]*build.AssignExpr{}


### PR DESCRIPTION
WIth #1148 buildozer doesn't force all files to be treated as BUILD files. However for compatibility reasons if the file type is unknown (e.g. it comes via stdin and its name is unknown) it should be still treated as BUILD, not as Default.