### PR TITLE
Revert the signature of edit.InterpretLabel

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -100,7 +100,15 @@ func InterpretLabelForWorkspaceLocation(root, target string) (buildFile, repo, p
 
 // InterpretLabel returns the name of the BUILD file to edit, the full
 // package name, and the rule. It uses the pwd for resolving workspace file paths.
-func InterpretLabel(target string) (buildFile string, repo string, pkg string, rule string) {
+func InterpretLabel(target string) (buildFile string, pkg string, rule string) {
+	buildFile, _, pkg, rule = InterpretLabelForWorkspaceLocation("", target)
+	return buildFile, pkg, rule
+}
+
+// InterpretLabelWithRepo returns the name of the BUILD file to edit, repo name,
+// the full package name, and the rule. It uses the pwd for resolving workspace
+// file paths.
+func InterpretLabelWithRepo(target string) (buildFile string, repo string, pkg string, rule string) {
 	return InterpretLabelForWorkspaceLocation("", target)
 }
 

--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -264,7 +264,7 @@ func hasRuntimeComment(expr build.Expr) bool {
 // to remove that entry from the deps attribute of the rule identified by label.
 // Returns true if at least one command was printed, or false otherwise.
 func printCommands(label string, deps map[string]bool) (anyCommandPrinted bool) {
-	buildFileName, repo, pkg, ruleName := edit.InterpretLabel(label)
+	buildFileName, repo, pkg, ruleName := edit.InterpretLabelWithRepo(label)
 	if repo != "" {
 		outputBase := blazeInfo(config.DefaultOutputBase)
 		buildFileName = fmt.Sprintf("%s/external/%s/%s", outputBase, repo, buildFileName)
@@ -397,7 +397,7 @@ func main() {
 			// https://docs.bazel.build/versions/main/cquery.html#configurations
 			continue
 		}
-		_, repo, pkg, ruleName := edit.InterpretLabel(label)
+		_, repo, pkg, ruleName := edit.InterpretLabelWithRepo(label)
 		blazeBin := binDir
 		if repo != "" {
 			blazeBin = fmt.Sprintf("%s/external/%s", binDir, repo)


### PR DESCRIPTION
The method is public and is currently used by many other projects, changing its signature breaks them.