### PR TITLE
Fix false positive for uninitialized variables

### DIFF
--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -1273,4 +1273,15 @@ def foo():
 `,
 		[]string{},
 		scopeEverywhere)
+
+	checkFindings(t, "uninitialized", `
+def foo():
+  def bar(x):
+    print(x)
+
+  for x, y in z:
+    bar(x)
+`,
+		[]string{},
+		scopeEverywhere)
 }


### PR DESCRIPTION
If a variable is not initialized in some execution paths of a function but is a parameter to an inner function, it shouldn't be warned there as uninitialized.