### PR TITLE
buildifier: Resolve unit test flake in `TestFindConfigPath`

### DIFF
--- a/buildifier/config/config_test.go
+++ b/buildifier/config/config_test.go
@@ -479,6 +479,7 @@ func TestFindConfigPath(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for k, v := range tc.env {
 				os.Setenv(k, v)
+				defer os.Unsetenv(k)
 			}
 
 			tmp, err := ioutil.TempDir("", name+"*")


### PR DESCRIPTION
The following buildifier unit test has been flaking in my CI, with symptom:

```bash
$ bazel test //...
INFO: Invocation ID: 0c41e58f-9ab7-4337-9787-aa525e5e80a3
INFO: Analyzed 128 targets (0 packages loaded, 0 targets configured).
INFO: Found 105 targets and 23 test targets...
FAIL: //buildifier/config:go_default_test (see /mnt/ssd0/cache/bazel/_bazel_kiwi/c4dc02d2b3fe20521581445ef560a9ba/execroot/com_github_bazelbuild_buildtools/bazel-out/k8-fastbuild/testlogs/buildifier/config/go_default_test/test.log)
INFO: Elapsed time: 0.987s, Critical Path: 0.93s
INFO: 24 processes: 8 disk cache hit, 24 linux-sandbox.
INFO: Build completed, 1 test FAILED, 24 total actions
//api_proto:api.gen.pb.go_checkshtest                                    PASSED in 0.0s
//build:go_default_test                                                  PASSED in 0.1s
//build_proto:build.gen.pb.go_checkshtest                                PASSED in 0.0s
//buildifier:buildifier_integration_test                                 PASSED in 0.1s
//buildifier/npm:integration_test                                        PASSED in 0.1s
//buildifier/utils:go_default_test                                       PASSED in 0.0s
//buildozer:buildozer_test                                               PASSED in 0.9s
//buildozer/npm:integration_test                                         PASSED in 0.1s
//bzlenv:bzlenv_test                                                     PASSED in 0.0s
//bzlenv:go_default_test                                                 PASSED in 0.0s
//deps_proto:deps.gen.pb.go_checkshtest                                  PASSED in 0.0s
//edit:go_default_test                                                   PASSED in 0.1s
//edit/bzlmod:go_default_test                                            PASSED in 0.0s
//extra_actions_base_proto:extra_actions_base.gen.pb.go_checkshtest      PASSED in 0.0s
//labels:go_default_test                                                 PASSED in 0.0s
//lang:tables.gen.go_checkshtest                                         PASSED in 0.0s
//tables:go_default_test                                                 PASSED in 0.0s
//unused_deps:go_default_test                                            PASSED in 0.0s
//unused_deps:jar_manifest_test                                          PASSED in 0.0s
//warn:go_default_test                                                   PASSED in 0.2s
//warn/docs:go_default_test                                              PASSED in 0.0s
//wspace:go_default_test                                                 PASSED in 0.0s
//buildifier/config:go_default_test                                      FAILED in 0.0s
  /mnt/ssd0/cache/bazel/_bazel_kiwi/c4dc02d2b3fe20521581445ef560a9ba/execroot/com_github_bazelbuild_buildtools/bazel-out/k8-fastbuild/testlogs/buildifier/config/go_default_test/test.log

Executed 23 out of 23 tests: 22 tests pass and 1 fails locally.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```

The test output is:

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //buildifier/config:go_default_test
-----------------------------------------------------------------------------
--- FAIL: TestFindConfigPath (0.00s)
    --- FAIL: TestFindConfigPath/no-config-file (0.00s)
        config_test.go:494: tmp: /tmp/no-config-file131613270
        config_test.go:514: FindConfigPath: want "", got ".buildifier2.json"
FAIL
```

This seems to be a side effect of the environment improperly leaking across test cases; unsetting the environment after `os.Setenv` seems to resolve this.