### PR TITLE
Prepare release scripts for the new tag format

### DIFF
--- a/release/github.sh
+++ b/release/github.sh
@@ -8,9 +8,10 @@ then
     exit 1
 fi
 
-TAG="$(git describe --abbrev=0 --tags | sed 's/* //')"
+TAG="$(git describe --abbrev=0 --tags | sed 's/* //')"  # v1.2.3
+VERSION=$(echo $TAG | sed 's/v//')  # 1.2.3
 DATE="$(date +"%Y-%m-%d")"
-NAME="Release $TAG ($DATE)"
+NAME="Release $VERSION ($DATE)"
 
 GH_REPO="repos/bazelbuild/buildtools"
 GH_AUTH_HEADER="Authorization: token $GITHUB_ACCESS_TOKEN"

--- a/status.py
+++ b/status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+ #!/usr/bin/env python
 
 from __future__ import print_function, unicode_literals
 from subprocess import Popen, PIPE
@@ -15,11 +15,12 @@ def run(*cmd):
 
 def main():
     tags = run("git", "describe", "--tags")
-    print("STABLE_buildVersion", tags.split("-")[0])
+    version = tags.lstrip('v')
+    print("STABLE_buildVersion", version)
 
     # rules_nodejs expects to read from volatile-status.txt
-    print("BUILD_SCM_VERSION", tags.split("-")[0])
-    
+    print("BUILD_SCM_VERSION", version)
+
     revision = run("git", "rev-parse", "HEAD")
     print("STABLE_buildScmRevision", revision)
 

--- a/status.py
+++ b/status.py
@@ -1,4 +1,4 @@
- #!/usr/bin/env python
+#!/usr/bin/env python
 
 from __future__ import print_function, unicode_literals
 from subprocess import Popen, PIPE


### PR DESCRIPTION
Versions in the future will be tagged with `v1.2.3` instead of `1.2.3`, the release scripts should handle them correctly (see #1098).