### PR TITLE
Add the ability to escape `|` in command files to Buildozer.

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -277,7 +277,8 @@ bazel query --output=build //path/to/BUILD
 
 Use `buildozer -f <file>` to load a list of commands from a file. The usage is
 just like arguments on the command-line, except that arguments are separated by
-`|`. Lines that start with `#` are ignored.
+`|`. Lines that start with `#` are ignored. `|`s in commands can be escaped like
+`\|`, but double null bytes (`\x00\x00`) are not valid in command files.
 
 ```shell
 $ cat /tmp/cmds

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -1290,7 +1290,11 @@ func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile ma
 		if line == "" || line[0] == '#' {
 			continue
 		}
+		line = escapePipes(line)
 		args := strings.Split(line, "|")
+		for i, arg := range args {
+			args[i] = unescapePipes(arg)
+		}
 		if len(args) > 1 && args[1] == "*" {
 			cmd := append([]string{args[0]}, labels...)
 			if err := appendCommands(opts, commandsByFile, cmd); err != nil {
@@ -1303,6 +1307,14 @@ func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile ma
 		}
 	}
 	return nil
+}
+
+func escapePipes(s string) string {
+	return strings.ReplaceAll(s, `\|`, "\x00\x00")
+}
+
+func unescapePipes(s string) string {
+	return strings.ReplaceAll(s, "\x00\x00", "|")
 }
 
 func printRecord(writer io.Writer, record *apipb.Output_Record) {

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -1290,10 +1290,10 @@ func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile ma
 		if line == "" || line[0] == '#' {
 			continue
 		}
-		line = escapePipes(line)
+		line = saveEscapedPipes(line)
 		args := strings.Split(line, "|")
 		for i, arg := range args {
-			args[i] = unescapePipes(arg)
+			args[i] = replaceSavedPipes(arg)
 		}
 		if len(args) > 1 && args[1] == "*" {
 			cmd := append([]string{args[0]}, labels...)
@@ -1309,11 +1309,11 @@ func appendCommandsFromReader(opts *Options, reader io.Reader, commandsByFile ma
 	return nil
 }
 
-func escapePipes(s string) string {
+func saveEscapedPipes(s string) string {
 	return strings.ReplaceAll(s, `\|`, "\x00\x00")
 }
 
-func unescapePipes(s string) string {
+func replaceSavedPipes(s string) string {
 	return strings.ReplaceAll(s, "\x00\x00", "|")
 }
 

--- a/edit/buildozer_command_file_test.go
+++ b/edit/buildozer_command_file_test.go
@@ -129,6 +129,16 @@ func TestLongLineInCommandFileParsesAsOneCommand(t *testing.T) {
 	}
 }
 
+func TestEscapedPipesInCommandFileArentSplit(t *testing.T) {
+	commands := parseCommandFile("set srcs mytarget.go|//test-project:mytarget(\\|\\|)\n", t)
+	if len(commands) != 1 {
+		t.Error("Exactly one command should be read")
+	}
+	if commands[0].target != "//test-project:mytarget(||)" {
+		t.Error("Read command target should be for the correct target")
+	}
+}
+
 func parseCommandFile(fileContent string, t *testing.T) []parsedCommand {
 	reader := strings.NewReader(fileContent)
 	commandsByBuildFile := make(map[string][]commandsForTarget)


### PR DESCRIPTION
`|` in command files can now be escaped like `\|` to prevent Buildozer from splitting the command on them. This allows the use of some more complex regex in `substitute` as well as handling targets and commands that need to contain `|` for other reasons.

As a result of this change double null bytes (`\x00\x00`) is no longer legal in a command string however.