### PR TITLE
Work with canonical labels

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -181,6 +181,9 @@ func directDepParams(blazeOutputPath string, paramsFileNames ...string) (depsByJ
 			if len(label) > 2 && label[0] == '@' && label[1] == '@' {
 				label = label[1:]
 			}
+			if len(label) > 2 && label[0] == '@' && label[1] == '/' {
+				label = label[1:]
+			}
 			depsByJar[jar] = label
 		}
 		if err := scanner.Err(); err != nil {


### PR DESCRIPTION
rules_jvm uses the label name as is. Account for it when parsing the stamped manifest.

see https://github.com/bazelbuild/rules_jvm_external/blob/eec0b9c5e7e95d5/private/rules/jvm_import.bzl#L21