### PR TITLE
unused_deps: Add exported dependencies before removing

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -291,6 +291,8 @@ func printCommands(label string, deps map[string]bool) (anyCommandPrinted bool) 
 				if hasRuntimeComment(str) {
 					fmt.Printf("buildozer 'move deps runtime_deps %s' %s\n", str.Value, label)
 				} else {
+					// add dep's exported dependencies to label before removing dep
+					fmt.Printf("buildozer \"add deps $(%s query 'labels(exports, %s)' | tr '\\n' ' ')\" %s\n", *buildTool, str.Value, label)
 					fmt.Printf("buildozer 'remove deps %s' %s\n", str.Value, label)
 				}
 				anyCommandPrinted = true


### PR DESCRIPTION
A dependency that is marked for removal might contain [exports](https://bazel.build/reference/be/java#java_library.exports). Since exports are treated as if the parent explicitly depended on them, removal of such a dependency can cause issues since the exported dependencies will no longer be available to the parent. 
This PR proposes to fix this by first adding the exports explicitly to the parent's deps before removing the dependency. 