### PR TITLE
Also generate `import`-style targets with Gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,21 +21,22 @@ test_suite(
     name = "tests",
     tests = [
         "//api_proto:api.gen.pb.go_checkshtest",
-        "//build:go_default_test",
+        "//build:build_test",
         "//build_proto:build.gen.pb.go_checkshtest",
         "//buildifier:buildifier_integration_test",
         "//deps_proto:deps.gen.pb.go_checkshtest",
-        "//edit:go_default_test",
+        "//edit:edit_test",
         "//extra_actions_base_proto:extra_actions_base.gen.pb.go_checkshtest",
-        "//labels:go_default_test",
+        "//labels:labels_test",
         "//lang:tables.gen.go_checkshtest",
-        "//tables:go_default_test",
-        "//warn:go_default_test",
-        "//warn/docs:go_default_test",
-        "//wspace:go_default_test",
+        "//tables:tables_test",
+        "//warn:warn_test",
+        "//warn/docs:docs_test",
+        "//wspace:wspace_test",
     ],
 )
 
+#gazelle:go_naming_convention import_alias
 gazelle(
     name = "gazelle",
     prefix = "github.com/bazelbuild/buildtools",

--- a/api_proto/BUILD.bazel
+++ b/api_proto/BUILD.bazel
@@ -23,8 +23,14 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "api_proto",
     embed = [":api_proto_go_proto"],
     importpath = "github.com/bazelbuild/buildtools/api_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":api_proto",
     visibility = ["//visibility:public"],
 )

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -8,7 +8,7 @@ go_yacc(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "build",
     srcs = [
         "lex.go",
         "parse.y.baz.go",  # keep
@@ -23,12 +23,12 @@ go_library(
     importpath = "github.com/bazelbuild/buildtools/build",
     visibility = ["//visibility:public"],
     deps = [
-        "//tables:go_default_library",
+        "//tables",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "build_test",
     size = "small",
     srcs = [
         "checkfile_test.go",
@@ -49,9 +49,15 @@ go_test(
         "rewrite_test_files/original_formatted.star",
         "rewrite_test_files/original.star",
     ],
-    embed = [":go_default_library"],
+    embed = [":build"],
     deps = [
-        "//tables:go_default_library",
+        "//tables",
         "//testutils",
     ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":build",
+    visibility = ["//visibility:public"],
 )

--- a/build_proto/BUILD.bazel
+++ b/build_proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//build:build_defs.bzl", "go_proto_checkedin_test")
@@ -21,5 +22,12 @@ go_proto_library(
     name = "go_default_library",
     importpath = "github.com/bazelbuild/buildtools/build_proto",
     proto = ":blaze_query_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "build_proto",
+    embed = [":go_default_library"],
+    importpath = "github.com/bazelbuild/buildtools/build_proto",
     visibility = ["//visibility:public"],
 )

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -2,14 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
     name = "buildifier",
-    embed = [":go_default_library"],
+    embed = [":buildifier_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_binary(
     name = "buildifier-darwin",
     out = "buildifier-darwin_amd64",
-    embed = [":go_default_library"],
+    embed = [":buildifier_lib"],
     goarch = "amd64",
     goos = "darwin",
     pure = "on",
@@ -19,7 +19,7 @@ go_binary(
 go_binary(
     name = "buildifier-linux",
     out = "buildifier-linux_amd64",
-    embed = [":go_default_library"],
+    embed = [":buildifier_lib"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
@@ -29,7 +29,7 @@ go_binary(
 go_binary(
     name = "buildifier-windows",
     out = "buildifier-windows_amd64.exe",
-    embed = [":go_default_library"],
+    embed = [":buildifier_lib"],
     goarch = "amd64",
     goos = "windows",
     pure = "on",
@@ -39,7 +39,7 @@ go_binary(
 go_binary(
     name = "buildifier-darwin-arm64",
     out = "buildifier-darwin_arm64",
-    embed = [":go_default_library"],
+    embed = [":buildifier_lib"],
     goarch = "arm64",
     goos = "darwin",
     pure = "on",
@@ -49,7 +49,7 @@ go_binary(
 go_binary(
     name = "buildifier-linux-arm64",
     out = "buildifier-linux_arm64",
-    embed = [":go_default_library"],
+    embed = [":buildifier_lib"],
     goarch = "arm64",
     goos = "linux",
     pure = "on",
@@ -73,7 +73,7 @@ sh_test(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "buildifier_lib",
     srcs = ["buildifier.go"],
     importpath = "github.com/bazelbuild/buildtools/buildifier",
     visibility = ["//visibility:private"],
@@ -82,13 +82,11 @@ go_library(
         "main.buildScmRevision": "{STABLE_buildScmRevision}",
     },
     deps = [
-        "//build:go_default_library",
-        "//buildifier/config:go_default_library",
-        "//buildifier/utils:go_default_library",
-        "//differ:go_default_library",
-        "//tables:go_default_library",
-        "//warn:go_default_library",
-        "//wspace:go_default_library",
+        "//build",
+        "//buildifier/config",
+        "//buildifier/utils",
+        "//differ",
+        "//wspace",
     ],
 )
 

--- a/buildifier/config/BUILD.bazel
+++ b/buildifier/config/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "config",
     srcs = [
         "config.go",
         "validation.go",
@@ -9,14 +9,20 @@ go_library(
     importpath = "github.com/bazelbuild/buildtools/buildifier/config",
     visibility = ["//buildifier:__pkg__"],
     deps = [
-        "//tables:go_default_library",
-        "//warn:go_default_library",
-        "//wspace:go_default_library",
+        "//tables",
+        "//warn",
+        "//wspace",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "config_test",
     srcs = ["config_test.go"],
-    embed = [":go_default_library"],
+    embed = [":config"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":config",
+    visibility = ["//visibility:public"],
 )

--- a/buildifier/utils/BUILD.bazel
+++ b/buildifier/utils/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "utils",
     srcs = [
         "diagnostics.go",
         "tempfile.go",
@@ -10,13 +10,19 @@ go_library(
     importpath = "github.com/bazelbuild/buildtools/buildifier/utils",
     visibility = ["//buildifier:__subpackages__"],
     deps = [
-        "//build:go_default_library",
-        "//warn:go_default_library",
+        "//build",
+        "//warn",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "utils_test",
     srcs = ["utils_test.go"],
-    embed = [":go_default_library"],
+    embed = [":utils"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":utils",
+    visibility = ["//visibility:public"],
 )

--- a/buildifier2/BUILD.bazel
+++ b/buildifier2/BUILD.bazel
@@ -1,19 +1,19 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "buildifier2_lib",
     srcs = ["buildifier2.go"],
     importpath = "github.com/bazelbuild/buildtools/buildifier2",
     visibility = ["//visibility:private"],
     deps = [
-        "//build:go_default_library",
-        "//convertast:go_default_library",
-        "@skylark_syntax//syntax:go_default_library",
+        "//build",
+        "//convertast",
+        "@skylark_syntax//syntax",
     ],
 )
 
 go_binary(
     name = "buildifier2",
-    embed = [":go_default_library"],
+    embed = [":buildifier2_lib"],
     visibility = ["//visibility:public"],
 )

--- a/buildozer/BUILD.bazel
+++ b/buildozer/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "buildozer_lib",
     srcs = ["main.go"],
     importpath = "github.com/bazelbuild/buildtools/buildozer",
     visibility = ["//visibility:private"],
@@ -10,15 +10,15 @@ go_library(
         "main.buildScmRevision": "{STABLE_buildScmRevision}",
     },
     deps = [
-        "//build:go_default_library",
-        "//edit:go_default_library",
-        "//tables:go_default_library",
+        "//build",
+        "//edit",
+        "//tables",
     ],
 )
 
 go_binary(
     name = "buildozer",
-    embed = [":go_default_library"],
+    embed = [":buildozer_lib"],
     visibility = ["//visibility:public"],
 )
 
@@ -39,7 +39,7 @@ sh_test(
 go_binary(
     name = "buildozer-darwin",
     out = "buildozer-darwin_amd64",
-    embed = [":go_default_library"],
+    embed = [":buildozer_lib"],
     goarch = "amd64",
     goos = "darwin",
     pure = "on",
@@ -49,7 +49,7 @@ go_binary(
 go_binary(
     name = "buildozer-linux",
     out = "buildozer-linux_amd64",
-    embed = [":go_default_library"],
+    embed = [":buildozer_lib"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
@@ -59,7 +59,7 @@ go_binary(
 go_binary(
     name = "buildozer-windows",
     out = "buildozer-windows_amd64.exe",
-    embed = [":go_default_library"],
+    embed = [":buildozer_lib"],
     goarch = "amd64",
     goos = "windows",
     pure = "on",
@@ -69,7 +69,7 @@ go_binary(
 go_binary(
     name = "buildozer-darwin-arm64",
     out = "buildozer-darwin_arm64",
-    embed = [":go_default_library"],
+    embed = [":buildozer_lib"],
     goarch = "arm64",
     goos = "darwin",
     pure = "on",
@@ -79,7 +79,7 @@ go_binary(
 go_binary(
     name = "buildozer-linux-arm64",
     out = "buildozer-linux_arm64",
-    embed = [":go_default_library"],
+    embed = [":buildozer_lib"],
     goarch = "arm64",
     goos = "linux",
     pure = "on",

--- a/bzlenv/BUILD.bazel
+++ b/bzlenv/BUILD.bazel
@@ -1,23 +1,23 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "bzlenv",
     srcs = ["bzlenv.go"],
     importpath = "github.com/bazelbuild/buildtools/bzlenv",
     visibility = ["//visibility:public"],
-    deps = ["//build:go_default_library"],
+    deps = ["//build"],
 )
 
 go_test(
     name = "bzlenv_test",
     size = "small",
     srcs = ["bzlenv_test.go"],
-    embed = [":go_default_library"],
+    embed = [":bzlenv"],
+    deps = ["//build"],
 )
 
-go_test(
-    name = "go_default_test",
-    srcs = ["bzlenv_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//build:go_default_library"],
+alias(
+    name = "go_default_library",
+    actual = ":bzlenv",
+    visibility = ["//visibility:public"],
 )

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -1,8 +1,14 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "config",
     srcs = ["config.go"],
     importpath = "github.com/bazelbuild/buildtools/config",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":config",
     visibility = ["//visibility:public"],
 )

--- a/convertast/BUILD.bazel
+++ b/convertast/BUILD.bazel
@@ -1,12 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "convertast",
     srcs = ["convert_ast.go"],
     importpath = "github.com/bazelbuild/buildtools/convertast",
     visibility = ["//visibility:public"],
     deps = [
-        "//build:go_default_library",
-        "@skylark_syntax//syntax:go_default_library",
+        "//build",
+        "@skylark_syntax//syntax",
     ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":convertast",
+    visibility = ["//visibility:public"],
 )

--- a/deps_proto/BUILD.bazel
+++ b/deps_proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//build:build_defs.bzl", "go_proto_checkedin_test")
@@ -21,5 +22,12 @@ go_proto_library(
     name = "go_default_library",
     importpath = "github.com/bazelbuild/buildtools/deps_proto",
     proto = ":blaze_deps_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "deps_proto",
+    embed = [":go_default_library"],
+    importpath = "github.com/bazelbuild/buildtools/deps_proto",
     visibility = ["//visibility:public"],
 )

--- a/differ/BUILD.bazel
+++ b/differ/BUILD.bazel
@@ -1,12 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "differ",
     srcs = [
         "diff.go",
         "isatty_other.go",
         "isatty_windows.go",
     ],
     importpath = "github.com/bazelbuild/buildtools/differ",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":differ",
     visibility = ["//visibility:public"],
 )

--- a/edit/BUILD.bazel
+++ b/edit/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "edit",
     srcs = [
         "buildozer.go",
         "default_buildifier.go",
@@ -12,31 +12,37 @@ go_library(
     importpath = "github.com/bazelbuild/buildtools/edit",
     visibility = ["//visibility:public"],
     deps = [
-        "//api_proto:go_default_library",
-        "//build:go_default_library",
-        "//build_proto:go_default_library",
-        "//edit/bzlmod:go_default_library",
-        "//file:go_default_library",
-        "//labels:go_default_library",
-        "//lang:go_default_library",
-        "//tables:go_default_library",
-        "//wspace:go_default_library",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "//api_proto",
+        "//build",
+        "//build_proto",
+        "//edit/bzlmod",
+        "//file",
+        "//labels",
+        "//lang",
+        "//tables",
+        "//wspace",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "edit_test",
     srcs = [
         "buildozer_command_file_test.go",
         "buildozer_test.go",
         "edit_test.go",
         "fix_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":edit"],
     deps = [
-        "//build:go_default_library",
+        "//build",
         "@com_github_google_go_cmp//cmp",
     ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":edit",
+    visibility = ["//visibility:public"],
 )

--- a/edit/bzlmod/BUILD.bazel
+++ b/edit/bzlmod/BUILD.bazel
@@ -1,18 +1,22 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "bzlmod",
     srcs = ["bzlmod.go"],
     importpath = "github.com/bazelbuild/buildtools/edit/bzlmod",
     visibility = ["//visibility:public"],
-    deps = [
-        "//build:go_default_library",
-        "//labels:go_default_library",
-    ],
+    deps = ["//build"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "bzlmod_test",
     srcs = ["bzlmod_test.go"],
-    embed = [":go_default_library"],
+    embed = [":bzlmod"],
+    deps = ["//build"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":bzlmod",
+    visibility = ["//visibility:public"],
 )

--- a/edit/safe/BUILD.bazel
+++ b/edit/safe/BUILD.bazel
@@ -1,12 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "safe",
     srcs = ["buildifier.go"],
     importpath = "github.com/bazelbuild/buildtools/edit/safe",
     visibility = ["//visibility:public"],
     deps = [
-        "//build:go_default_library",
-        "//edit:go_default_library",
+        "//build",
+        "//edit",
     ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":safe",
+    visibility = ["//visibility:public"],
 )

--- a/extra_actions_base_proto/BUILD.bazel
+++ b/extra_actions_base_proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//build:build_defs.bzl", "go_proto_checkedin_test")
@@ -21,5 +22,12 @@ go_proto_library(
     name = "go_default_library",
     importpath = "github.com/bazelbuild/buildtools/extra_actions_base_proto",
     proto = ":blaze_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "extra_actions_base_proto",
+    embed = [":go_default_library"],
+    importpath = "github.com/bazelbuild/buildtools/extra_actions_base_proto",
     visibility = ["//visibility:public"],
 )

--- a/file/BUILD.bazel
+++ b/file/BUILD.bazel
@@ -1,8 +1,14 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "file",
     srcs = ["file.go"],
     importpath = "github.com/bazelbuild/buildtools/file",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":file",
     visibility = ["//visibility:public"],
 )

--- a/generatetables/BUILD.bazel
+++ b/generatetables/BUILD.bazel
@@ -1,18 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "generatetables_lib",
     srcs = ["generate_tables.go"],
     importpath = "github.com/bazelbuild/buildtools/generatetables",
     visibility = ["//visibility:private"],
     deps = [
-        "//build_proto:go_default_library",
+        "//build_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 
 go_binary(
     name = "generatetables",
-    embed = [":go_default_library"],
+    embed = [":generatetables_lib"],
     visibility = ["//visibility:public"],
 )

--- a/labels/BUILD.bazel
+++ b/labels/BUILD.bazel
@@ -1,18 +1,20 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
-    srcs = [
-        "labels.go",
-    ],
+    name = "labels",
+    srcs = ["labels.go"],
     importpath = "github.com/bazelbuild/buildtools/labels",
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
-    srcs = [
-        "labels_test.go",
-    ],
-    embed = [":go_default_library"],
+    name = "labels_test",
+    srcs = ["labels_test.go"],
+    embed = [":labels"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":labels",
+    visibility = ["//visibility:public"],
 )

--- a/lang/BUILD.bazel
+++ b/lang/BUILD.bazel
@@ -18,13 +18,19 @@ generate_tables(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "lang",
     srcs = [
         "tables.go",  # keep
     ],
     importpath = "github.com/bazelbuild/buildtools/lang",
     visibility = ["//visibility:public"],
     deps = [
-        "//build_proto:go_default_library",  # keep
+        "//build_proto",  # keep
     ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":lang",
+    visibility = ["//visibility:public"],
 )

--- a/tables/BUILD.bazel
+++ b/tables/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "tables",
     srcs = [
         "jsonparser.go",
         "tables.go",
@@ -11,9 +11,15 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "tables_test",
     size = "small",
     srcs = ["jsonparser_test.go"],
     data = glob(["testdata/*"]),
-    embed = [":go_default_library"],
+    embed = [":tables"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":tables",
+    visibility = ["//visibility:public"],
 )

--- a/testutils/BUILD.bazel
+++ b/testutils/BUILD.bazel
@@ -9,3 +9,9 @@ go_library(
     importpath = "github.com/bazelbuild/buildtools/testutils",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":testutils",
+    visibility = ["//visibility:public"],
+)

--- a/unused_deps/BUILD.bazel
+++ b/unused_deps/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "unused_deps_lib",
     srcs = [
         "jar_manifest.go",
         "unused_deps.go",
@@ -13,26 +13,26 @@ go_library(
         "main.buildScmRevision": "{STABLE_buildScmRevision}",
     },
     deps = [
-        "//build:go_default_library",
-        "//config:go_default_library",
-        "//deps_proto:go_default_library",
-        "//edit:go_default_library",
-        "//extra_actions_base_proto:go_default_library",
-        "//labels:go_default_library",
+        "//build",
+        "//config",
+        "//deps_proto",
+        "//edit",
+        "//extra_actions_base_proto",
+        "//labels",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 
 go_binary(
     name = "unused_deps",
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_binary(
     name = "unused_deps-darwin",
     out = "unused_deps-darwin_amd64",
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
     goarch = "amd64",
     goos = "darwin",
     pure = "on",
@@ -42,7 +42,7 @@ go_binary(
 go_binary(
     name = "unused_deps-linux",
     out = "unused_deps-linux_amd64",
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",
@@ -52,7 +52,7 @@ go_binary(
 go_binary(
     name = "unused_deps-windows",
     out = "unused_deps-windows_amd64.exe",
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
     goarch = "amd64",
     goos = "windows",
     pure = "on",
@@ -62,7 +62,7 @@ go_binary(
 go_binary(
     name = "unused_deps-linux-arm64",
     out = "unused_deps-linux_arm64",
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
     goarch = "arm64",
     goos = "linux",
     pure = "on",
@@ -72,7 +72,7 @@ go_binary(
 go_binary(
     name = "unused_deps-darwin-arm64",
     out = "unused_deps-darwin_arm64",
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
     goarch = "arm64",
     goos = "darwin",
     pure = "on",
@@ -83,11 +83,11 @@ go_test(
     name = "jar_manifest_test",
     size = "small",
     srcs = ["jar_manifest_test.go"],
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "unused_deps_test",
     srcs = ["jar_manifest_test.go"],
-    embed = [":go_default_library"],
+    embed = [":unused_deps_lib"],
 )

--- a/warn/BUILD.bazel
+++ b/warn/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "warn",
     srcs = [
         "multifile.go",
         "types.go",
@@ -21,16 +21,16 @@ go_library(
     importpath = "github.com/bazelbuild/buildtools/warn",
     visibility = ["//visibility:public"],
     deps = [
-        "//build:go_default_library",
-        "//bzlenv:go_default_library",
-        "//edit:go_default_library",
-        "//labels:go_default_library",
-        "//tables:go_default_library",
+        "//build",
+        "//bzlenv",
+        "//edit",
+        "//labels",
+        "//tables",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "warn_test",
     size = "small",
     srcs = [
         "types_test.go",
@@ -47,10 +47,16 @@ go_test(
         "warn_test.go",
         "warn_visibility_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":warn"],
     deps = [
-        "//build:go_default_library",
-        "//tables:go_default_library",
+        "//build",
+        "//tables",
         "//testutils",
     ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":warn",
+    visibility = ["//visibility:public"],
 )

--- a/warn/docs/BUILD.bazel
+++ b/warn/docs/BUILD.bazel
@@ -12,47 +12,47 @@ documentation(
 
 go_binary(
     name = "go_default_binary",
-    embed = [":go_default_library"],
+    embed = [":docs_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_library(
-    name = "go_default_library",
+    name = "docs_lib",
     srcs = ["docs.go"],
-    importpath = "github.com/bazelbuild/buildtools/warn.docs",
+    importpath = "github.com/bazelbuild/buildtools/warn/docs",
     visibility = ["//visibility:private"],
     deps = [
-        ":docs_go_proto",
-        "//warn:go_default_library",
+        ":proto_go_proto",
+        "//warn",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "docs_test",
     size = "small",
-    srcs = [
-        "docs_test.go",
-    ],
+    srcs = ["docs_test.go"],
     data = [
         "warnings.textproto",
         ":warnings_docs",
         "//:warnings",
     ],
-    embed = [":go_default_library"],
+    embed = [":docs_lib"],
     deps = [
         "//testutils",
+        "//warn",
     ],
 )
 
 proto_library(
     name = "docs_proto",
     srcs = ["docs.proto"],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
-    name = "docs_go_proto",
+    name = "proto_go_proto",
     importpath = "github.com/bazelbuild/buildtools/warn/docs/proto",
     proto = ":docs_proto",
+    visibility = ["//visibility:public"],
 )

--- a/warn/docs/docs.proto
+++ b/warn/docs/docs.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package docs;
 
+option go_package = "github.com/bazelbuild/buildtools/warn/docs/proto";
+
 message Warnings {
   message Warning {
     repeated string name = 1;

--- a/wspace/BUILD.bazel
+++ b/wspace/BUILD.bazel
@@ -1,16 +1,22 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "wspace",
     srcs = ["workspace.go"],
     importpath = "github.com/bazelbuild/buildtools/wspace",
     visibility = ["//visibility:public"],
-    deps = ["//build:go_default_library"],
+    deps = ["//build"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "wspace_test",
     size = "small",
     srcs = ["workspace_test.go"],
-    embed = [":go_default_library"],
+    embed = [":wspace"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":wspace",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Since the repo uses checked-in build files, it should support both the `import` and `go_default_library` naming conventions supported by Gazelle to ensure that it works with all possible values of the `gazelle:go_naming_convention_external` directive.

This is achieved by using `gazelle:go_naming_convention import_alias`.