### PR TITLE
Fix `use_repo_add` with no existing `use_repo`

### DIFF
--- a/edit/bzlmod/bzlmod.go
+++ b/edit/bzlmod/bzlmod.go
@@ -289,7 +289,7 @@ func parseTag(stmt build.Expr) string {
 // lastProxyUsage returns the index of the last statement in the given file that uses one of the
 // given extension proxies (either in a use_extension assignment or tag call). If no such statement
 // exists, -1 is returned.
-func lastProxyUsage(f *build.File, proxies []string) (lastUsage int, proxy string) {
+func lastProxyUsage(f *build.File, proxies []string) (lastUsage int, lastProxy string) {
 	proxiesSet := make(map[string]struct{})
 	for _, p := range proxies {
 		proxiesSet[p] = struct{}{}
@@ -297,11 +297,12 @@ func lastProxyUsage(f *build.File, proxies []string) (lastUsage int, proxy strin
 
 	lastUsage = -1
 	for i, stmt := range f.Stmt {
-		proxy, _, _, _ = parseUseExtension(stmt)
+		proxy, _, _, _ := parseUseExtension(stmt)
 		if proxy != "" {
 			_, isUsage := proxiesSet[proxy]
 			if isUsage {
 				lastUsage = i
+				lastProxy = proxy
 				continue
 			}
 		}
@@ -311,10 +312,11 @@ func lastProxyUsage(f *build.File, proxies []string) (lastUsage int, proxy strin
 			_, isUsage := proxiesSet[proxy]
 			if isUsage {
 				lastUsage = i
+				lastProxy = proxy
 				continue
 			}
 		}
 	}
 
-	return lastUsage, proxy
+	return lastUsage, lastProxy
 }

--- a/edit/bzlmod/bzlmod_test.go
+++ b/edit/bzlmod/bzlmod_test.go
@@ -243,6 +243,38 @@ use_repo(prox1)
 `,
 			3,
 		},
+		{
+			`go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+pull = use_extension("@rules_oci//oci:pull.bzl", "go_deps")
+pull.oci_pull(name = "distroless_base")
+`,
+			[]string{"go_deps"},
+			`go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(go_deps)
+
+pull = use_extension("@rules_oci//oci:pull.bzl", "go_deps")
+pull.oci_pull(name = "distroless_base")
+`,
+			2,
+		},
+		{
+			`go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+pull = use_extension("@rules_oci//oci:pull.bzl", "go_deps")
+`,
+			[]string{"go_deps"},
+			`go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(go_deps)
+
+pull = use_extension("@rules_oci//oci:pull.bzl", "go_deps")
+`,
+			2,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			f, err := build.ParseModule("MODULE.bazel", []byte(tc.content))


### PR DESCRIPTION
`use_repo_add` now inserts a `use_repo` call for the correct proxy when none exists. Previously, it added such a call for the last proxy in the module file, whatever that might be.

Originally observed in https://bazelbuild.slack.com/archives/CDBP88Z0D/p1690549451155769?thread_ts=1690507292.465539&cid=CDBP88Z0D