### PR TITLE
Enable out-of-order-load by default

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -765,7 +765,6 @@ The statement has no effect. Consider removing it or storing its result in a var
 
   * Category name: `out-of-order-load`
   * Automatic fix: yes
-  * [Disabled by default](buildifier/README.md#linter)
   * [Suppress the warning](#suppress): `# buildifier: disable=out-of-order-load`
 
 Load statements should be ordered by their first argument - extension file label.

--- a/buildifier/config/config_test.go
+++ b/buildifier/config/config_test.go
@@ -335,7 +335,7 @@ func TestValidate(t *testing.T) {
 			// "native-proto",
 			// "native-py",
 			"no-effect",
-			// "out-of-order-load",
+			"out-of-order-load",
 			"output-group",
 			"overly-nested-depset",
 			"package-name",
@@ -357,7 +357,7 @@ func TestValidate(t *testing.T) {
 			// "unsorted-dict-items",
 			"unused-variable",
 		}},
-		"warnings plus/minus": {options: "--warnings=+out-of-order-load,-print,-deprecated-function", wantWarnings: []string{
+		"warnings plus/minus": {options: "--warnings=+native-cc,-print,-deprecated-function", wantWarnings: []string{
 			"attr-applicable_licenses",
 			"attr-cfg",
 			"attr-license",
@@ -394,12 +394,12 @@ func TestValidate(t *testing.T) {
 			"name-conventions",
 			// "native-android",
 			"native-build",
-			// "native-cc",
 			// "native-java",
 			"native-package",
 			// "native-proto",
 			// "native-py",
 			"no-effect",
+			"out-of-order-load",
 			"output-group",
 			"overly-nested-depset",
 			"package-name",
@@ -420,9 +420,9 @@ func TestValidate(t *testing.T) {
 			"unreachable",
 			// "unsorted-dict-items",
 			"unused-variable",
-			"out-of-order-load",
+			"native-cc",
 		}},
-		"warnings error": {options: "--warnings=out-of-order-load,-print,-deprecated-function", wantErr: fmt.Errorf(`warning categories with modifiers ("+" or "-") can't be mixed with raw warning categories`)},
+		"warnings error": {options: "--warnings=native-cc,-print,-deprecated-function", wantErr: fmt.Errorf(`warning categories with modifiers ("+" or "-") can't be mixed with raw warning categories`)},
 	} {
 		t.Run(name, func(t *testing.T) {
 			c := New()

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -187,7 +187,6 @@ var MultiFileWarningMap = map[string]func(f *build.File, fileReader *FileReader)
 // nonDefaultWarnings contains warnings that are enabled by default because they're not applicable
 // for all files and cause too much diff noise when applied.
 var nonDefaultWarnings = map[string]bool{
-	"out-of-order-load":   true, // load statements should be sorted by their labels
 	"unsorted-dict-items": true, // dict items should be sorted
 	"native-android":      true, // disables native android rules
 	"native-cc":           true, // disables native cc rules


### PR DESCRIPTION
I couldn't find any info to why this one wasn't enabled by default already, it seems like a nice organizational rule that can help reduce conflicts when adding and removing loads in high traffic bzl files