### PR TITLE
go_default_library should not be a go_proto_library

### DIFF
--- a/build_proto/BUILD.bazel
+++ b/build_proto/BUILD.bazel
@@ -19,7 +19,7 @@ proto_library(
 )
 
 go_proto_library(
-    name = "go_default_library",
+    name = "build_proto_go_proto",
     importpath = "github.com/bazelbuild/buildtools/build_proto",
     proto = ":blaze_query_proto",
     visibility = ["//visibility:public"],
@@ -27,7 +27,13 @@ go_proto_library(
 
 go_library(
     name = "build_proto",
-    embed = [":go_default_library"],
+    embed = [":build_proto_go_proto"],
     importpath = "github.com/bazelbuild/buildtools/build_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":build_proto",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
naming this: https://github.com/bazelbuild/buildtools/blob/master/build_proto/BUILD.bazel#L22 `go_default_library` is causing issues:
```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
link: package conflict error: github.com/bazelbuild/buildtools/lang: package imports github.com/bazelbuild/buildtools/build_proto
          was compiled with: @@gazelle~override~go_deps~com_github_bazelbuild_buildtools//build_proto:build_proto
        but was linked with: @@gazelle~override~go_deps~com_github_bazelbuild_buildtools//build_proto:go_default_library
See https://github.com/bazelbuild/rules_go/issues/1877.
```

We should not be calling a `go_proto_library(` `go_default_library` because it prevents adding the alias. See the `api_proto` file as an example: https://github.com/bazelbuild/buildtools/blob/master/api_proto/BUILD.bazel 