### PR TITLE
Compare load paths as paths instead of just strings

### DIFF
--- a/buildifier/npm/BUILD.bazel
+++ b/buildifier/npm/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test", "pkg_npm")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test", "pkg_npm")
 
 copy_file(
     name = "copy_LICENSE",

--- a/buildozer/npm/BUILD.bazel
+++ b/buildozer/npm/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test", "pkg_npm")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test", "pkg_npm")
 load("@buildozer_npm_deps//typescript:index.bzl", "tsc")
 
 copy_file(

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -120,8 +120,8 @@ func packageOnTopWarning(f *build.File) []*LinterFinding {
 			}
 			return []*LinterFinding{makeLinterFinding(rule.Call,
 				"Package declaration should be at the top of the file, after the load() statements, "+
-					"but before any call to a rule or a macro. "+
-					"package_group() and licenses() may be called before package().")}
+						"but before any call to a rule or a macro. "+
+						"package_group() and licenses() may be called before package().")}
 		}
 		seenRule = true
 	}
@@ -194,16 +194,23 @@ func loadOnTopWarning(f *build.File) []*LinterFinding {
 // comparePaths compares two strings as if they were paths (the path delimiter,
 // '/', should be treated as smallest symbol).
 func comparePaths(path1, path2 string) bool {
+	if path1 == path2 {
+		return false
+	}
+
 	chunks1 := strings.Split(path1, "/")
 	chunks2 := strings.Split(path2, "/")
 
-	for i := 0; i <= len(chunks1) && i <= len(chunks2); i++ {
-		if chunks1[i] != chunks2[i] {
-			return chunks1[i] < chunks2[i]
+	for i, chunk1 := range chunks1 {
+		if i >= len(chunks2) {
+			return false
+		}
+		chunk2 := chunks2[i]
+		if chunk1 != chunk2 {
+			return chunk1 < chunk2
 		}
 	}
-	return len(chunks1) < len(chunks2)
-
+	return true
 }
 
 // compareLoadLabels compares two module names

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -21,7 +21,6 @@ package warn
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"sort"
 	"strings"
 
@@ -197,7 +196,13 @@ func loadOnTopWarning(f *build.File) []*LinterFinding {
 func comparePaths(path1, path2 string) bool {
 	chunks1 := strings.Split(path1, "/")
 	chunks2 := strings.Split(path2, "/")
-	return slices.Compare(chunks1, chunks2)
+
+	for i := 0; i <= len(chunks1) && i <= len(chunks2); i++ {
+		if chunks1[i] != chunks2[i] {
+			return chunks1[i] < chunks2[i]
+		}
+	}
+	return len(chunks1) < len(chunks2)
 
 }
 

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -277,11 +277,15 @@ load(":a.bzl", "a")`,
 		[]string{}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
-load("//foo:xyz.bzl", "xyz")
-load("//foo/bar:mno.bzl", "mno")
+load("//foo-bar:xyz.bzl", "xyz")
+load("//foo/bar/baz/mno.bzl", "mno")
+load("//foo/bar-baz:mno/prs.bzl", "prs")
+load("//foo/bar-baz:mno-prs.bzl", "prs")
 `, `
 load("//foo:xyz.bzl", "xyz")
-load("//foo/bar:mno.bzl", "mno")`,
+load("//foo/bar/baz/mno.bzl", "mno")
+load("//foo/bar-baz:mno/prs.bzl", "prs")
+load("//foo/bar-baz:mno-prs.bzl", "prs")`,
 		[]string{}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -278,15 +278,17 @@ load(":a.bzl", "a")`,
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 load("//foo-bar:xyz.bzl", "xyz")
-load("//foo/bar/baz/mno.bzl", "mno")
+load("//foo/bar:baz/mno.bzl", "mno")
 load("//foo/bar-baz:mno/prs.bzl", "prs")
 load("//foo/bar-baz:mno-prs.bzl", "prs")
 `, `
-load("//foo:xyz.bzl", "xyz")
-load("//foo/bar/baz/mno.bzl", "mno")
+load("//foo/bar:baz/mno.bzl", "mno")
 load("//foo/bar-baz:mno/prs.bzl", "prs")
-load("//foo/bar-baz:mno-prs.bzl", "prs")`,
-		[]string{}, scopeEverywhere)
+load("//foo/bar-baz:mno-prs.bzl", "prs")
+load("//foo-bar:xyz.bzl", "xyz")`,
+		[]string{
+			"2: Load statement is out of its lexicographical order.",
+		}, scopeEverywhere)
 
 	checkFindingsAndFix(t, "out-of-order-load", `
 load("//foo:xyz.bzl", "xyz")


### PR DESCRIPTION
Paths like "abc/def" should precede "abc-def" (although `-` is smaller than `/` in ASCII).