### PR TITLE
buildifier: fix uninitialised check when using list unpack assignment

### DIFF
--- a/bzlenv/bzlenv.go
+++ b/bzlenv/bzlenv.go
@@ -148,6 +148,10 @@ func CollectLValues(node build.Expr) []*build.Ident {
 		for _, item := range node.List {
 			result = append(result, CollectLValues(item)...)
 		}
+	case *build.ListExpr:
+		for _, item := range node.List {
+			result = append(result, CollectLValues(item)...)
+		}
 	}
 	return result
 }

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -1284,4 +1284,13 @@ def foo():
 `,
 		[]string{},
 		scopeEverywhere)
+
+	checkFindings(t, "uninitialized", `
+def foo():
+  [x, y] = [1, 2]
+  x = 3
+  print(x)
+`,
+		[]string{},
+		scopeEverywhere)
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/buildtools/issues/1201

As the test added in this commit shows, prior to this commit, the uninitialized check would incorrectly fail when using list unpack assignment, if the same variable is reused later.

This modifies `CollectLValues`, so that it supports list unpack assignments (in addition to tuple, and normal assignments).

Please let me know if there's anything that needs to be added/modified in this change, thanks! 🙏 