### PR TITLE
Disable Bzlmod explicitly in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,3 +8,7 @@ build:release -c opt --stamp --workspace_status_command="$PWD/status.py"
 # *last* statement in the root configuration file, as the local configuration
 # file should be able to overwrite flags from the root configuration.
 try-import %workspace%/.bazelrc.user
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/buildtools/issues/1204
+common --noenable_bzlmod

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,2 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/buildtools/issues/1204


### PR DESCRIPTION
This will help make sure [Bazel Downstream Pipeline](https://github.com/bazelbuild/continuous-integration/blob/master/docs/downstream-testing.md) is green after enabling Bzlmod at Bazel@HEAD

See https://github.com/bazelbuild/bazel/issues/18958#issuecomment-1749058780

Related https://github.com/bazelbuild/buildtools/issues/1204