### PR TITLE
Fix package-on-top warning

### DIFF
--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -102,7 +102,7 @@ func sameOriginLoadWarning(f *build.File) []*LinterFinding {
 	return findings
 }
 
-// packageOnTopWarning hoists package statements to the top after any comments / docstrings / load statments.
+// packageOnTopWarning hoists package statements to the top after any comments / docstrings / load statements.
 // If applied together with loadOnTopWarning and/or outOfOrderLoadWarning, it should be applied after them.
 // This is currently guaranteed by sorting the warning categories names before applying them:
 // "load-on-top" < "out-of-order-load" < "package-on-top"
@@ -120,7 +120,9 @@ func packageOnTopWarning(f *build.File) []*LinterFinding {
 		_, isString := stmt.(*build.StringExpr) // typically a docstring
 		_, isComment := stmt.(*build.CommentBlock)
 		_, isLoad := stmt.(*build.LoadStmt)
-		if isString || isComment || isLoad || stmt == nil {
+		_, isLicense := edit.ExprToRule(stmt, "license")
+		_, isPackageGroup := edit.ExprToRule(stmt, "package_group")
+		if isString || isComment || isLoad || || isLicense || isPackageGroup || stmt == nil {
 			continue
 		}
 		rule, ok := edit.ExprToRule(stmt, "package")

--- a/warn/warn_cosmetic.go
+++ b/warn/warn_cosmetic.go
@@ -120,9 +120,9 @@ func packageOnTopWarning(f *build.File) []*LinterFinding {
 		_, isString := stmt.(*build.StringExpr) // typically a docstring
 		_, isComment := stmt.(*build.CommentBlock)
 		_, isLoad := stmt.(*build.LoadStmt)
-		_, isLicense := edit.ExprToRule(stmt, "license")
+		_, isLicenses := edit.ExprToRule(stmt, "licenses")
 		_, isPackageGroup := edit.ExprToRule(stmt, "package_group")
-		if isString || isComment || isLoad || || isLicense || isPackageGroup || stmt == nil {
+		if isString || isComment || isLoad || isLicenses || isPackageGroup || stmt == nil {
 			continue
 		}
 		rule, ok := edit.ExprToRule(stmt, "package")

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -167,11 +167,8 @@ load(":foo.bzl", "foo")
 load(":bar.bzl", baz = "bar")
 
 package_group(name = "my_group")
-
 licenses(["my_license"])
-
 foo(baz)
-
 package()`,
 		`
 # Some comments
@@ -182,13 +179,11 @@ load(":foo.bzl", "foo")
 load(":bar.bzl", baz = "bar")
 
 package_group(name = "my_group")
-
 licenses(["my_license"])
 
 package()
-
 foo(baz)`,
-		[]string{":14: Package declaration should be at the top of the file, after the load() statements, but before any call to a rule or a macro. package_group() and licenses() may be called before package()."},
+		[]string{":11: Package declaration should be at the top of the file, after the load() statements, but before any call to a rule or a macro. package_group() and licenses() may be called before package()."},
 		scopeDefault|scopeBzl|scopeBuild)
 }
 

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -155,6 +155,41 @@ package()
 foo(baz)`,
 		[]string{},
 		scopeDefault|scopeBzl|scopeBuild)
+
+	checkFindingsAndFix(t,
+		"package-on-top",
+		`
+# Some comments
+
+"""This is a docstring"""
+
+load(":foo.bzl", "foo")
+load(":bar.bzl", baz = "bar")
+
+package_group(name = "my_group")
+
+licenses(["my_license"])
+
+foo(baz)
+
+package()`,
+		`
+# Some comments
+
+"""This is a docstring"""
+
+load(":foo.bzl", "foo")
+load(":bar.bzl", baz = "bar")
+
+package_group(name = "my_group")
+
+licenses(["my_license"])
+
+package()
+
+foo(baz)`,
+		[]string{":14: Package declaration should be at the top of the file, after the load() statements, but before any call to a rule or a macro. package_group() and licenses() may be called before package()."},
+		scopeDefault|scopeBzl|scopeBuild)
 }
 
 func TestLoadOnTop(t *testing.T) {


### PR DESCRIPTION
Allow `licenses()` and `package_group()` statements appear before `package()` (like it's been implemented before).