### PR TITLE
Fix false positive warnings for package on top

### DIFF
--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -212,6 +212,33 @@ foo()
 package(default_visibility = VISIBILITY)`,
 		[]string{},
 		scopeDefault|scopeBzl|scopeBuild)
+
+	checkFindingsAndFix(t,
+		"package-on-top",
+		`
+"""This is a docstring"""
+
+load(":foo.bzl", "foo")
+load(":bar.bzl", baz = "bar")
+
+irrelevant = baz
+
+foo()
+
+package()`,
+		`
+"""This is a docstring"""
+
+load(":foo.bzl", "foo")
+load(":bar.bzl", baz = "bar")
+
+irrelevant = baz
+
+foo()
+
+package()`,
+		[]string{},
+		scopeDefault|scopeBzl|scopeBuild)
 }
 
 func TestLoadOnTop(t *testing.T) {

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -185,6 +185,33 @@ package()
 foo(baz)`,
 		[]string{":11: Package declaration should be at the top of the file, after the load() statements, but before any call to a rule or a macro. package_group() and licenses() may be called before package()."},
 		scopeDefault|scopeBzl|scopeBuild)
+
+	checkFindingsAndFix(t,
+		"package-on-top",
+		`
+"""This is a docstring"""
+
+load(":foo.bzl", "foo")
+load(":bar.bzl", baz = "bar")
+
+VISIBILITY = baz
+
+foo()
+
+package(default_visibility = VISIBILITY)`,
+		`
+"""This is a docstring"""
+
+load(":foo.bzl", "foo")
+load(":bar.bzl", baz = "bar")
+
+VISIBILITY = baz
+
+foo()
+
+package(default_visibility = VISIBILITY)`,
+		[]string{},
+		scopeDefault|scopeBzl|scopeBuild)
 }
 
 func TestLoadOnTop(t *testing.T) {


### PR DESCRIPTION
A package declaration may be not at the top of the file if it depends on some variables defined earlier:

    VISIBILITY = [...]

    package(
        ...
        default_visibility = VISIBILITY,
    )

This dependance may also be indirect and it may be hard to determine whether the package declaration can safely be moved on top, and, if so, together with which assignment expressions. To avoid false positive warnings, with this buildifier will just suppress package-on-top warnings in case there's any assignment expression above package declarations. If the visibility scope in the example above has been loaded from another file it wouldn't have cause a similar issue because load statements come before package declarations by design (which is also enforced by other warnings) and loaded symbols are frozen and can't be mutated in the current file by other types of statements (non-assignment statements, e.g. `VISIBILITY.append("bar")` to modify the visibility before using it in the package declaration is not valid anyway).