### PR TITLE
Properly handle default_package_metadata attribute.

### DIFF
--- a/generatetables/generate_tables.go
+++ b/generatetables/generate_tables.go
@@ -74,7 +74,8 @@ func generateTable(rules []*buildpb.RuleDefinition) map[string]buildpb.Attribute
 	types["default_copts"] = types["copts"]
 	types["default_deprecation"] = types["deprecation"]
 	types["default_testonly"] = types["testonly"]
-	types["default_applicable_licenses"] = types["applicable_licenses"]
+	types["default_applicable_licenses"] = buildpb.Attribute_LABEL_LIST
+	types["default_package_metadata"] = buildpb.Attribute_LABEL_LIST
 	types["features"] = buildpb.Attribute_STRING_LIST
 
 	types["extra_srcs"] = types["srcs"]

--- a/generatetables/generate_tables.go
+++ b/generatetables/generate_tables.go
@@ -81,6 +81,12 @@ func generateTable(rules []*buildpb.RuleDefinition) map[string]buildpb.Attribute
 	types["extra_srcs"] = types["srcs"]
 	types["pytype_deps"] = types["deps"]
 
+	// Make sure we always have this.
+	_, ok := types["package_metadata"]
+	if ! ok {
+		types["package_metadata"] = buildpb.Attribute_LABEL_LIST
+	}
+
 	return types
 }
 

--- a/lang/tables.gen.go
+++ b/lang/tables.gen.go
@@ -326,6 +326,7 @@ var TypeOf = map[string]buildpb.Attribute_Discriminator{
 	"output_to_bindir":	buildpb.Attribute_BOOLEAN,
 	"outs":	buildpb.Attribute_STRING_LIST,
 	"package_configuration":	buildpb.Attribute_LABEL_LIST,
+	"package_metadata":	buildpb.Attribute_LABEL_LIST,
 	"packages":	buildpb.Attribute_LABEL_LIST,
 	"parents":	buildpb.Attribute_LABEL_LIST,
 	"path":	buildpb.Attribute_STRING,

--- a/lang/tables.gen.go
+++ b/lang/tables.gen.go
@@ -187,6 +187,7 @@ var TypeOf = map[string]buildpb.Attribute_Discriminator{
 	"default_hdrs_check":	buildpb.Attribute_STRING,
 	"default_ios_sdk_version":	buildpb.Attribute_STRING,
 	"default_macos_sdk_version":	buildpb.Attribute_STRING,
+	"default_package_metadata":	buildpb.Attribute_LABEL_LIST,
 	"default_properties":	buildpb.Attribute_LABEL,
 	"default_testonly":	buildpb.Attribute_BOOLEAN,
 	"default_tvos_sdk_version":	buildpb.Attribute_STRING,


### PR DESCRIPTION
Update buildozer to account for the renaming the global attribute `applicable_licenses` to `package_metadata`.

The previous code assumed that `applicable_licenses` existed, and used it to set the type for `default_applicable_licenses`.  Now we simply assume that `default_applicable_licenses` and `default_package_metadata` are label lists.