### PR TITLE
Cover missing cases during module extension label normalization

### DIFF
--- a/edit/bzlmod/BUILD.bazel
+++ b/edit/bzlmod/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["bzlmod.go"],
     importpath = "github.com/bazelbuild/buildtools/edit/bzlmod",
     visibility = ["//visibility:public"],
-    deps = ["//build"],
+    deps = [
+        "//build",
+        "//labels",
+    ],
 )
 
 go_test(

--- a/edit/bzlmod/bzlmod.go
+++ b/edit/bzlmod/bzlmod.go
@@ -18,9 +18,8 @@ limitations under the License.
 package bzlmod
 
 import (
-	"strings"
-
 	"github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/buildtools/labels"
 )
 
 // Proxies returns the names of extension proxies (i.e. the names of variables to which the result
@@ -225,19 +224,18 @@ func getApparentModuleName(f *build.File) string {
 
 // normalizeLabelString converts a label string into the form @apparent_name//path/to:target.
 func normalizeLabelString(rawLabel, apparentModuleName string) string {
-	// This implements
-	// https://github.com/bazelbuild/bazel/blob/dd822392db96bb7bccdb673414a20c4b91e3dbc1/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java#L416
-	// with the assumption that the current module is the root module.
-	if strings.HasPrefix(rawLabel, "//") {
-		// Relative labels always refer to the current module.
-		return "@" + apparentModuleName + rawLabel
-	} else if strings.HasPrefix(rawLabel, "@//") {
-		// In the root module only, this syntax refer to the module. Since we are inspecting its
-		// module file as a tool, we can assume that the current module is the root module.
-		return "@" + apparentModuleName + rawLabel[1:]
-	} else {
-		return rawLabel
+	label := labels.ParseRelative(rawLabel, "")
+	if label.Repository == "" {
+		// This branch is taken in two different cases:
+		// 1. The label is relative. In this case, labels.ParseRelative populates the Package field
+		//    but not the Repository field.
+		// 2. The label is of the form "@//pkg:extension.bzl". Normalize to spelling out the
+		//    apparent name of the root module. Note that this syntax is only allowed in the root
+		//    module, but since we are inspecting its module file as a tool, we can assume that the
+		//    current module is the root module.
+		label.Repository = apparentModuleName
 	}
+	return label.Format()
 }
 
 func parseUseExtension(stmt build.Expr) (proxy string, bzlFile string, name string, dev bool, isolate bool) {

--- a/edit/bzlmod/bzlmod_test.go
+++ b/edit/bzlmod/bzlmod_test.go
@@ -66,6 +66,9 @@ prox9 = use_extension(
 prox9.use(label = "@name//:bar")
 prox10 = use_extension("@dep//:extensions.bzl", "other_ext", dev_dependency = bool(1))
 prox10.use(dict = {"foo": "bar"})
+prox11 = use_extension("extension.bzl", "ext")
+prox12 = use_extension(":extension.bzl", "ext")
+prox13 = use_extension("//:extension.bzl", "ext")
 `
 
 func TestProxies(t *testing.T) {
@@ -138,6 +141,13 @@ func TestProxies(t *testing.T) {
 			"other_ext",
 			true,
 			[]string{"prox10"},
+		},
+		{
+			proxiesModuleRepoNameHeader + proxiesBody,
+			[]string{"//:extension.bzl", "@//:extension.bzl"},
+			"ext",
+			false,
+			[]string{"prox11", "prox12", "prox13"},
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
The previous logic missed to normalize cases such as "extension.bzl" and ":extension.bzl". Instead of enumerating cases, parse the label and track it in canonical form.