### PR TITLE
MODULE.bazel should be a marker of the root of the repo

### DIFF
--- a/wspace/workspace.go
+++ b/wspace/workspace.go
@@ -55,6 +55,7 @@ func isExecutable(fi os.FileInfo) bool {
 var repoRootFiles = map[string]func(os.FileInfo) bool{
 	workspaceFile:            isFile,
 	workspaceFile + ".bazel": isFile,
+	"MODULE.bazel":           isFile,
 	".buckconfig":            isFile,
 	"pants":                  isExecutable,
 }

--- a/wspace/workspace_test.go
+++ b/wspace/workspace_test.go
@@ -62,6 +62,7 @@ func runBasicTestWithRepoRootFile(t *testing.T, repoRootFile string) {
 func TestBasic(t *testing.T) {
 	runBasicTestWithRepoRootFile(t, ".buckconfig")
 	runBasicTestWithRepoRootFile(t, workspaceFile)
+	runBasicTestWithRepoRootFile(t, "MODULE.bazel")
 }
 
 func TestFindRepoBuildfiles(t *testing.T) {


### PR DESCRIPTION
When converting over to bzlmod and not having a `WORKSPACE` file in the root of the repo anymore

```
buildifier 'print label' //python/...:%py_library
```

Will return only the label name. e.g `//:some_target` instead of `//nested:some_target` or where ever it should be relative to root.