### PR TITLE
constant-glob validates named include argument

### DIFF
--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -45,7 +45,7 @@ func constantGlobPatternWarning(patterns *build.ListExpr) []*LinterFinding {
 			message := fmt.Sprintf(
 				`Glob pattern %q has no wildcard ('*'). Constant patterns can be error-prone, move the file outside the glob.`, str.Value)
 			findings = append(findings, makeLinterFinding(expr, message))
-			break // at most one warning per glob
+			return findings // at most one warning per glob
 		}
 	}
 	return findings
@@ -69,10 +69,10 @@ func constantGlobWarning(f *build.File) []*LinterFinding {
 		if !ok || ident.Name != "glob" {
 			return
 		}
-		arg, ok := call.List[0].(*build.ListExpr)
+		patterns, ok := call.List[0].(*build.ListExpr)
 		if ok {
 			// first arg is unnamed and is a list
-			findings = constantGlobPatternWarning(arg)
+			findings = constantGlobPatternWarning(patterns)
 			return // at most one warning per glob
 		}
 

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -54,12 +54,12 @@ func constantGlobWarning(f *build.File) []*LinterFinding {
 		}
 
 		for _, arg := range call.List {
-			assign_expr, ok := arg.(*build.AssignExpr)
 			var patterns *build.ListExpr
 			var pattern_ok bool
+			assign_expr, ok := arg.(*build.AssignExpr)
 			if ok {
 				str, ok := assign_expr.LHS.(*build.Ident)
-				if ok && str.Name != "include" {
+				if !ok || str.Name != "include" {
 					// only validate include; it's reasonable to have constant exclude
 					continue
 				}

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -72,7 +72,7 @@ func constantGlobWarning(f *build.File) []*LinterFinding {
 		patterns, ok := call.List[0].(*build.ListExpr)
 		if ok {
 			// first arg is unnamed and is a list
-			findings = constantGlobPatternWarning(patterns)
+			findings = append(findings, constantGlobPatternWarning(patterns)...)
 			return // at most one warning per glob
 		}
 
@@ -88,7 +88,7 @@ func constantGlobWarning(f *build.File) []*LinterFinding {
 			}
 			patterns, ok := assign_expr.RHS.(*build.ListExpr)
 			if ok {
-				findings = constantGlobPatternWarning(patterns)
+				findings = append(findings, constantGlobPatternWarning(patterns)...)
 				return // at most one warning per glob
 			}
 		}

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -34,6 +34,23 @@ var functionsWithPositionalArguments = map[string]bool{
 	"vardef":              true,
 }
 
+func constantGlobPatternWarning(patterns *build.ListExpr) []*LinterFinding {
+	findings := []*LinterFinding{}
+	for _, expr := range patterns.List {
+		str, ok := expr.(*build.StringExpr)
+		if !ok {
+			continue
+		}
+		if !strings.Contains(str.Value, "*") {
+			message := fmt.Sprintf(
+				`Glob pattern %q has no wildcard ('*'). Constant patterns can be error-prone, move the file outside the glob.`, str.Value)
+			findings = append(findings, makeLinterFinding(expr, message))
+			break // at most one warning per glob
+		}
+	}
+	return findings
+}
+
 func constantGlobWarning(f *build.File) []*LinterFinding {
 	switch f.Type {
 	case build.TypeBuild, build.TypeWorkspace, build.TypeBzl:
@@ -52,36 +69,27 @@ func constantGlobWarning(f *build.File) []*LinterFinding {
 		if !ok || ident.Name != "glob" {
 			return
 		}
+		arg, ok := call.List[0].(*build.ListExpr)
+		if ok {
+			// first arg is unnamed and is a list
+			findings = constantGlobPatternWarning(arg)
+			return // at most one warning per glob
+		}
 
+		// look for named args called include
 		for _, arg := range call.List {
-			var patterns *build.ListExpr
-			var pattern_ok bool
 			assign_expr, ok := arg.(*build.AssignExpr)
-			if ok {
-				str, ok := assign_expr.LHS.(*build.Ident)
-				if !ok || str.Name != "include" {
-					// only validate include; it's reasonable to have constant exclude
-					continue
-				}
-				patterns, pattern_ok = assign_expr.RHS.(*build.ListExpr)
-			} else {
-				patterns, pattern_ok = arg.(*build.ListExpr)
-			}
-			if !pattern_ok {
-				// patterns isn't a list
+			if !ok {
 				continue
 			}
-			for _, expr := range patterns.List {
-				str, ok := expr.(*build.StringExpr)
-				if !ok {
-					continue
-				}
-				if !strings.Contains(str.Value, "*") {
-					message := fmt.Sprintf(
-						`Glob pattern %q has no wildcard ('*'). Constant patterns can be error-prone, move the file outside the glob.`, str.Value)
-					findings = append(findings, makeLinterFinding(expr, message))
-					return // at most one warning per glob
-				}
+			str, ok := assign_expr.LHS.(*build.Ident)
+			if !ok || str.Name != "include" {
+				continue
+			}
+			patterns, ok := assign_expr.RHS.(*build.ListExpr)
+			if ok {
+				findings = constantGlobPatternWarning(patterns)
+				return // at most one warning per glob
 			}
 		}
 	})

--- a/warn/warn_bazel_test.go
+++ b/warn/warn_bazel_test.go
@@ -21,15 +21,24 @@ import "testing"
 func TestConstantGlob(t *testing.T) {
 	checkFindings(t, "constant-glob", `
 cc_library(srcs = glob(["foo.cc"]))
-cc_library(srcs = glob(["*.cc"]))
+cc_library(srcs = glob(include = ["foo.cc"]))
+cc_library(srcs = glob(include = ["foo.cc"], exclude = ["bar.cc"]))
+cc_library(srcs = glob(exclude = ["bar.cc"], include = ["foo.cc"]))
 cc_library(srcs =
-  ["constant"] + glob([
-    "*.cc",
-    "test.cpp",
-  ])
-)`,
+	["constant"] + glob([
+		"*.cc",
+		"test.cpp",
+		])
+	)
+cc_library(srcs = glob(["*.cc"]))
+cc_library(srcs = glob(["*.cc"], exclude = ["bar.cc"]))
+cc_library(srcs = glob(include = ["*.cc"], exclude = ["bar.cc"]))
+cc_library(srcs = glob(exclude = ["bar.cc"], include = ["*.cc"]))`,
 		[]string{`:1: Glob pattern "foo.cc" has no wildcard`,
-			`:6: Glob pattern "test.cpp" has no wildcard`},
+			`:2: Glob pattern "foo.cc" has no wildcard`,
+			`:3: Glob pattern "foo.cc" has no wildcard`,
+			`:4: Glob pattern "foo.cc" has no wildcard`,
+			`:8: Glob pattern "test.cpp" has no wildcard`},
 		scopeBuild|scopeBzl|scopeWorkspace)
 }
 


### PR DESCRIPTION
Fixes #1256.

Previously: constant-glob failed to warn when using named argument `include` with a constant pattern.

Now: constant-glob warns when using named argument `include` with a constant pattern or when the first unnamed argument uses a constant pattern.
