### PR TITLE
Reference runner.bat with local workspace path

### DIFF
--- a/buildifier/internal/factory.bzl
+++ b/buildifier/internal/factory.bzl
@@ -80,7 +80,7 @@ def buildifier_attr_factory(test_rule = False):
             allow_single_file = True,
         ),
         "_windows_runner": attr.label(
-            default = "@com_github_bazelbuild_buildtools//buildifier:runner.bat.template",
+            default = "//buildifier:runner.bat.template",
             allow_single_file = True,
         ),
     }


### PR DESCRIPTION
This matches with how the corresponding runner.bash.template is referenced.

This should fix #1259 
