### PR TITLE
Stop testing the ability to set `licenses` and `distribs` in `package()`

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1007,26 +1007,6 @@ function test_set_int() {
 )'
 }
 
-function test_set_licenses() {
-  in='cc_test(name = "a")'
-
-  run "$in" 'set licenses foo' '//pkg:a'
-  assert_equals 'cc_test(
-    name = "a",
-    licenses = ["foo"],
-)'
-}
-
-function test_set_distribs() {
-  in='cc_test(name = "a")'
-
-  run "$in" 'set distribs foo' '//pkg:a'
-  assert_equals 'cc_test(
-    name = "a",
-    distribs = ["foo"],
-)'
-}
-
 function test_set_if_absent_absent() {
   in='soy_js(name = "a")'
 

--- a/warn/warn_bazel.go
+++ b/warn/warn_bazel.go
@@ -26,7 +26,6 @@ import (
 )
 
 var functionsWithPositionalArguments = map[string]bool{
-	"distribs":            true,
 	"exports_files":       true,
 	"licenses":            true,
 	"print":               true,


### PR DESCRIPTION
Stop testing the ability to set `licenses` and `distribs` in the `package()` function.

The `distribs` and `licenses` features are being removed from Bazel. Both are obsolete in the `package()` rule.
`distribs` as a top level function will be removed in a near release of Bazel.
`licenses` in `package()` may soon become a no-op.