### PR TITLE
Do not declare bash output on windows

### DIFF
--- a/buildifier/internal/factory.bzl
+++ b/buildifier/internal/factory.bzl
@@ -168,8 +168,6 @@ def buildifier_impl_factory(ctx, test_rule = False):
             fail("Cannot use 'no_sandbox' without a 'workspace'")
         workspace = ctx.file.workspace.path
 
-    out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
-
     substitutions = {
         "@@ARGS@@": shell.array_literal(args),
         "@@BUILDIFIER_SHORT_PATH@@": shell.quote(ctx.executable.buildifier.short_path),


### PR DESCRIPTION
Calling declare_file on windows even if later is overwritten is a problem in windows genereting the following error
```
The following files have no generating action:
buildifier.bash
```