### PR TITLE
Fix crash when MODULE.bazel has `foo = bar.baz()`

### DIFF
--- a/edit/bzlmod/bzlmod.go
+++ b/edit/bzlmod/bzlmod.go
@@ -252,6 +252,9 @@ func parseUseExtension(stmt build.Expr) (proxy string, bzlFile string, name stri
 		return
 	}
 	call := assign.RHS.(*build.CallExpr)
+	if _, ok = call.X.(*build.Ident); !ok {
+		return
+	}
 	if call.X.(*build.Ident).Name != "use_extension" {
 		return
 	}

--- a/edit/bzlmod/bzlmod_test.go
+++ b/edit/bzlmod/bzlmod_test.go
@@ -59,7 +59,7 @@ prox7.use(label = "@foo//:bar")
 isolated_prox4 = use_extension("@name//bzl:extensions.bzl", "ext", isolate = True)
 isolated_prox4.use(name = "foo")
 prox8 = use_extension("//bzl:extensions.bzl", "ext", dev_dependency = True)
-prox8.use(dict = {"foo": "bar"})
+unused = prox8.use(dict = {"foo": "bar"})
 prox9 = use_extension(
     # comment
     "@dep//:extensions.bzl", "other_ext")


### PR DESCRIPTION
Such assignments don't do anything, but we shouldn't crash on them.

Context: https://bazelbuild.slack.com/archives/C014RARENH0/p1712945309438879