### PR TITLE
Add support for `*.MODULE.bazel` files

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -42,7 +42,7 @@ const (
 	TypeWorkspace
 	// TypeBzl represents .bzl files
 	TypeBzl
-	//TypeModule represents MODULE.bazel files
+	//TypeModule represents MODULE.bazel and *.MODULE.bazel files
 	TypeModule
 )
 
@@ -130,7 +130,7 @@ func getFileType(filename string) FileType {
 	if strings.HasSuffix(basename, ".oss") {
 		basename = basename[:len(basename)-4]
 	}
-	if basename == "module.bazel" {
+	if basename == "module.bazel" || strings.HasSuffix(basename, ".module.bazel") {
 		return TypeModule
 	}
 	ext := filepath.Ext(basename)

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -2038,6 +2038,36 @@ EOF
   diff -u MODULE.bazel.expected MODULE.bazel || fail "Output didn't match"
 }
 
+function test_module_bazel_segment() {
+  cat > go.MODULE.bazel <<EOF
+module(
+    name = "foo",
+    version = "0.27.0",
+)
+
+bazel_dep(name = "gazelle", version = "0.30.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(go_deps, "com_example_foo")
+EOF
+
+  cat > go.MODULE.bazel.expected <<EOF
+module(
+    name = "foo",
+    version = "0.27.0",
+)
+
+bazel_dep(name = "gazelle", version = "0.30.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+EOF
+
+  $buildozer 'delete' //go.MODULE.bazel:%10
+  diff -u go.MODULE.bazel.expected go.MODULE.bazel || fail "Output didn't match"
+}
+
 function test_module_bazel_new() {
   cat > MODULE.bazel <<EOF
 bazel_dep(name = "gazelle", version = "0.30.0")


### PR DESCRIPTION
After https://github.com/bazelbuild/bazel/pull/22075, these are the files that can be `include()`ed into `MODULE.bazel` files and should be formatted and edited just like them.

Work towards bazelbuild/bazel#22063