### PR TITLE
Ensure that `buildifier`'s `add_tables` attribute is in the runfiles

### DIFF
--- a/buildifier/internal/factory.bzl
+++ b/buildifier/internal/factory.bzl
@@ -190,6 +190,8 @@ def buildifier_impl_factory(ctx, test_rule = False):
     )
 
     runfiles = [ctx.executable.buildifier]
+    if ctx.attr.add_tables:
+        runfiles.append(ctx.file.add_tables)
     if test_rule:
         runfiles.extend(ctx.files.srcs)
         if ctx.attr.no_sandbox:


### PR DESCRIPTION
Without this, if the `add_tables` value is the output of another rule, it won't be available to `buildifier`.