### PR TITLE
Replace usage deprecated io/iotil

### DIFF
--- a/build/checkfile_test.go
+++ b/build/checkfile_test.go
@@ -18,7 +18,6 @@ package build
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -29,7 +28,7 @@ import (
 func TestFilesMatch(t *testing.T) {
 	testdata := path.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), "build")
 
-	generated, err := ioutil.ReadFile(path.Join(testdata, "parse.y.baz.go"))
+	generated, err := os.ReadFile(path.Join(testdata, "parse.y.baz.go"))
 	if err != nil {
 		t.Fatalf("ReadFile(%q) = %v", "parse.y.baz.go", err)
 	}
@@ -38,7 +37,7 @@ func TestFilesMatch(t *testing.T) {
 	// robust.
 	generated = generated[bytes.IndexByte(generated, '\n')+2:]
 
-	checkedIn, err := ioutil.ReadFile(path.Join(testdata, "parse.y.go"))
+	checkedIn, err := os.ReadFile(path.Join(testdata, "parse.y.go"))
 	if err != nil {
 		t.Fatalf("ReadFile(%q) = %v", "parse.y.go", err)
 	}

--- a/build/parse_test.go
+++ b/build/parse_test.go
@@ -18,7 +18,6 @@ package build
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -63,7 +62,7 @@ func TestParseTestdata(t *testing.T) {
 			continue
 		}
 
-		data, err := ioutil.ReadFile(out)
+		data, err := os.ReadFile(out)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/build/print_test.go
+++ b/build/print_test.go
@@ -19,7 +19,6 @@ package build
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -119,7 +118,7 @@ func TestSyntaxError(t *testing.T) {
 	}
 
 	for _, in := range ins {
-		data, err := ioutil.ReadFile(in)
+		data, err := os.ReadFile(in)
 		if err != nil {
 			t.Error(err)
 			return
@@ -177,13 +176,13 @@ func findTests(t *testing.T, suffix string) ([]string, func()) {
 // It reads the file named in, reformats it, and compares
 // the result to the file named out.
 func testPrint(t *testing.T, in, out string, isBuild bool) {
-	data, err := ioutil.ReadFile(in)
+	data, err := os.ReadFile(in)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	golden, err := ioutil.ReadFile(out)
+	golden, err := os.ReadFile(out)
 	if err != nil {
 		t.Error(err)
 		return
@@ -229,7 +228,7 @@ func TestPrintParse(t *testing.T) {
 			continue
 		}
 
-		data, err := ioutil.ReadFile(out)
+		data, err := os.ReadFile(out)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -261,7 +260,7 @@ func TestPrintNewSequences(t *testing.T) {
 	outs, chdir := findTests(t, "064.*")
 	defer chdir()
 	for _, out := range outs {
-		golden, err := ioutil.ReadFile(out)
+		golden, err := os.ReadFile(out)
 		if err != nil {
 			t.Error(err)
 			return

--- a/build/rewrite_test.go
+++ b/build/rewrite_test.go
@@ -18,7 +18,6 @@ package build
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -28,10 +27,10 @@ var workingDir string = path.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORK
 var originalFilePath = workingDir + "/rewrite_test_files/original.star"
 var formattedFilePath = workingDir + "/rewrite_test_files/original_formatted.star"
 
-var originalBytes, _ = ioutil.ReadFile(originalFilePath)
+var originalBytes, _ = os.ReadFile(originalFilePath)
 var originalFile, _ = ParseDefault(originalFilePath, originalBytes)
 
-var formattedBytes, _ = ioutil.ReadFile(formattedFilePath)
+var formattedBytes, _ = os.ReadFile(formattedFilePath)
 var formattedFile, _ = ParseDefault(formattedFilePath, formattedBytes)
 
 var name map[string]int = map[string]int{"name": -99}
@@ -44,7 +43,7 @@ var rewriter = Rewriter{
 
 func TestRewriterRegular(t *testing.T) {
 	// Load the original file
-	var modifyBytes, _ = ioutil.ReadFile(originalFilePath)
+	var modifyBytes, _ = os.ReadFile(originalFilePath)
 	var modifiedFile, _ = ParseDefault(originalFilePath, modifyBytes)
 
 	// Perform rewrite on loaded file, rewrite should do nothing here
@@ -71,7 +70,7 @@ func TestRewriterRegular(t *testing.T) {
 
 func TestRewriterWithRewriter(t *testing.T) {
 	// Load the original file
-	var modifyBytes, _ = ioutil.ReadFile(originalFilePath)
+	var modifyBytes, _ = os.ReadFile(originalFilePath)
 	var modifiedFile, _ = ParseDefault(originalFilePath, modifyBytes)
 
 	// Perform rewrite with rewriter on loaded file, should proceed to reorder

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -175,7 +175,7 @@ func (b *buildifier) run(args []string) int {
 	var diagnostics *utils.Diagnostics
 	if len(args) == 0 || (len(args) == 1 && (args)[0] == "-") {
 		// Read from stdin, write to stdout.
-		data, err := ioutil.ReadAll(os.Stdin)
+		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "buildifier: reading stdin: %v\n", err)
 			return 2
@@ -243,7 +243,7 @@ func (b *buildifier) processFiles(files []string, tf *utils.TempFile) (*utils.Di
 		go func(i int) {
 			for j := i; j < len(files); j += nworker {
 				file := files[j]
-				data, err := ioutil.ReadFile(file)
+				data, err := os.ReadFile(file)
 				ch[i] <- result{file, data, err}
 			}
 		}(i)
@@ -361,7 +361,7 @@ func (b *buildifier) processFile(filename string, data []byte, displayFileNames 
 			return fileDiagnostics, exitCode
 		}
 
-		err := ioutil.WriteFile(filename, ndata, 0666)
+		err := os.WriteFile(filename, ndata, 0666)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "buildifier: %s\n", err)
 			return fileDiagnostics, 3

--- a/buildifier/config/config.go
+++ b/buildifier/config/config.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -132,7 +131,7 @@ func (c *Config) LoadFile() error {
 
 // LoadReader unmarshals JSON data from the given reader.
 func (c *Config) LoadReader(in io.Reader) error {
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return fmt.Errorf("reading config: %w", err)
 	}

--- a/buildifier/config/config_test.go
+++ b/buildifier/config/config_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -479,7 +478,7 @@ func TestFindConfigPath(t *testing.T) {
 				defer os.Unsetenv(k)
 			}
 
-			tmp, err := ioutil.TempDir("", name+"*")
+			tmp, err := os.MkdirTemp("", name+"*")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -499,7 +498,7 @@ func TestFindConfigPath(t *testing.T) {
 					}
 				}
 				filename := filepath.Join(dir, rel)
-				if err := ioutil.WriteFile(filename, []byte(content), 0644); err != nil {
+				if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/buildifier/utils/tempfile.go
+++ b/buildifier/utils/tempfile.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -29,7 +28,7 @@ type TempFile struct {
 
 // WriteTemp writes data to a temporary file and returns the name of the file.
 func (tf *TempFile) WriteTemp(data []byte) (file string, err error) {
-	f, err := ioutil.TempFile("", "buildifier-tmp-")
+	f, err := os.CreateTemp("", "buildifier-tmp-")
 	if err != nil {
 		return "", fmt.Errorf("creating temporary file: %v", err)
 	}

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -19,7 +19,6 @@ limitations under the License.
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -110,7 +109,7 @@ func getFileReader(workspaceRoot string) *warn.FileReader {
 		filename = strings.ReplaceAll(filename, "/", string(os.PathSeparator))
 		path := filepath.Join(workspaceRoot, filename)
 
-		return ioutil.ReadFile(path)
+		return os.ReadFile(path)
 	}
 
 	return warn.NewFileReader(readFile)

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -1135,7 +1134,7 @@ func rewrite(opts *Options, commandsForFile commandsForFile) *rewriteResult {
 	var fi os.FileInfo
 	records := []*apipb.Output_Record{}
 	if name == stdinPackageName { // read on stdin
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return &rewriteResult{file: name, errs: []error{err}}
 		}
@@ -1297,7 +1296,7 @@ func findBuildFiles(rootDir string) []string {
 		dir := searchDirs[lastIndex]
 		searchDirs = searchDirs[:lastIndex]
 
-		dirFiles, err := ioutil.ReadDir(dir)
+		dirFiles, err := os.ReadDir(dir)
 		if err != nil {
 			continue
 		}

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package edit
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -128,7 +127,7 @@ type targetExpressionToBuildFilesTestCase struct {
 }
 
 func setupTestTmpWorkspace(t *testing.T, buildFileName string) (tmp string) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,19 +144,19 @@ func setupTestTmpWorkspace(t *testing.T, buildFileName string) (tmp string) {
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "c"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "WORKSPACE"), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "WORKSPACE"), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, buildFileName), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, buildFileName), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "a", buildFileName), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a", buildFileName), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "a", "b", buildFileName), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a", "b", buildFileName), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "a", "c", buildFileName), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a", "c", buildFileName), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
 	return

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -18,7 +18,6 @@ package edit
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -728,7 +727,7 @@ type testCase struct {
 }
 
 func runTestInterpretLabelForWorkspaceLocation(t *testing.T, buildFileName string) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -736,16 +735,16 @@ func runTestInterpretLabelForWorkspaceLocation(t *testing.T, buildFileName strin
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "b"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "WORKSPACE"), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "WORKSPACE"), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, buildFileName), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, buildFileName), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "a", buildFileName), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a", buildFileName), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "a", "b", buildFileName), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a", "b", buildFileName), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/file/file.go
+++ b/file/file.go
@@ -20,34 +20,35 @@ package file
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
 // ReadFile can be updated from the caller to change the API
 // for reading a file.
 var ReadFile = readFile
+
 // WriteFile can be updated from the caller to change the API
 // for writing a file.
 var WriteFile = writeFile
+
 // OpenReadFile can be updated from the caller to change the API
 // for opening a file.
 var OpenReadFile = openReadFile
 
-// readFile is like ioutil.ReadFile.
+// readFile is like os.ReadFile.
 func readFile(name string) ([]byte, os.FileInfo, error) {
 	fi, err := os.Stat(name)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	data, err := ioutil.ReadFile(name)
+	data, err := os.ReadFile(name)
 	return data, fi, err
 }
 
-// writeFile is like ioutil.WriteFile.
+// writeFile is like os.WriteFile.
 func writeFile(name string, data []byte) error {
-	return ioutil.WriteFile(name, data, 0644)
+	return os.WriteFile(name, data, 0644)
 }
 
 // openReadFile is like os.Open.

--- a/generatetables/generate_tables.go
+++ b/generatetables/generate_tables.go
@@ -22,7 +22,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -36,7 +35,7 @@ var outputPath = flag.String("output", "", "output file")
 
 // bazelBuildLanguage reads a proto file and returns a BuildLanguage object.
 func bazelBuildLanguage(file string) (*buildpb.BuildLanguage, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot read %s: %s\n", file, err)
 		return nil, err
@@ -83,7 +82,7 @@ func generateTable(rules []*buildpb.RuleDefinition) map[string]buildpb.Attribute
 
 	// Make sure we always have this.
 	_, ok := types["package_metadata"]
-	if ! ok {
+	if !ok {
 		types["package_metadata"] = buildpb.Attribute_LABEL_LIST
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bazelbuild/buildtools
 
-go 1.15
+go 1.20
 
 require (
 	github.com/golang/protobuf v1.4.3

--- a/tables/jsonparser.go
+++ b/tables/jsonparser.go
@@ -18,7 +18,7 @@ package tables
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 type Definitions struct {
@@ -37,7 +37,7 @@ type Definitions struct {
 func ParseJSONDefinitions(file string) (Definitions, error) {
 	var definitions Definitions
 
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return definitions, err
 	}

--- a/testutils/diff.go
+++ b/testutils/diff.go
@@ -18,7 +18,6 @@ limitations under the License.
 package testutils
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -26,14 +25,14 @@ import (
 
 // Diff returns the output of running diff on b1 and b2.
 func Diff(b1, b2 []byte) ([]byte, error) {
-	f1, err := ioutil.TempFile("", "testdiff")
+	f1, err := os.CreateTemp("", "testdiff")
 	if err != nil {
 		return nil, err
 	}
 	defer os.Remove(f1.Name())
 	defer f1.Close()
 
-	f2, err := ioutil.TempFile("", "testdiff")
+	f2, err := os.CreateTemp("", "testdiff")
 	if err != nil {
 		return nil, err
 	}

--- a/unused_deps/jar_manifest.go
+++ b/unused_deps/jar_manifest.go
@@ -19,7 +19,7 @@ package main
 import (
 	"archive/zip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 )
 
@@ -71,7 +71,7 @@ func jarManifestValue(jarFileName string, key string) (string, error) {
 		}
 		defer rc.Close()
 
-		bytes, err := ioutil.ReadAll(rc)
+		bytes, err := io.ReadAll(rc)
 		if err != nil {
 			return "", err
 		}

--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -93,7 +92,7 @@ func stringList(name, help string) func() []string {
 
 // getJarPath prints the path to the output jar file specified in the extra_action file at path.
 func getJarPath(path string) (string, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -154,7 +153,7 @@ func directDepParams(blazeOutputPath string, paramsFileNames ...string) (depsByJ
 	depsByJar = make(map[string]string)
 	errs := make([]error, 0)
 	for _, paramsFileName := range paramsFileNames {
-		data, err := ioutil.ReadFile(paramsFileName)
+		data, err := os.ReadFile(paramsFileName)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -200,7 +199,7 @@ func directDepParams(blazeOutputPath string, paramsFileNames ...string) (depsByJ
 // at compile time, and returns those values in the depsByJar map that aren't used at compile time.
 func unusedDeps(depsFileName string, depsByJar map[string]string) (unusedDeps map[string]bool) {
 	unusedDeps = make(map[string]bool)
-	data, err := ioutil.ReadFile(depsFileName)
+	data, err := os.ReadFile(depsFileName)
 	if err != nil {
 		log.Println(err)
 		return unusedDeps
@@ -223,7 +222,7 @@ func unusedDeps(depsFileName string, depsByJar map[string]string) (unusedDeps ma
 
 // parseBuildFile tries to read and parse the contents of buildFileName.
 func parseBuildFile(buildFileName string) (buildFile *build.File, err error) {
-	data, err := ioutil.ReadFile(buildFileName)
+	data, err := os.ReadFile(buildFileName)
 	if err != nil {
 		return nil, err
 	}
@@ -302,16 +301,16 @@ func printCommands(label string, deps map[string]bool) (anyCommandPrinted bool) 
 // setupAspect creates a workspace in a tmpdir and populates it with an aspect,
 // which is used with --override_repository below.
 func setupAspect() (string, error) {
-	tmp, err := ioutil.TempDir(os.TempDir(), "unused_deps")
+	tmp, err := os.MkdirTemp(os.TempDir(), "unused_deps")
 	if err != nil {
 		return "", err
 	}
 	for _, f := range []string{"WORKSPACE", "BUILD"} {
-		if err := ioutil.WriteFile(path.Join(tmp, f), []byte{}, 0666); err != nil {
+		if err := os.WriteFile(path.Join(tmp, f), []byte{}, 0666); err != nil {
 			return "", err
 		}
 	}
-	if err := ioutil.WriteFile(path.Join(tmp, "unused_deps.bzl"), []byte(aspect), 0666); err != nil {
+	if err := os.WriteFile(path.Join(tmp, "unused_deps.bzl"), []byte(aspect), 0666); err != nil {
 		return "", err
 	}
 	return tmp, nil

--- a/warn/docs/docs.go
+++ b/warn/docs/docs.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -33,7 +32,7 @@ import (
 )
 
 func readWarningsFromFile(path string) (*docspb.Warnings, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/warn/docs/docs_test.go
+++ b/warn/docs/docs_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -52,14 +51,14 @@ func TestAllWarningsAreDocumented(t *testing.T) {
 func TestFilesMatch(t *testing.T) {
 	testdata := path.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"))
 
-	generatedPath := path.Join(testdata, "warn", "docs", "WARNINGS.md") 
-	generated, err := ioutil.ReadFile(generatedPath)
+	generatedPath := path.Join(testdata, "warn", "docs", "WARNINGS.md")
+	generated, err := os.ReadFile(generatedPath)
 	if err != nil {
 		t.Fatalf("ReadFile(%q) = %v", generatedPath, err)
 	}
 
 	checkedInPath := path.Join(testdata, "WARNINGS.md")
-	checkedIn, err := ioutil.ReadFile(checkedInPath)
+	checkedIn, err := os.ReadFile(checkedInPath)
 	if err != nil {
 		t.Fatalf("ReadFile(%q) = %v", checkedInPath, err)
 	}

--- a/wspace/workspace.go
+++ b/wspace/workspace.go
@@ -18,7 +18,6 @@ limitations under the License.
 package wspace
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -128,7 +127,7 @@ func FindRepoBuildFiles(root string) (map[string]string, error) {
 		"new_git_repository",
 		"new_http_archive",
 	}
-	data, err := ioutil.ReadFile(ws)
+	data, err := os.ReadFile(ws)
 	if err != nil {
 		return nil, err
 	}

--- a/wspace/workspace_test.go
+++ b/wspace/workspace_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package wspace
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,7 +29,7 @@ type testCase struct {
 }
 
 func runBasicTestWithRepoRootFile(t *testing.T, repoRootFile string) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "wspace")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,10 +37,10 @@ func runBasicTestWithRepoRootFile(t *testing.T, repoRootFile string) {
 	if err := os.MkdirAll(filepath.Join(tmp, "a", "b", "c"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, repoRootFile), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, repoRootFile), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmp, "a", "b", repoRootFile), nil, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a", "b", repoRootFile), nil, 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,7 +64,7 @@ func TestBasic(t *testing.T) {
 }
 
 func TestFindRepoBuildfiles(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +95,7 @@ new_http_archive(
     build_file = "//third_party:f.BUILD",
 )
 `)
-	if err := ioutil.WriteFile(filepath.Join(tmp, workspaceFile), workspace, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, workspaceFile), workspace, 0755); err != nil {
 		t.Fatal(err)
 	}
 	files, err := FindRepoBuildFiles(tmp)
@@ -129,7 +128,7 @@ func checkSplitFilePathOutput(t *testing.T, name, filename, expectedWorkspaceRoo
 }
 
 func TestSplitFilePath(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -143,7 +142,7 @@ func TestSplitFilePath(t *testing.T) {
 	checkSplitFilePathOutput(t, "No WORKSPACE file", filename, "", "", "")
 
 	// Create a WORKSPACE file and try again (dir/WORKSPACE)
-	if err := ioutil.WriteFile(filepath.Join(dir, "WORKSPACE"), []byte{}, os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "WORKSPACE"), []byte{}, os.ModePerm); err != nil {
 		t.Error(err)
 	}
 	checkSplitFilePathOutput(t, "WORKSPACE file exists", filename, dir, "", "path/to/package/file.bzl")
@@ -151,7 +150,7 @@ func TestSplitFilePath(t *testing.T) {
 
 	// Add a BUILD file
 	buildPath := filepath.Join(dir, "path", "to", "BUILD")
-	if err := ioutil.WriteFile(buildPath, []byte{}, os.ModePerm); err != nil {
+	if err := os.WriteFile(buildPath, []byte{}, os.ModePerm); err != nil {
 		t.Error(err)
 	}
 	checkSplitFilePathOutput(t, "WORKSPACE and BUILD files exists 1", buildPath, dir, "path/to", "BUILD")
@@ -159,7 +158,7 @@ func TestSplitFilePath(t *testing.T) {
 
 	// Add a subpackage BUILD file
 	subBuildPath := filepath.Join(dir, "path", "to", "package", "BUILD.bazel")
-	if err := ioutil.WriteFile(subBuildPath, []byte{}, os.ModePerm); err != nil {
+	if err := os.WriteFile(subBuildPath, []byte{}, os.ModePerm); err != nil {
 		t.Error(err)
 	}
 	checkSplitFilePathOutput(t, "WORKSPACE and two BUILD files exists 1", subBuildPath, dir, "path/to/package", "BUILD.bazel")
@@ -177,7 +176,7 @@ func TestSplitFilePath(t *testing.T) {
 	if err := os.MkdirAll(newRoot, os.ModePerm); err != nil {
 		t.Error(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(newRoot, "WORKSPACE"), []byte{}, os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(newRoot, "WORKSPACE"), []byte{}, os.ModePerm); err != nil {
 		t.Error(err)
 	}
 	checkSplitFilePathOutput(t, "Two WORKSPACE files exist", filename, newRoot, "to/package", "file.bzl")


### PR DESCRIPTION
`io/ioutil` has been deprecated since Go 1.16.

- https://pkg.go.dev/io/ioutil
- https://go-review.googlesource.com/c/go/+/285377

This PR removes it in favor of equivalents in `os` and `io` packages.
