### PR TITLE
Replace references to 'master' branches with 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains developer tools for working with Google's `bazel` build
 * [buildifier](buildifier/README.md) For formatting BUILD, BUILD.bazel and BUCK files in a standard way
 * [buildozer](buildozer/README.md) For doing command-line operations on these files.
 * [unused_deps](unused_deps/README.md) For finding unneeded dependencies in
-[java_library](https://docs.bazel.build/versions/master/be/java.html#java_library) rules.
+[java_library](https://docs.bazel.build/versions/main/be/java.html#java_library) rules.
 
 [![Build status](https://badge.buildkite.com/6a80fcf7909883296cada2e474286ea627994b9130aed110e2.svg)](https://buildkite.com/bazel/buildtools-postsubmit)
 

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -106,9 +106,9 @@ Using `applicable_licenses` as an attribute name may cause unexpected behavior. 
   * Automatic fix: yes
   * [Suppress the warning](#suppress): `# buildifier: disable=attr-cfg`
 
-The [Configuration](https://docs.bazel.build/versions/master/skylark/rules.html#configurations)
+The [Configuration](https://docs.bazel.build/versions/main/skylark/rules.html#configurations)
 `cfg = "data"` is deprecated and has no effect. Consider removing it.
-The [Configuration](https://docs.bazel.build/versions/master/skylark/rules.html#configurations)
+The [Configuration](https://docs.bazel.build/versions/main/skylark/rules.html#configurations)
 `cfg = "host"` is deprecated. Consider replacing it with `cfg = "exec"`.
 
 --------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ Using licenses as an attribute name may cause unexpected behavior.
   * Automatic fix: yes
   * [Suppress the warning](#suppress): `# buildifier: disable=attr-non-empty`
 
-The `non_empty` [attribute](https://docs.bazel.build/versions/master/skylark/lib/attr.html)
+The `non_empty` [attribute](https://docs.bazel.build/versions/main/skylark/lib/attr.html)
 for attr definitions is deprecated, please use `allow_empty` with an opposite value instead.
 
 --------------------------------------------------------------------------------
@@ -177,7 +177,7 @@ Using `package_metadata` as an attribute name may cause unexpected behavior. Its
   * Automatic fix: yes
   * [Suppress the warning](#suppress): `# buildifier: disable=attr-single-file`
 
-The `single_file` [attribute](https://docs.bazel.build/versions/master/skylark/lib/attr.html)
+The `single_file` [attribute](https://docs.bazel.build/versions/main/skylark/lib/attr.html)
 is deprecated, please use `allow_single_file` instead.
 
 --------------------------------------------------------------------------------
@@ -225,7 +225,7 @@ The names `l`, `I`, or `O` can be easily confused with `I`, `l`, or `0` correspo
   * Automatic fix: no
   * [Suppress the warning](#suppress): `# buildifier: disable=constant-glob`
 
-[Glob function](https://docs.bazel.build/versions/master/be/functions.html#glob)
+[Glob function](https://docs.bazel.build/versions/main/be/functions.html#glob)
 is used to get a list of files from the depot. The patterns (the first argument)
 typically include a wildcard (* character). A pattern without a wildcard is
 often useless and sometimes harmful.
@@ -267,16 +267,16 @@ performance (glob can be relatively slow):
   * Automatic fix: yes
   * [Suppress the warning](#suppress): `# buildifier: disable=ctx-actions`
 
-The following [actions](https://docs.bazel.build/versions/master/skylark/lib/actions.html)
+The following [actions](https://docs.bazel.build/versions/main/skylark/lib/actions.html)
 are deprecated, please use the new API:
 
-  * [`ctx.new_file`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#new_file) → [`ctx.actions.declare_file`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#declare_file)
-  * `ctx.experimental_new_directory` → [`ctx.actions.declare_directory`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#declare_directory)
-  * [`ctx.file_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#file_action) → [`ctx.actions.write`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#write)
-  * [`ctx.action(command = "...")`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#action) → [`ctx.actions.run_shell`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run_shell)
-  * [`ctx.action(executable = "...")`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#action) → [`ctx.actions.run`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run)
-  * [`ctx.empty_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#empty_action) → [`ctx.actions.do_nothing`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#do_nothing)
-  * [`ctx.template_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#template_action) → [`ctx.actions.expand_template`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#expand_template)
+  * [`ctx.new_file`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#new_file) → [`ctx.actions.declare_file`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#declare_file)
+  * `ctx.experimental_new_directory` → [`ctx.actions.declare_directory`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#declare_directory)
+  * [`ctx.file_action`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#file_action) → [`ctx.actions.write`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#write)
+  * [`ctx.action(command = "...")`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#action) → [`ctx.actions.run_shell`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#run_shell)
+  * [`ctx.action(executable = "...")`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#action) → [`ctx.actions.run`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#run)
+  * [`ctx.empty_action`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#empty_action) → [`ctx.actions.do_nothing`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#do_nothing)
+  * [`ctx.template_action`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#template_action) → [`ctx.actions.expand_template`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#expand_template)
 
 --------------------------------------------------------------------------------
 
@@ -287,10 +287,10 @@ are deprecated, please use the new API:
   * Automatic fix: yes
   * [Suppress the warning](#suppress): `# buildifier: disable=ctx-args`
 
-It's deprecated to use the [`add`](https://docs.bazel.build/versions/master/skylark/lib/Args.html#add)
+It's deprecated to use the [`add`](https://docs.bazel.build/versions/main/skylark/lib/Args.html#add)
 method of `ctx.actions.args()` to add a list (or a depset) of variables. Please use either
-[`add_all`](https://docs.bazel.build/versions/master/skylark/lib/Args.html#add_all) or
-[`add_joined`](https://docs.bazel.build/versions/master/skylark/lib/Args.html#add_joined),
+[`add_all`](https://docs.bazel.build/versions/main/skylark/lib/Args.html#add_all) or
+[`add_joined`](https://docs.bazel.build/versions/main/skylark/lib/Args.html#add_joined),
 depending on the desired behavior.
 
 --------------------------------------------------------------------------------
@@ -314,7 +314,7 @@ the [`function-docstring`](#function-docstring) warning.
   * Automatic fix: no
   * [Suppress the warning](#suppress): `# buildifier: disable=depset-items`
 
-The `items` parameter for [`depset`](https://docs.bazel.build/versions/master/skylark/lib/globals.html#depset)
+The `items` parameter for [`depset`](https://docs.bazel.build/versions/main/skylark/lib/globals.html#depset)
 is deprecated. In its old form it's either a list of direct elements to be
 added (use the `direct` or unnamed first parameter instead) or a depset that
 becomes a transitive element of the new depset (use the `transitive` parameter
@@ -356,7 +356,7 @@ depset1 | depset2
 depset1.union(depset2)
 ```
 
-Please use the [depset](https://docs.bazel.build/versions/master/skylark/lib/depset.html) constructor
+Please use the [depset](https://docs.bazel.build/versions/main/skylark/lib/depset.html) constructor
 instead:
 
 ```python
@@ -364,9 +364,9 @@ depset(transitive = [depset1, depset2])
 ```
 
 When fixing this issue, make sure you
-[understand depsets](https://docs.bazel.build/versions/master/skylark/depsets.html)
+[understand depsets](https://docs.bazel.build/versions/main/skylark/depsets.html)
 and try to
-[reduce the number of calls to depset](https://docs.bazel.build/versions/master/skylark/performance.html#reduce-the-number-of-calls-to-depset).
+[reduce the number of calls to depset](https://docs.bazel.build/versions/main/skylark/performance.html#reduce-the-number-of-calls-to-depset).
 
 --------------------------------------------------------------------------------
 
@@ -453,7 +453,7 @@ To fix the issue just change the name attribute of one rule/macro.
   * [Suppress the warning](#suppress): `# buildifier: disable=filetype`
 
 The function `FileType` is deprecated. Instead of using it as an argument to the
-[`rule` function](https://docs.bazel.build/versions/master/skylark/lib/globals.html#rule)
+[`rule` function](https://docs.bazel.build/versions/main/skylark/lib/globals.html#rule)
 just use a list of strings.
 
 --------------------------------------------------------------------------------
@@ -586,7 +586,7 @@ Transforming `x += [expr]` to `x.append(expr)` avoids a list allocation.
 
 ### Background
 
-[load](https://docs.bazel.build/versions/master/skylark/concepts.html#loading-an-extension)
+[load](https://docs.bazel.build/versions/main/skylark/concepts.html#loading-an-extension)
 is used to import definitions in a BUILD file. If the definition is not used in
 the file, the load can be safely removed. If a symbol is loaded two times, you
 will get a warning on the second occurrence.
@@ -791,7 +791,7 @@ of a symbol load and its usage can change resulting in runtime error.
   * [Suppress the warning](#suppress): `# buildifier: disable=output-group`
 
 The `output_group` field of a target is deprecated in favor of the
-[`OutputGroupInfo` provider](https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html).
+[`OutputGroupInfo` provider](https://docs.bazel.build/versions/main/skylark/lib/OutputGroupInfo.html).
 
 --------------------------------------------------------------------------------
 
@@ -828,9 +828,9 @@ x = depset(..., transitive = [y.deps for y in ...])
 ```
 
 For more information, read Bazel documentation about
-[depsets](https://docs.bazel.build/versions/master/skylark/depsets.html)
+[depsets](https://docs.bazel.build/versions/main/skylark/depsets.html)
 and
-[reducing the number of calls to depset](https://docs.bazel.build/versions/master/skylark/performance.html#reduce-the-number-of-calls-to-depset).
+[reducing the number of calls to depset](https://docs.bazel.build/versions/main/skylark/performance.html#reduce-the-number-of-calls-to-depset).
 
 --------------------------------------------------------------------------------
 
@@ -842,7 +842,7 @@ and
   * [Suppress the warning](#suppress): `# buildifier: disable=package-name`
 
 The global variable `PACKAGE_NAME` is deprecated, please use
-[`native.package_name()`](https://docs.bazel.build/versions/master/skylark/lib/native.html#package_name)
+[`native.package_name()`](https://docs.bazel.build/versions/main/skylark/lib/native.html#package_name)
 instead.
 
 --------------------------------------------------------------------------------
@@ -952,7 +952,7 @@ AllInfo = provider("This provider accepts any field.", fields = None)
 NoneInfo = provider("This provider cannot have fields.", fields = [])
 ```
 
-See the [documentation for providers](https://docs.bazel.build/versions/master/skylark/lib/globals.html#provider).
+See the [documentation for providers](https://docs.bazel.build/versions/main/skylark/lib/globals.html#provider).
 
 --------------------------------------------------------------------------------
 
@@ -985,7 +985,7 @@ forbid reassignment, but not every side-effect.
   * [Suppress the warning](#suppress): `# buildifier: disable=repository-name`
 
 The global variable `REPOSITORY_NAME` is deprecated, please use
-[`native.repository_name()`](https://docs.bazel.build/versions/master/skylark/lib/native.html#repository_name)
+[`native.repository_name()`](https://docs.bazel.build/versions/main/skylark/lib/native.html#repository_name)
 instead.
 
 --------------------------------------------------------------------------------
@@ -1011,9 +1011,9 @@ know certain parts of the code cannot be reached, add the statement
   * [Suppress the warning](#suppress): `# buildifier: disable=rule-impl-return`
 
 Returning structs from rule implementation functions is
-[deprecated](https://docs.bazel.build/versions/master/skylark/rules.html#migrating-from-legacy-providers),
+[deprecated](https://docs.bazel.build/versions/main/skylark/rules.html#migrating-from-legacy-providers),
 consider using
-[providers](https://docs.bazel.build/versions/master/skylark/rules.html#providers)
+[providers](https://docs.bazel.build/versions/main/skylark/rules.html#providers)
 or lists of providers instead.
 
 --------------------------------------------------------------------------------
@@ -1029,7 +1029,7 @@ Obsolete; the warning has been implemented in the formatter and the fix is now a
 
 ### Background
 
-[load](https://docs.bazel.build/versions/master/skylark/concepts.html#loading-an-extension)
+[load](https://docs.bazel.build/versions/main/skylark/concepts.html#loading-an-extension)
 is used to import definitions in a BUILD file. If the same label is used for loading
 symbols more the ones, all such loads can be merged into a single one.
 

--- a/buildifier/README.md
+++ b/buildifier/README.md
@@ -186,7 +186,7 @@ The output format is the following:
                     "actionable": true,
                     "autoFixable": true,
                     "message": "The \"/\" operator for integer division is deprecated in favor of \"//\".",
-                    "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division"
+                    "url": "https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#integer-division"
                 }
             ]
         },

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -384,11 +384,11 @@ test_dir/to_fix_tmp.bzl: applied fixes, 2 warnings left
 fixed test_dir/to_fix_tmp.bzl
 EOF
 
-error_bzl="test_dir/to_fix_tmp.bzl:1: bzl-visibility: Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//to_fix_tmp.bzl\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#bzl-visibility)"
-error_docstring="test_dir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring."$'\n'"A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines). (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"
-error_integer="test_dir/to_fix_tmp.bzl:4: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"
-error_dict="test_dir/to_fix_tmp.bzl:5: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unsorted-dict-items)"
-error_cfg="test_dir/to_fix_tmp.bzl:6: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg)"
+error_bzl="test_dir/to_fix_tmp.bzl:1: bzl-visibility: Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//to_fix_tmp.bzl\". (https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#bzl-visibility)"
+error_docstring="test_dir/to_fix_tmp.bzl:1: module-docstring: The file has no module docstring."$'\n'"A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines). (https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#module-docstring)"
+error_integer="test_dir/to_fix_tmp.bzl:4: integer-division: The \"/\" operator for integer division is deprecated in favor of \"//\". (https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#integer-division)"
+error_dict="test_dir/to_fix_tmp.bzl:5: unsorted-dict-items: Dictionary items are out of their lexicographical order. (https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#unsorted-dict-items)"
+error_cfg="test_dir/to_fix_tmp.bzl:6: attr-cfg: cfg = \"data\" for attr definitions has no effect and should be removed. (https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#attr-cfg)"
 
 test_lint () {
   ret=0
@@ -485,7 +485,7 @@ cat > golden/json_report_golden <<EOF
                     "actionable": true,
                     "autoFixable": false,
                     "message": "Module \"//foo/bar/internal/baz:module.bzl\" can only be loaded from files located inside \"//foo/bar\", not from \"//json/to_fix.bzl\".",
-                    "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#bzl-visibility"
+                    "url": "https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#bzl-visibility"
                 },
                 {
                     "start": {
@@ -500,7 +500,7 @@ cat > golden/json_report_golden <<EOF
                     "actionable": true,
                     "autoFixable": true,
                     "message": "The \"/\" operator for integer division is deprecated in favor of \"//\".",
-                    "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division"
+                    "url": "https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#integer-division"
                 },
                 {
                     "start": {
@@ -515,7 +515,7 @@ cat > golden/json_report_golden <<EOF
                     "actionable": true,
                     "autoFixable": true,
                     "message": "cfg = \"data\" for attr definitions has no effect and should be removed.",
-                    "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg"
+                    "url": "https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#attr-cfg"
                 }
             ]
         },
@@ -638,7 +638,7 @@ load(":nonexistent.bzl", "foo2", "bar2")
 EOF
 
 cat > report_golden <<EOF
-BUILD:1: deprecated-function: The function "bar" defined in "//lib.bzl" is deprecated. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#deprecated-function)
+BUILD:1: deprecated-function: The function "bar" defined in "//lib.bzl" is deprecated. (https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#deprecated-function)
 EOF
 
 $buildifier --lint=warn --warnings=deprecated-function BUILD 2> report || ret=$?

--- a/buildozer/npm/index.js
+++ b/buildozer/npm/index.js
@@ -7,7 +7,7 @@ const {getNativeBinary} = require('./buildozer');
 
 /**
  * run buildozer with a list of commands
- * @see https://github.com/bazelbuild/buildtools/tree/master/buildozer#do-multiple-changes-at-once
+ * @see https://github.com/bazelbuild/buildtools/tree/main/buildozer#do-multiple-changes-at-once
  * @returns The standard out of the buildozer command, split by lines
  */
 function run(...commands) {
@@ -21,7 +21,7 @@ function run(...commands) {
  * @param flags any buildozer flags to pass
  */
 function runWithOptions(commands, options, flags = []) {
-    // From https://github.com/bazelbuild/buildtools/tree/master/buildozer#usage:
+    // From https://github.com/bazelbuild/buildtools/tree/main/buildozer#usage:
     // Here, label-list is a space-separated list of Bazel labels,
     // for example //path/to/pkg1:rule1 //path/to/pkg2:rule2.
     // Buildozer reads commands from FILE (- for stdin 
@@ -34,7 +34,7 @@ function runWithOptions(commands, options, flags = []) {
         input,
         encoding: 'utf-8',
     });
-    // https://github.com/bazelbuild/buildtools/tree/master/buildozer#error-code
+    // https://github.com/bazelbuild/buildtools/tree/main/buildozer#error-code
     if (status == 0 || status == 3) return stdout.trim().split('\n').filter(l => !!l);
 
     console.error(`buildozer exited with status ${status}\n${stderr}`);

--- a/launcher.js
+++ b/launcher.js
@@ -41,7 +41,7 @@ function getNativeBinary() {
   if (arch == undefined || platform == undefined || (arch == 'arm64' && platform == 'windows')) {
     console.error(`FATAL: Your platform/architecture combination ${
         os.platform()} - ${os.arch()} is not yet supported.
-    See instructions at https://github.com/bazelbuild/buildtools/blob/master/_TOOL_/README.md.`);
+    See instructions at https://github.com/bazelbuild/buildtools/blob/main/_TOOL_/README.md.`);
     return Promise.resolve(1);
   }
 

--- a/release/github.sh
+++ b/release/github.sh
@@ -30,7 +30,7 @@ for tool in "buildifier" "buildozer" "unused_deps"; do
 done;
 
 echo "Creating a draft release"
-API_JSON="{\"tag_name\": \"$TAG\", \"target_commitish\": \"master\", \"name\": \"$NAME\", \"draft\": true}"
+API_JSON="{\"tag_name\": \"$TAG\", \"target_commitish\": \"main\", \"name\": \"$NAME\", \"draft\": true}"
 RESPONSE=$(curl -s --show-error -H "$GH_AUTH_HEADER" --data "$API_JSON" "https://api.github.com/$GH_REPO/releases")
 RELEASE_ID=$(echo $RESPONSE | jq -r '.id')
 RELEASE_URL=$(echo $RESPONSE | jq -r '.html_url')

--- a/unused_deps/README.md
+++ b/unused_deps/README.md
@@ -1,7 +1,7 @@
 # Unused Deps
 
 unused_deps is a command line tool to determine any unused dependencies
-in [java_library](https://docs.bazel.build/versions/master/be/java.html#java_library)
+in [java_library](https://docs.bazel.build/versions/main/be/java.html#java_library)
 rules. targets.  It outputs `buildozer` commands to apply the suggested
 prunings.
 

--- a/warn/docs/warnings.textproto
+++ b/warn/docs/warnings.textproto
@@ -6,9 +6,9 @@ warnings: {
   name: "attr-cfg"
   header: "`cfg = \"data\"` for attr definitions has no effect"
   description:
-    "The [Configuration](https://docs.bazel.build/versions/master/skylark/rules.html#configurations)\n"
+    "The [Configuration](https://docs.bazel.build/versions/main/skylark/rules.html#configurations)\n"
     "`cfg = \"data\"` is deprecated and has no effect. Consider removing it.\n"
-    "The [Configuration](https://docs.bazel.build/versions/master/skylark/rules.html#configurations)\n"
+    "The [Configuration](https://docs.bazel.build/versions/main/skylark/rules.html#configurations)\n"
     "`cfg = \"host\"` is deprecated. Consider replacing it with `cfg = \"exec\"`."
   bazel_flag: "--incompatible_disallow_data_transition"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/6153"
@@ -48,7 +48,7 @@ warnings: {
   name: "attr-non-empty"
   header: "`non_empty` attribute for attr definitions is deprecated"
   description:
-    "The `non_empty` [attribute](https://docs.bazel.build/versions/master/skylark/lib/attr.html)\n"
+    "The `non_empty` [attribute](https://docs.bazel.build/versions/main/skylark/lib/attr.html)\n"
     "for attr definitions is deprecated, please use `allow_empty` with an opposite value instead."
   bazel_flag: "--incompatible_disable_deprecated_attr_params"
   autofix: true
@@ -70,7 +70,7 @@ warnings: {
   name: "attr-single-file"
   header: "`single_file` is deprecated"
   description:
-    "The `single_file` [attribute](https://docs.bazel.build/versions/master/skylark/lib/attr.html)\n"
+    "The `single_file` [attribute](https://docs.bazel.build/versions/main/skylark/lib/attr.html)\n"
     "is deprecated, please use `allow_single_file` instead."
   bazel_flag: "--incompatible_disable_deprecated_attr_params"
   autofix: true
@@ -108,7 +108,7 @@ warnings: {
   name: "constant-glob"
   header: "Glob pattern has no wildcard ('*')"
   description:
-    "[Glob function](https://docs.bazel.build/versions/master/be/functions.html#glob)\n"
+    "[Glob function](https://docs.bazel.build/versions/main/be/functions.html#glob)\n"
     "is used to get a list of files from the depot. The patterns (the first argument)\n"
     "typically include a wildcard (* character). A pattern without a wildcard is\n"
     "often useless and sometimes harmful.\n\n"
@@ -138,15 +138,15 @@ warnings: {
   name: "ctx-actions"
   header: "`ctx.{action_name}` is deprecated"
   description:
-    "The following [actions](https://docs.bazel.build/versions/master/skylark/lib/actions.html)\n"
+    "The following [actions](https://docs.bazel.build/versions/main/skylark/lib/actions.html)\n"
     "are deprecated, please use the new API:\n\n"
-    "  * [`ctx.new_file`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#new_file) → [`ctx.actions.declare_file`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#declare_file)\n"
-    "  * `ctx.experimental_new_directory` → [`ctx.actions.declare_directory`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#declare_directory)\n"
-    "  * [`ctx.file_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#file_action) → [`ctx.actions.write`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#write)\n"
-    "  * [`ctx.action(command = \"...\")`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#action) → [`ctx.actions.run_shell`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run_shell)\n"
-    "  * [`ctx.action(executable = \"...\")`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#action) → [`ctx.actions.run`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run)\n"
-    "  * [`ctx.empty_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#empty_action) → [`ctx.actions.do_nothing`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#do_nothing)\n"
-    "  * [`ctx.template_action`](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#template_action) → [`ctx.actions.expand_template`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#expand_template)"
+    "  * [`ctx.new_file`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#new_file) → [`ctx.actions.declare_file`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#declare_file)\n"
+    "  * `ctx.experimental_new_directory` → [`ctx.actions.declare_directory`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#declare_directory)\n"
+    "  * [`ctx.file_action`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#file_action) → [`ctx.actions.write`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#write)\n"
+    "  * [`ctx.action(command = \"...\")`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#action) → [`ctx.actions.run_shell`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#run_shell)\n"
+    "  * [`ctx.action(executable = \"...\")`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#action) → [`ctx.actions.run`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#run)\n"
+    "  * [`ctx.empty_action`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#empty_action) → [`ctx.actions.do_nothing`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#do_nothing)\n"
+    "  * [`ctx.template_action`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#template_action) → [`ctx.actions.expand_template`](https://docs.bazel.build/versions/main/skylark/lib/actions.html#expand_template)"
   bazel_flag: "--incompatible_new_actions_api"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/5825"
   autofix: true
@@ -156,10 +156,10 @@ warnings: {
   name: "ctx-args"
   header: "`ctx.actions.args().add()` for multiple arguments is deprecated"
   description:
-    "It's deprecated to use the [`add`](https://docs.bazel.build/versions/master/skylark/lib/Args.html#add)\n"
+    "It's deprecated to use the [`add`](https://docs.bazel.build/versions/main/skylark/lib/Args.html#add)\n"
     "method of `ctx.actions.args()` to add a list (or a depset) of variables. Please use either\n"
-    "[`add_all`](https://docs.bazel.build/versions/master/skylark/lib/Args.html#add_all) or\n"
-    "[`add_joined`](https://docs.bazel.build/versions/master/skylark/lib/Args.html#add_joined),\n"
+    "[`add_all`](https://docs.bazel.build/versions/main/skylark/lib/Args.html#add_all) or\n"
+    "[`add_joined`](https://docs.bazel.build/versions/main/skylark/lib/Args.html#add_joined),\n"
     "depending on the desired behavior."
   bazel_flag: "--incompatible_disallow_old_style_args_add"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/5822"
@@ -179,7 +179,7 @@ warnings: {
   name: "depset-items"
   header: "Depset's \"items\" parameter is deprecated"
   description:
-    "The `items` parameter for [`depset`](https://docs.bazel.build/versions/master/skylark/lib/globals.html#depset)\n"
+    "The `items` parameter for [`depset`](https://docs.bazel.build/versions/main/skylark/lib/globals.html#depset)\n"
     "is deprecated. In its old form it's either a list of direct elements to be\n"
     "added (use the `direct` or unnamed first parameter instead) or a depset that\n"
     "becomes a transitive element of the new depset (use the `transitive` parameter\n"
@@ -215,15 +215,15 @@ warnings: {
     "depset1 | depset2\n"
     "depset1.union(depset2)\n"
     "```\n\n"
-    "Please use the [depset](https://docs.bazel.build/versions/master/skylark/lib/depset.html) constructor\n"
+    "Please use the [depset](https://docs.bazel.build/versions/main/skylark/lib/depset.html) constructor\n"
     "instead:\n\n"
     "```python\n"
     "depset(transitive = [depset1, depset2])\n"
     "```\n\n"
     "When fixing this issue, make sure you\n"
-    "[understand depsets](https://docs.bazel.build/versions/master/skylark/depsets.html)\n"
+    "[understand depsets](https://docs.bazel.build/versions/main/skylark/depsets.html)\n"
     "and try to\n"
-    "[reduce the number of calls to depset](https://docs.bazel.build/versions/master/skylark/performance.html#reduce-the-number-of-calls-to-depset)."
+    "[reduce the number of calls to depset](https://docs.bazel.build/versions/main/skylark/performance.html#reduce-the-number-of-calls-to-depset)."
   bazel_flag: "--incompatible_depset_union"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/5817"
 }
@@ -289,7 +289,7 @@ warnings: {
   header: "The `FileType` function is deprecated"
   description:
     "The function `FileType` is deprecated. Instead of using it as an argument to the\n"
-    "[`rule` function](https://docs.bazel.build/versions/master/skylark/lib/globals.html#rule)\n"
+    "[`rule` function](https://docs.bazel.build/versions/main/skylark/lib/globals.html#rule)\n"
     "just use a list of strings."
   bazel_flag: "--incompatible_disallow_filetype"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/5831"
@@ -403,7 +403,7 @@ warnings: {
   header: "Loaded symbol is unused"
   description:
     "### Background\n\n"
-    "[load](https://docs.bazel.build/versions/master/skylark/concepts.html#loading-an-extension)\n"
+    "[load](https://docs.bazel.build/versions/main/skylark/concepts.html#loading-an-extension)\n"
     "is used to import definitions in a BUILD file. If the definition is not used in\n"
     "the file, the load can be safely removed. If a symbol is loaded two times, you\n"
     "will get a warning on the second occurrence.\n\n"
@@ -565,7 +565,7 @@ warnings: {
   header: "`ctx.attr.dep.output_group` is deprecated"
   description:
     "The `output_group` field of a target is deprecated in favor of the\n"
-    "[`OutputGroupInfo` provider](https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html)."
+    "[`OutputGroupInfo` provider](https://docs.bazel.build/versions/main/skylark/lib/OutputGroupInfo.html)."
   bazel_flag: "--incompatible_no_target_output_group"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/7949"
   autofix: true
@@ -596,9 +596,9 @@ warnings: {
     "x = depset(..., transitive = [y.deps for y in ...])\n"
     "```\n\n"
     "For more information, read Bazel documentation about\n"
-    "[depsets](https://docs.bazel.build/versions/master/skylark/depsets.html)\n"
+    "[depsets](https://docs.bazel.build/versions/main/skylark/depsets.html)\n"
     "and\n"
-    "[reducing the number of calls to depset](https://docs.bazel.build/versions/master/skylark/performance.html#reduce-the-number-of-calls-to-depset)."
+    "[reducing the number of calls to depset](https://docs.bazel.build/versions/main/skylark/performance.html#reduce-the-number-of-calls-to-depset)."
 }
 
 warnings: {
@@ -606,7 +606,7 @@ warnings: {
   header: "Global variable `PACKAGE_NAME` is deprecated"
   description:
     "The global variable `PACKAGE_NAME` is deprecated, please use\n"
-    "[`native.package_name()`](https://docs.bazel.build/versions/master/skylark/lib/native.html#package_name)\n"
+    "[`native.package_name()`](https://docs.bazel.build/versions/main/skylark/lib/native.html#package_name)\n"
     "instead."
   bazel_flag: "--incompatible_package_name_is_a_function"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/5827"
@@ -693,7 +693,7 @@ warnings: {
     "\n"
     "NoneInfo = provider(\"This provider cannot have fields.\", fields = [])\n"
     "```\n\n"
-    "See the [documentation for providers](https://docs.bazel.build/versions/master/skylark/lib/globals.html#provider)."
+    "See the [documentation for providers](https://docs.bazel.build/versions/main/skylark/lib/globals.html#provider)."
 }
 
 warnings: {
@@ -715,7 +715,7 @@ warnings: {
   header: "Global variable `REPOSITORY_NAME` is deprecated"
   description:
     "The global variable `REPOSITORY_NAME` is deprecated, please use\n"
-    "[`native.repository_name()`](https://docs.bazel.build/versions/master/skylark/lib/native.html#repository_name)\n"
+    "[`native.repository_name()`](https://docs.bazel.build/versions/main/skylark/lib/native.html#repository_name)\n"
     "instead."
   bazel_flag: "--incompatible_package_name_is_a_function"
   bazel_flag_link: "https://github.com/bazelbuild/bazel/issues/5827"
@@ -738,9 +738,9 @@ warnings: {
   header: "Avoid using the legacy provider syntax"
   description:
     "Returning structs from rule implementation functions is\n"
-    "[deprecated](https://docs.bazel.build/versions/master/skylark/rules.html#migrating-from-legacy-providers),\n"
+    "[deprecated](https://docs.bazel.build/versions/main/skylark/rules.html#migrating-from-legacy-providers),\n"
     "consider using\n"
-    "[providers](https://docs.bazel.build/versions/master/skylark/rules.html#providers)\n"
+    "[providers](https://docs.bazel.build/versions/main/skylark/rules.html#providers)\n"
     "or lists of providers instead."
 }
 
@@ -752,7 +752,7 @@ warnings: {
     "is now automatically applied to all files except `WORKSPACE` files "
     "(unless suppressed).\n\n"
     "### Background\n\n"
-    "[load](https://docs.bazel.build/versions/master/skylark/concepts.html#loading-an-extension)\n"
+    "[load](https://docs.bazel.build/versions/main/skylark/concepts.html#loading-an-extension)\n"
     "is used to import definitions in a BUILD file. If the same label is used for loading\n"
     "symbols more the ones, all such loads can be merged into a single one.\n\n"
     "### How to fix it\n\n"

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -78,7 +78,7 @@ type Replacement struct {
 }
 
 func docURL(cat string) string {
-	return "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#" + cat
+	return "https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#" + cat
 }
 
 // makeFinding creates a Finding object

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -321,7 +321,7 @@ foo()
 # Skylark
 bar() # SKYLARK
 
-# see https://docs.bazel.build/versions/master/skylark/lib/Label.html
+# see https://docs.bazel.build/versions/main/skylark/lib/Label.html
 Label()
 `, `
 # Skyline
@@ -332,7 +332,7 @@ foo()
 # Starlark
 bar() # STARLARK
 
-# see https://docs.bazel.build/versions/master/skylark/lib/Label.html
+# see https://docs.bazel.build/versions/main/skylark/lib/Label.html
 Label()
 `,
 		[]string{
@@ -373,7 +373,7 @@ def f():
 
 def l():
   """
-  Returns https://docs.bazel.build/versions/master/skylark/lib/Label.html
+  Returns https://docs.bazel.build/versions/main/skylark/lib/Label.html
   """
   return Label("skylark")
 `, `
@@ -388,7 +388,7 @@ def f():
 
 def l():
   """
-  Returns https://docs.bazel.build/versions/master/skylark/lib/Label.html
+  Returns https://docs.bazel.build/versions/main/skylark/lib/Label.html
   """
   return Label("skylark")
 `,


### PR DESCRIPTION
This affects Buildtools and Bazel repos and docs.