### PR TITLE
Replace log.Fatalf with log.Exitf to avoid spamming stderr.

### DIFF
--- a/warn/warn.go
+++ b/warn/warn.go
@@ -336,7 +336,7 @@ func FileWarnings(f *build.File, enabledWarnings []string, formatted *[]byte, mo
 		} else if fct, ok := RuleWarningMap[warn]; ok {
 			findings = append(findings, runWarningsFunction(warn, f, ruleWarningWrapper(fct), formatted, mode, fileReader)...)
 		} else {
-			log.Fatalf("unexpected warning %q", warn)
+			log.Exitf("unexpected warning %q", warn)
 		}
 	}
 	sort.Slice(findings, func(i, j int) bool { return findings[i].Start.Line < findings[j].Start.Line })

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -336,7 +336,8 @@ func FileWarnings(f *build.File, enabledWarnings []string, formatted *[]byte, mo
 		} else if fct, ok := RuleWarningMap[warn]; ok {
 			findings = append(findings, runWarningsFunction(warn, f, ruleWarningWrapper(fct), formatted, mode, fileReader)...)
 		} else {
-			log.Exitf("unexpected warning %q", warn)
+			log.Printf("unexpected warning %q", warn)
+			os.Exit(1)
 		}
 	}
 	sort.Slice(findings, func(i, j int) bool { return findings[i].Start.Line < findings[j].Start.Line })


### PR DESCRIPTION
The set of warnings is something that is changing over time. As scripts tend to hardcode these, they get out of date and we hit this unexpected warning code path. There's little benefit of having a stack trace from this issue. Thus, it's more convenient to just print the error itself and nothing else.