### PR TITLE
Return empty string when no BUILD file is available in our workspace

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -54,7 +54,7 @@ func InterpretLabelForWorkspaceLocation(root, target string) (buildFile, repo, p
 				return buildFile, repo, pkg, rule
 			}
 		}
-		// TODO(rodrigoq): report error for other repos
+		return "", repo, pkg, rule
 	}
 
 	defaultBuildFileName := "BUILD"


### PR DESCRIPTION
There are many cases where `BUILD` files are not available locally: Either they are available upstream or in BCR. Consumers of this function often ignore this return value anyways. Setting it to an empty string seems much more plausible then falling through an matching any other unsuitable case.

Related #1287