### PR TITLE
Skip ubuntu1804 in downstream testing

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,6 +6,7 @@ platforms:
   ubuntu1804:
     test_targets:
     - "//..."
+    skip_in_bazel_downstream_pipeline: "Newer abseil-cpp introduced doesn't work on this old platform"
   ubuntu2004:
     test_targets:
     - "//..."


### PR DESCRIPTION
Addressing https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4122#0191e992-f553-4cd2-9b37-319f62073ab6

We probably need to drop support for ubuntu1804 when upgrading Bazel to 8.0