### PR TITLE
Remove "out" from the listArg-list

### DIFF
--- a/tables/tables.go
+++ b/tables/tables.go
@@ -132,7 +132,6 @@ var IsSortableListArg = map[string]bool{
 	"javadeps":            true,
 	"lib_deps":            true,
 	"module_deps":         true,
-	"out":                 true,
 	"outs":                true,
 	"packages":            true,
 	"plugin_modules":      true,


### PR DESCRIPTION
"out" as an attribute seems to be a list and a string literal, varying between different rules.

From a lexical standpoint, it would be more likely to be a singluar value as the the wording is singular, and it would be more expected for a rule which provides multiple outs to use the "outs" attribute.

Metrics (based on Google internal use) show use of the attribute are ~5% lists, and ~95% string.