### PR TITLE
Add change command to buildozer to change rule kind in place

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -108,6 +108,8 @@ Buildozer supports the following commands(`'command args'`):
   * `new <rule_kind> <rule_name> [(before|after) <relative_rule_name>]`: Add a
     new rule at the end of the BUILD file (before/after `<relative_rule>`). The
     identifier `__pkg__` can be used to position rules relative to package().
+  * `change <rule_kind>`: Change a rule or rules to the new rule kind in place.
+    All attributes on the current rule are preserved.
   * `print <attr(s)>`
   * `remove <attr>`: Removes attribute `attr`. The wildcard `*` matches all
     attributes except `name`.

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -258,6 +258,12 @@ func cmdNew(opts *Options, env CmdEnvironment) (*build.File, error) {
 	return env.File, nil
 }
 
+func cmdChange(opts *Options, env CmdEnvironment) (*build.File, error) {
+	kind := env.Args[0]
+	env.Rule.Call.X = &build.Ident{Name: kind}
+	return env.File, nil
+}
+
 // findInsertionIndex is used by cmdNew to find the place at which to insert the new rule.
 func findInsertionIndex(env CmdEnvironment) (bool, int, error) {
 	if len(env.Args) < 4 {
@@ -922,6 +928,7 @@ var AllCommands = map[string]CommandInfo{
 	"fix":                   {cmdFix, true, 0, -1, "<fix(es)>?"},
 	"move":                  {cmdMove, true, 3, -1, "<old_attr> <new_attr> <value(s)>"},
 	"new":                   {cmdNew, false, 2, 4, "<rule_kind> <rule_name> [(before|after) <relative_rule_name>]"},
+	"change":                {cmdChange, true, 1, 1, "<rule_kind>"},
 	"print":                 {cmdPrint, true, 0, -1, "<attribute(s)>"},
 	"remove":                {cmdRemove, true, 1, -1, "<attr> <value(s)>"},
 	"remove_comment":        {cmdRemoveComment, true, 0, 2, "<attr>? <value>?"},


### PR DESCRIPTION
I'm actively working on a migration where I need to change the kind of a rule from one to another in place.  Prior to this step, I used move, rename, and set to make the attributes of the two rules look comparable.  I now need to switch to the new rule. Combing change with multiple other commands in a single invocation allows for doing reasonably complex changes in place.

I wasn't seeing a command to perform this operation, though I could have missed that.  "rename" is already taken for attributes.  "change" seemed the clearest after that. Open to other suggestions.

I've provided some basic test cases, and am happy to add more, but it didn't seem particulary worthwhile, given the simplicity of the command implementation.