### PR TITLE
Updating `set kind` to remember starting line of the rule

### DIFF
--- a/build/rule.go
+++ b/build/rule.go
@@ -191,9 +191,10 @@ func (r *Rule) Kind() string {
 func (r *Rule) SetKind(kind string) {
 	names := strings.Split(kind, ".")
 	var expr Expr
-	expr = &Ident{Name: names[0]}
+        startPos, _ := r.Call.X.Span()
+	expr = &Ident{Name: names[0], NamePos: startPos}
 	for _, name := range names[1:] {
-		expr = &DotExpr{X: expr, Name: name}
+		expr = &DotExpr{X: expr, Name: name, NamePos: startPos}
 	}
 	r.Call.X = expr
 }


### PR DESCRIPTION
Prior to this change, if a user were to run multiple consecutive commands, including one `set kind` command.
Any command including a line number would fail if referring to the rule with the changed kind.

Example
```
$ cat package/BUILD
foo_lib(
    name = "unknown",
    deps = [
        "path/to/some:dep",
    ],
)

$ cat commands
set kind bar_lib|package:%1
rename deps new_deps|package:%1
```


## Before this change
```
$ buildozer -f ./commands 
.../package/BUILD: error while executing commands [{[rename deps new_deps]}] on target package:%1: rule '%1' not found
```

## Including change
```
$buildozer -f ./commands 
fixed .../package/BUILD

$ cat package/BUILD 
bar_lib(
    name = "unknown",
    new_deps = [
        "path/to/some:dep",
    ],
)
```


