### PR TITLE
Note that list-append incorrectly warns on select statements

### DIFF
--- a/warn/docs/warnings.textproto
+++ b/warn/docs/warnings.textproto
@@ -394,7 +394,8 @@ warnings: {
 warnings: {
   name: "list-append"
   header: "Prefer using `.append()` to adding a single element list"
-  description: "Transforming `x += [expr]` to `x.append(expr)` avoids a list allocation."
+  description: "Transforming `x += [expr]` to `x.append(expr)` avoids a list allocation. This replacement does not apply to select statements, but the warning might
+trigger anyway. Feel free to suppress using the command above."
   autofix: true
 }
 


### PR DESCRIPTION
Buildifier advises authors to use the append function to add singletons to variables. 

This works when the variable is a list. If the variable is a select statement, this doesn't work. In this case, the only option is to add a singleton list to the select.