### PR TITLE
Note that list-append incorrectly warns on select statements

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -612,6 +612,8 @@ the readability.
   * [Suppress the warning](#suppress): `# buildifier: disable=list-append`
 
 Transforming `x += [expr]` to `x.append(expr)` avoids a list allocation.
+This replacement does not apply to select statements, but the warning might trigger
+anyway. Feel free to suppress using the command above.
 
 --------------------------------------------------------------------------------
 

--- a/warn/docs/warnings.textproto
+++ b/warn/docs/warnings.textproto
@@ -394,7 +394,9 @@ warnings: {
 warnings: {
   name: "list-append"
   header: "Prefer using `.append()` to adding a single element list"
-  description: "Transforming `x += [expr]` to `x.append(expr)` avoids a list allocation."
+  description: "Transforming `x += [expr]` to `x.append(expr)` avoids a list allocation.\n"
+    "This replacement does not apply to select statements, but the warning might trigger\n"
+    "anyway. Feel free to suppress using the command above."
   autofix: true
 }
 


### PR DESCRIPTION
Buildifier advises authors to use the append function to add singletons to variables.

This works when the variable is a list. If the variable is a select statement, this doesn't work. In this case, the only option is to add a singleton list to the select.