### PR TITLE
Adding nil check for Rule Call Expression

### DIFF
--- a/build/rule.go
+++ b/build/rule.go
@@ -190,8 +190,11 @@ func (r *Rule) Kind() string {
 // SetKind changes rule's kind (such as "go_library").
 func (r *Rule) SetKind(kind string) {
 	names := strings.Split(kind, ".")
+	var startPos Position
+	if x := r.Call.X; x != nil {
+		startPos, _ = x.Span()
+	}
 	var expr Expr
-        startPos, _ := r.Call.X.Span()
 	expr = &Ident{Name: names[0], NamePos: startPos}
 	for _, name := range names[1:] {
 		expr = &DotExpr{X: expr, Name: name, NamePos: startPos}


### PR DESCRIPTION
Rules can currently be created with Call.X(Expr) set to nil, which results in the code panicking. Checking for this error and using the type default for position if there is no other value defined.

Fixes bug introduced in #1342