### PR TITLE
Keep targets like "@foo//:foo" formatted as-is.

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -217,8 +217,7 @@ func keepSorted(x Expr) bool {
 // "//x" + ":y" (usually split across multiple lines) into "//x:y".
 //
 // Second, it removes redundant target qualifiers, turning labels like
-// "//third_party/m4:m4" into "//third_party/m4" as well as ones like
-// "@foo//:foo" into "@foo".
+// "//third_party/m4:m4" into "//third_party/m4".
 func fixLabels(f *File, w *Rewriter) {
 	joinLabel := func(p *Expr) {
 		add, ok := (*p).(*BinaryExpr)
@@ -288,8 +287,6 @@ func fixLabels(f *File, w *Rewriter) {
 		}
 		if m[4] != "" && m[4] == m[5] { // e.g. //foo:foo
 			str.Value = m[1]
-		} else if m[3] != "" && m[4] == "" && m[3] == m[5] { // e.g. @foo//:foo
-			str.Value = "@" + m[3]
 		}
 	}
 

--- a/build/testdata/019.build.golden
+++ b/build/testdata/019.build.golden
@@ -299,7 +299,7 @@ cc_library(
         "//a|zzz",
         "//a}zzz",
         "//a~zzz",
-        "@abc",
+        "@abc//:abc",
         "@abc//:xyz",
         "@abc//foo",
         "@zzz",


### PR DESCRIPTION
Fix incorrect rewrites of `@foo//:foo`.  Encountered when renaming `@com_google_re2//:re2` to `@re2//:re2`.

buildifier should leave these as-is since in `@re2//:re2`, the repository is `re2`, the package is the empty string, and the target is `re2`, and it is not correct to assume that repositories have stable names.

https://github.com/bazelbuild/buildtools/issues/1354