### PR TITLE
Revert "Keep targets like "@foo//:foo" formatted as-is."

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -217,7 +217,8 @@ func keepSorted(x Expr) bool {
 // "//x" + ":y" (usually split across multiple lines) into "//x:y".
 //
 // Second, it removes redundant target qualifiers, turning labels like
-// "//third_party/m4:m4" into "//third_party/m4".
+// "//third_party/m4:m4" into "//third_party/m4" as well as ones like
+// "@foo//:foo" into "@foo".
 func fixLabels(f *File, w *Rewriter) {
 	joinLabel := func(p *Expr) {
 		add, ok := (*p).(*BinaryExpr)
@@ -287,6 +288,8 @@ func fixLabels(f *File, w *Rewriter) {
 		}
 		if m[4] != "" && m[4] == m[5] { // e.g. //foo:foo
 			str.Value = m[1]
+		} else if m[3] != "" && m[4] == "" && m[3] == m[5] { // e.g. @foo//:foo
+			str.Value = "@" + m[3]
 		}
 	}
 

--- a/build/testdata/019.build.golden
+++ b/build/testdata/019.build.golden
@@ -299,7 +299,7 @@ cc_library(
         "//a|zzz",
         "//a}zzz",
         "//a~zzz",
-        "@abc//:abc",
+        "@abc",
         "@abc//:xyz",
         "@abc//foo",
         "@zzz",


### PR DESCRIPTION
Reverts bazelbuild/buildtools#1355

The label `@foo` is synonymous with the label `@foo//:foo`, and the label `@@bar` is synonymous with the label `@@bar//:bar`. Especially the former syntax is widely adopted in the community.