### PR TITLE
Bug fix. Correctly identify expressions using &=, ^=, >>=, and <<= as assignment statements when parsing BUILD files.

### DIFF
--- a/build/parse.y
+++ b/build/parse.y
@@ -1076,7 +1076,7 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 	ystart, _ := y.Span()
 
 	switch op {
-	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "|=":
+	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "&=", "|=", "^=", "<<=", ">>=":
 		return &AssignExpr{
 			LHS:       x,
 			OpPos:     pos,

--- a/build/parse.y.go
+++ b/build/parse.y.go
@@ -165,7 +165,7 @@ func binary(x Expr, pos Position, op string, y Expr) Expr {
 	ystart, _ := y.Span()
 
 	switch op {
-	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "|=":
+	case "=", "+=", "-=", "*=", "/=", "//=", "%=", "&=", "|=", "^=", "<<=", ">>=":
 		return &AssignExpr{
 			LHS:       x,
 			OpPos:     pos,

--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -352,7 +352,15 @@ foo != bar
 
 foo += bar
 bar -= bar
-
+bar *= bar
+bar /= bar
+bar //= bar
+bar %= bar
+bar &= bar
+bar |= bar
+bar ^= bar
+bar <<= bar
+bar >>= bar
 `,
 		[]string{":1:", ":3:", ":4:", ":5:", ":6:"},
 		scopeEverywhere)


### PR DESCRIPTION
Correctly identify expressions using &=, ^=, >>=, <<= as assignment statements when parsing BUILD files.

The Starlark grammar reference (https://github.com/bazelbuild/starlark/blob/master/spec.md#grammar-reference) identifies expressions using all of these as assignment statements, but the parser doesn't include them in the list, probably an old oversight.

This fixes issue #1330.