### PR TITLE
Adding function to execute Buildozer commands on a single in-memory file

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -350,6 +350,25 @@ Buildozer commands can be made executable by means of a shebang line, too:
 add deps //base //strings|-:foo|-:bar
 ```
 
+## Using Buildozer in-memory
+
+Some clients of Buildozer have the need to execute buildozer actions in memory
+(due to a service environment which does not have access to their file system).
+This can be done using, `edit.ExecuteCommandsOnInlineFile`, which accepts
+commands and BUILD file content as bytes, applies the changes and returns the
+raw file content.
+For more details and implementation, see [`/edit/buildozer.go`](../edit/buildozer.go)
+
+Some caveats of running Buildozer in-memory:
+
+* The function assumes (and validates to some extent) that all commands apply to
+  the same file and will return errors if there are commands affecting different
+  paths.
+* When referencing targets, the function will not reliably determine if targets
+  are local or remote. Hence redundant path references may be included in
+  output. (e.g. `add dep //package/path:bar|//package/path:foo` would add the dep
+  `//package/path:bar` instead of just `:bar`).
+
 ## Error code
 
 The return code is:

--- a/edit/buildozer_test.go
+++ b/edit/buildozer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package edit
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -24,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/buildtools/build"
+	"github.com/google/go-cmp/cmp"
 )
 
 var removeCommentTests = []struct {
@@ -695,6 +697,170 @@ func TestCmdSetSelect(t *testing.T) {
 			got := strings.TrimSpace(string(build.Format(bld)))
 			if got != tc.expected {
 				t.Errorf("cmdSetSelect(%d):\ngot:\n%s\nexpected:\n%s", i, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestExecuteCommandsOnInlineFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent []byte
+		commands    []string
+		wantOutput  []byte
+	}{
+		{
+			name:        "creating_new_target_and_adding_deps",
+			fileContent: nil,
+			commands: []string{
+				"new java_library foo|//package/path/BUILD",
+				"add deps :bar|//package/path:foo",
+			},
+			wantOutput: []byte(strings.Join([]string{
+				`java_library(`,
+				`    name = "foo",`,
+				`    deps = [":bar"],`,
+				`)`,
+				``}, "\n")),
+		},
+		{
+			name: "adding_deps_to_existing_targets",
+			fileContent: []byte(strings.Join([]string{
+				`java_library(`,
+				`    name = "foo",`,
+				`)`,
+				``,
+				`java_library(`,
+				`    name = "fruits",`,
+				`    deps = ["//package/fruits:apples"],`,
+				`)`,
+				``}, "\n")),
+			commands: []string{
+				"add deps :bar|//package/path:foo",
+				"add deps //package/fruits:oranges|//package/path:fruits",
+			},
+			wantOutput: []byte(strings.Join([]string{
+				`java_library(`,
+				`    name = "foo",`,
+				`    deps = [":bar"],`,
+				`)`,
+				``,
+				`java_library(`,
+				`    name = "fruits",`,
+				`    deps = [`,
+				`        "//package/fruits:apples",`,
+				`        "//package/fruits:oranges",`,
+				`    ],`,
+				`)`,
+				``}, "\n")),
+		},
+		{
+			name: "substituting_a_target",
+			fileContent: []byte(strings.Join([]string{
+				`java_library(`,
+				`    name = "fruits",`,
+				`    deps = ["//package/fruits:apples"],`,
+				`)`,
+				``}, "\n")),
+			commands: []string{
+				"replace deps //package/fruits:apples //package/fruits:oranges|//whatever/package/path:fruits",
+			},
+			wantOutput: []byte(strings.Join([]string{
+				`java_library(`,
+				`    name = "fruits",`,
+				`    deps = ["//package/fruits:oranges"],`,
+				`)`,
+				``}, "\n")),
+		},
+		{
+			name: "no_changes_does_not_return_any_diff",
+			fileContent: []byte(strings.Join([]string{
+				`java_library(`,
+				`    name = "foo",`,
+				`    deps = [":bar"],`,
+				`)`,
+				``}, "\n")),
+			commands: []string{
+				"add deps :bar |//whatever/package/path:foo",
+			},
+			wantOutput: []byte(strings.Join([]string{
+				`java_library(`,
+				`    name = "foo",`,
+				`    deps = [":bar"],`,
+				`)`,
+				``}, "\n")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := ExecuteCommandsOnInlineFile(tc.fileContent, tc.commands)
+			if err != nil {
+				t.Fatalf("Error, got error %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantOutput, output); diff != "" {
+				t.Errorf("%s: (-want +got): %s", tc.name, diff)
+			}
+		})
+	}
+}
+
+func TestTestExecuteCommandsOnInlineFileFailed(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent []byte
+		commands    []string
+		wantErr     error
+	}{
+		{
+			name: "target_does_not_exist",
+			commands: []string{
+				"add deps :foo|//package/path:bar",
+			},
+			wantErr: fmt.Errorf("rule 'bar' not found"),
+		},
+		{
+			name: "invalid_input",
+			commands: []string{
+				"completely invalid command",
+			},
+			wantErr: fmt.Errorf("rule 'completely invalid command' not found"),
+		},
+		{
+			name: "missing_implementation",
+			commands: []string{
+				"extrapolate packages :foo|//package/path:bar",
+			},
+			wantErr: fmt.Errorf("invalid input commands, expected all commands to reference a single file"),
+		},
+		{
+			name: "commands_for_multiple_files",
+			commands: []string{
+				"add deps :foo|//package/path:bar",
+				"add deps :foo|//package2/path:bar",
+			},
+			wantErr: fmt.Errorf("invalid input commands, expected all commands to reference a single file"),
+		},
+		{
+			name: "command_with_unexpected_target_semicolons",
+			commands: []string{
+				"add deps :foo|//package:path:bar",
+			},
+			wantErr: fmt.Errorf("invalid target name \"//package:path:bar\""),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, gotErr := ExecuteCommandsOnInlineFile(tc.fileContent, tc.commands)
+
+			if output != nil {
+				t.Fatalf("Error, got response for invalid input %v, expected error", output)
+			}
+
+			if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+				t.Errorf("%s: (-want +got): %s", tc.name, diff)
 			}
 		})
 	}


### PR DESCRIPTION
A buildozer client are looking to execute the commands of buildozer on the content of a build file, in a service environment (without direct access to the file storage). The new function enables this by running the commands without accessing the file system.