### PR TITLE
Allowing escaped colon character in dict operations

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -141,9 +141,11 @@ Buildozer supports the following commands(`'command args'`):
   * `copy_no_overwrite <attr> <from_rule>`:  Copies the value of `attr` between
     rules. If it exists in the `to_rule`, no action is taken.
   * `dict_add <attr> <(key:value)(s)>`:  Sets the value of a key for the dict
-    attribute `attr`. If the key was already present, it will _not_ be overwritten
+    attribute `attr`. If the key was already present, it will _not_ be overwritten.
+    Colon characters can be included in key and value escaped as "\:".
   * `dict_set <attr> <(key:value)(s)>`:  Sets the value of a key for the dict
     attribute `attr`. If the key was already present, its old value is replaced.
+    Colon characters can be included in key and value escaped as "\:".
   * `dict_remove <attr> <key(s)>`:  Deletes the key for the dict attribute `attr`.
   * `dict_replace_if_equal <attr> <key> <old_value> <new_value>`: Replaces
     `old_value` with `new_value` for key `key` in dictionary attribute `attr`.


### PR DESCRIPTION
- dict_add, dict_set and dict_remove can now be used with keys / values containing "\:" escaped colon characters
- updating existing pipe-escape functionality to reuse same operation