### PR TITLE
feat: add `windows_arm64` releases

### DIFF
--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -58,6 +58,16 @@ go_binary(
 )
 
 go_binary(
+    name = "buildifier-windows-arm64",
+    out = "buildifier-windows_arm64.exe",
+    embed = [":buildifier_lib"],
+    goarch = "arm64",
+    goos = "windows",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
     name = "buildifier-linux-riscv64",
     out = "buildifier-linux_riscv64",
     embed = [":buildifier_lib"],

--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -8,7 +8,7 @@ go_binary(
 )
 
 go_binary(
-    name = "buildifier-darwin",
+    name = "buildifier-darwin-amd64",
     out = "buildifier-darwin_amd64",
     embed = [":buildifier_lib"],
     goarch = "amd64",
@@ -18,7 +18,7 @@ go_binary(
 )
 
 go_binary(
-    name = "buildifier-linux",
+    name = "buildifier-linux-amd64",
     out = "buildifier-linux_amd64",
     embed = [":buildifier_lib"],
     goarch = "amd64",
@@ -28,7 +28,7 @@ go_binary(
 )
 
 go_binary(
-    name = "buildifier-windows",
+    name = "buildifier-windows-amd64",
     out = "buildifier-windows_amd64.exe",
     embed = [":buildifier_lib"],
     goarch = "amd64",

--- a/buildifier/npm/BUILD.bazel
+++ b/buildifier/npm/BUILD.bazel
@@ -27,6 +27,7 @@ _PARENT_PACKAGE_FILES = [
     "buildifier-linux_arm64",
     "buildifier-linux_riscv64",
     "buildifier-windows_amd64.exe",
+    "buildifier-windows_arm64.exe",
 ]
 
 [
@@ -35,7 +36,7 @@ _PARENT_PACKAGE_FILES = [
         # go_binary doesn't give a predeclared output for
         # the file in "out" so we have to construct a
         # label to reference the go_binary rule itself.
-        src = "//buildifier:%s" % s.replace("_arm64", "-arm64").replace("_riscv64", "-riscv64").split("_amd64")[0],
+        src = "//buildifier:%s" % s.replace(".exe", "").replace("_", "-"),
         out = s,
     )
     for s in _PARENT_PACKAGE_FILES

--- a/buildozer/BUILD.bazel
+++ b/buildozer/BUILD.bazel
@@ -88,6 +88,16 @@ go_binary(
 )
 
 go_binary(
+    name = "buildozer-windows-arm64",
+    out = "buildozer-windows_arm64.exe",
+    embed = [":buildozer_lib"],
+    goarch = "arm64",
+    goos = "windows",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
     name = "buildozer-linux-riscv64",
     out = "buildozer-linux_riscv64",
     embed = [":buildozer_lib"],

--- a/buildozer/BUILD.bazel
+++ b/buildozer/BUILD.bazel
@@ -38,7 +38,7 @@ sh_test(
 )
 
 go_binary(
-    name = "buildozer-darwin",
+    name = "buildozer-darwin-amd64",
     out = "buildozer-darwin_amd64",
     embed = [":buildozer_lib"],
     goarch = "amd64",
@@ -48,7 +48,7 @@ go_binary(
 )
 
 go_binary(
-    name = "buildozer-linux",
+    name = "buildozer-linux-amd64",
     out = "buildozer-linux_amd64",
     embed = [":buildozer_lib"],
     goarch = "amd64",
@@ -58,7 +58,7 @@ go_binary(
 )
 
 go_binary(
-    name = "buildozer-windows",
+    name = "buildozer-windows-amd64",
     out = "buildozer-windows_amd64.exe",
     embed = [":buildozer_lib"],
     goarch = "amd64",

--- a/buildozer/npm/BUILD.bazel
+++ b/buildozer/npm/BUILD.bazel
@@ -27,6 +27,7 @@ _PARENT_PACKAGE_FILES = [
     "buildozer-linux_arm64",
     "buildozer-linux_riscv64",
     "buildozer-windows_amd64.exe",
+    "buildozer-windows_arm64.exe",
 ]
 
 [
@@ -35,7 +36,7 @@ _PARENT_PACKAGE_FILES = [
         # go_binary doesn't give a predeclared output for
         # the file in "out" so we have to construct a
         # label to reference the go_binary rule itself.
-        src = "//buildozer:%s" % s.replace("_arm64", "-arm64").replace("_riscv64", "-riscv64").split("_amd64")[0],
+        src = "//buildozer:%s" % s.replace(".exe", "").replace("_", "-"),
         out = s,
     )
     for s in _PARENT_PACKAGE_FILES

--- a/launcher.js
+++ b/launcher.js
@@ -39,7 +39,7 @@ function getNativeBinary() {
     'win32' : '.exe',
   }[os.platform()];
 
-  if (arch == undefined || platform == undefined || (arch == 'arm64' && platform == 'windows')) {
+  if (arch == undefined || platform == undefined) {
     console.error(`FATAL: Your platform/architecture combination ${
         os.platform()} - ${os.arch()} is not yet supported.
     See instructions at https://github.com/bazelbuild/buildtools/blob/main/_TOOL_/README.md.`);

--- a/release/github.sh
+++ b/release/github.sh
@@ -29,6 +29,7 @@ for tool in "buildifier" "buildozer" "unused_deps"; do
   cp bazel-bin/"$tool/$tool-darwin_amd64" $BIN_DIR
   cp bazel-bin/"$tool/$tool-darwin_arm64" $BIN_DIR
   cp bazel-bin/"$tool/$tool-windows_amd64.exe" $BIN_DIR
+  cp bazel-bin/"$tool/$tool-windows_arm64.exe" $BIN_DIR
 done;
 
 echo "Creating a draft release"
@@ -51,6 +52,7 @@ for tool in "buildifier" "buildozer" "unused_deps"; do
   upload_file "$BIN_DIR/$tool-darwin_amd64" "$tool-darwin-amd64"
   upload_file "$BIN_DIR/$tool-darwin_arm64" "$tool-darwin-arm64"
   upload_file "$BIN_DIR/$tool-windows_amd64.exe" "$tool-windows-amd64.exe"
+  upload_file "$BIN_DIR/$tool-windows_arm64.exe" "$tool-windows-arm64.exe"
 done
 
 rm -rf $BIN_DIR

--- a/unused_deps/BUILD.bazel
+++ b/unused_deps/BUILD.bazel
@@ -80,6 +80,16 @@ go_binary(
 )
 
 go_binary(
+    name = "unused_deps-windows-arm64",
+    out = "unused_deps-windows_arm64.exe",
+    embed = [":unused_deps_lib"],
+    goarch = "arm64",
+    goos = "windows",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
     name = "unused_deps-linux-s390x",
     out = "unused_deps-linux_s390x",
     embed = [":unused_deps_lib"],

--- a/unused_deps/BUILD.bazel
+++ b/unused_deps/BUILD.bazel
@@ -30,7 +30,7 @@ go_binary(
 )
 
 go_binary(
-    name = "unused_deps-darwin",
+    name = "unused_deps-darwin-amd64",
     out = "unused_deps-darwin_amd64",
     embed = [":unused_deps_lib"],
     goarch = "amd64",
@@ -40,7 +40,7 @@ go_binary(
 )
 
 go_binary(
-    name = "unused_deps-linux",
+    name = "unused_deps-linux-amd64",
     out = "unused_deps-linux_amd64",
     embed = [":unused_deps_lib"],
     goarch = "amd64",
@@ -50,7 +50,7 @@ go_binary(
 )
 
 go_binary(
-    name = "unused_deps-windows",
+    name = "unused_deps-windows-amd64",
     out = "unused_deps-windows_amd64.exe",
     embed = [":unused_deps_lib"],
     goarch = "amd64",


### PR DESCRIPTION
## Add Windows ARM64 support for `buildtools`

This adds native Windows ARM64 binaries for `buildifier`, `buildozer`, and `unused_deps`.

### Changes

- Added `go_binary` rules for Windows ARM64 targets across all tools
- Updated release script to build and distribute Windows ARM64 binaries via GitHub releases and NPM packages
- Removed Windows ARM64 platform restriction in JavaScript launcher

> [!NOTE]
> For consistency, renamed AMD64 build targets to include architecture suffix (e.g., `buildifier-windows` → `buildifier-windows-amd64`). This is an internal build change and doesn't affect end users.

Closes #874 