### PR TITLE
Run buildifier against all MODULE.bazel -like files

### DIFF
--- a/buildifier/runner.bash.template
+++ b/buildifier/runner.bash.template
@@ -52,7 +52,8 @@ find . \
     -o -name '*.BUILD' \
     -o -name 'BUILD.*.bazel' \
     -o -name 'BUILD.*.oss' \
-    -o -name '*MODULE.bazel' \
+    -o -name MODULE.bazel \
+    -o -name '*.MODULE.bazel' \
     -o -name WORKSPACE \
     -o -name WORKSPACE.bazel \
     -o -name WORKSPACE.oss \


### PR DESCRIPTION
I noticed the included files in our MODULE.bazel were not being linted.

I tracked it to this runner.bash template.

https://bazel.build/rules/lib/globals/module#include