### PR TITLE
Bugfix false positive for "unused" variable for nested `def`s

### DIFF
--- a/warn/warn_control_flow_test.go
+++ b/warn/warn_control_flow_test.go
@@ -668,6 +668,27 @@ bar()
 			":9: Variable \"y\" is unused.",
 		},
 		scopeEverywhere)
+
+	checkFindings(t, "unused-variable", `
+def sample_macro_with_unused_foo(name, foo = "foo"):
+  def inner_def(foo = "bar"):
+    print(foo)
+
+  inner_def()
+
+def sample_macro_with_used_foo(name, foo = "foo"):
+  def inner_def(foo = foo):
+    print(foo)
+
+  inner_def()
+
+sample_macro_with_unused_foo()
+sample_macro_with_used_foo()
+`,
+		[]string{
+			":1: Variable \"foo\" is unused.",
+		},
+		scopeEverywhere)
 }
 
 func TestRedefinedVariable(t *testing.T) {


### PR DESCRIPTION
When detecting whether symbols are used or not, variables referenced as argument defaults of the inner def would count as "use" in the inner scope, and hence falsely trigger "unused" warning.

Example:

```
def outer_def(name, foo = "foo"):
    def inner_def(foo = foo):
        print(foo)  # buildifier: disable=print

    inner_def()
```

Unused variable check for the above function would
1. Check outer_def for variable usage
2. Recursively check inner_def for variable usage
  - Detect that `foo` is used
  - Omit `foo` from returned usedSymbolsFromOuterScope since `foo` is a local variable
3. Receive no "usedSymbol" for `foo`
4. Output "unused-variable" warning

If there are RHS idents in a def statement, these idents are always from an outer scope, so these can check the later inner-scope definedSymbols check.