### PR TITLE
buildifier: improve Windows runner performance

### DIFF
--- a/buildifier/runner.bat.template
+++ b/buildifier/runner.bat.template
@@ -27,6 +27,7 @@ $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -
         -or $_.Name -clike 'WORKSPACE.*.bazel' `^
         -or $_.Name -clike 'WORKSPACE.*.oss'^
     };^
+ ^<# Process files in batches of 100- to avoid exceeding CreateProcess' maximum length of 32,767 characters #^> ^
 $i = 0;^
 while ($i -lt $Files.Count)^
 {^


### PR DESCRIPTION
This change aims to improve the `buildidier`'s runner performance on Windows where it can sometimes take minutes to complete.

It consists in replacing the slow COM `Scripting.FileSystemObject` with a "native" PowerShell `Get-ChildItem -Recurse` for file discovery, and batch `buildifier` invocations (100 files at a time) instead of invoking once per file.

This improves performance on large codebases (like from about 2 minutes to less than 3 seconds).

Notes:
- cross-process COM calls add latency, whereas `Get-ChildItem` is a compiled "cmdlet",
- by default, `Get-ChildItem` doesn't recurse into symbolic links to directories, which is consistent with the current implementation that explicitly avoids entering `ReparsePoint`s,
- batching files passed to `buildifier` reduces process creation overhead, with a limit to account for Windows command line length limitations.