### PR TITLE
[unused_deps] Print information about arguments in help

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -317,11 +317,13 @@ func setupAspect() (string, error) {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `usage: unused_deps TARGET...
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), `usage: unused_deps TARGET...
 
 For Java rules in TARGETs, prints commands to delete deps unused at compile time.
 Note these may be used at run time; see documentation for more information.
+
 `)
+	flag.PrintDefaults()
 	os.Exit(2)
 }
 


### PR DESCRIPTION
This change updates help of unused_deps to show arguments:

```
$ unused_deps --help
usage: unused_deps TARGET...

For Java rules in TARGETs, prints commands to delete deps unused at compile time.
Note these may be used at run time; see documentation for more information.

  -build_tool string
    	the build executable (like bazel) (default "bazel")
  -cquery
    	Use 'cquery' command instead of 'query'
  -extra_action_file string
    	When specified, just prints suspected unused deps.
  -extra_build_flags string
    	Extra build flags to use when building the targets.
  -output_file string
    	used only with extra_action_file
  -version
    	Print the version of unused_deps
```

Previously it would not include information about arguments:

```
unused_deps --help
usage: unused_deps TARGET...

For Java rules in TARGETs, prints commands to delete deps unused at compile time.
Note these may be used at run time; see documentation for more information.
```

This change also changes usage to be printed to stdout when help is requested with `--help`. It's printed to stderr otherwise.