### PR TITLE
warn if there are non-fixable errors in `-lint=fix`

### DIFF
--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -129,10 +129,10 @@ func Lint(f *build.File, lint string, warningsList *[]string, verbose bool) []*w
 	fileReader := getFileReader(f.WorkspaceRoot)
 
 	switch lint {
-	case "warn":
-		return warn.FileWarnings(f, *warningsList, nil, warn.ModeWarn, fileReader)
+	case "off":
+		return nil
 	case "fix":
 		warn.FixWarnings(f, *warningsList, verbose, fileReader)
 	}
-	return nil
+	return warn.FileWarnings(f, *warningsList, nil, warn.ModeWarn, fileReader)
 }


### PR DESCRIPTION
Fixes #1418 by making `-lint=fix` still warn/exit nonzero on unfixable lints.