### PR TITLE
Move package() up when safe

### DIFF
--- a/edit/fix_test.go
+++ b/edit/fix_test.go
@@ -72,6 +72,74 @@ load(":path.bzl", "x")
 foo()`,
 			false,
 		},
+		{`"""Docstring."""
+
+# Some comment 1
+
+load(":path.bzl", "some_target")
+
+# Some comment 2
+
+package_group(name = "my_group")
+
+licenses(["my_license"])
+
+some_target(name = "foo")
+
+some_list = []
+
+[
+    some_target(name = "x")
+    for x in some_list
+]
+
+package(default_visibility = ["//visibility:public"])`,
+			`"""Docstring."""
+
+# Some comment 1
+
+load(":path.bzl", "some_target")
+
+# Some comment 2
+
+package_group(name = "my_group")
+
+licenses(["my_license"])
+
+package(default_visibility = ["//visibility:public"])
+
+some_target(name = "foo")
+
+some_list = []
+
+[
+    some_target(name = "x")
+    for x in some_list
+]
+`,
+			true},
+		{`VISIBILITY = ["//visibility:public"]
+
+foo()
+
+package(default_visibility = VISIBILITY)`,
+			`VISIBILITY = ["//visibility:public"]
+
+foo()
+
+package(default_visibility = VISIBILITY)`,
+			false},
+		{`VISIBILITY = "//visibility:public"
+
+foo()
+
+package(default_visibility = [VISIBILITY])`,
+			`VISIBILITY = "//visibility:public"
+
+foo()
+
+package(default_visibility = [VISIBILITY])`,
+			false},
 	}
 
 	for i, tst := range tests {

--- a/warn/warn_cosmetic_test.go
+++ b/warn/warn_cosmetic_test.go
@@ -126,19 +126,37 @@ irrelevant = baz
 
 foo()
 
-package()`,
+package(default_visibility = ["//visibility:public"])`,
 		`
 """This is a docstring"""
 
 load(":foo.bzl", "foo")
 load(":bar.bzl", baz = "bar")
 
+package(default_visibility = ["//visibility:public"])
 irrelevant = baz
 
-foo()
+foo()`,
+		[]string{":10: Package declaration should be at the top of the file, after the load() statements, but before any call to a rule or a macro. package_group() and licenses() may be called before package()."},
+		scopeDefault|scopeBzl|scopeBuild)
 
-package()`,
-		[]string{},
+	// Similar test case from issue #1420: package() after a list assignment
+	checkFindingsAndFix(t,
+		"package-on-top",
+		`package_group(name = "my_group")
+
+some_target(name = "foo")
+
+some_list = []
+
+package(default_visibility = ["//visibility:public"])`,
+		`package_group(name = "my_group")
+
+package(default_visibility = ["//visibility:public"])
+some_target(name = "foo")
+
+some_list = []`,
+		[]string{":7: Package declaration should be at the top of the file, after the load() statements, but before any call to a rule or a macro. package_group() and licenses() may be called before package()."},
 		scopeDefault|scopeBzl|scopeBuild)
 }
 


### PR DESCRIPTION
If there are assignments above package() calls they could contain
variables used in the package() call. We now check for that case so we
can move it as far up as possible.

Fixes https://github.com/bazelbuild/buildtools/issues/1420
