### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
-# Admins
+# Codeowners added as reviewers at PR creation time
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 * @bazelbuild/buildtools-team


### PR DESCRIPTION
Updates code owners to include the GitHub team as reviewers for new PRs instead of separate users