### PR TITLE
Creating GitHub Stale workflow to auto close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,8 +8,8 @@
 name: Close stale issues and pull requests
 
 # TODO: oreflow@ - Enable automated runs for this workflow.
-#on:
-#  workflow_dispatch:
+on:
+  workflow_dispatch:
 #  schedule:
 #  - cron: '0 1 * * *'
 


### PR DESCRIPTION
Config is based on https://github.com/bazelbuild/bazel/blob/master/.github/workflows/stale.yml, but leaves a number of TODOs to first test the workflow and then enable it to run automatically.