### PR TITLE
Updated to run properly under Bazel 9.

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -305,7 +305,7 @@ func setupAspect() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for _, f := range []string{"MODULE.bazel", "BUILD"} {
+	for _, f := range []string{"MODULE.bazel", "WORKSPACE", "BUILD"} {
 		if err := os.WriteFile(path.Join(tmp, f), []byte{}, 0666); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
With Bazel 9 (and with Bazel 8 when using the `--enable_workspace=false` flag), the file `MODULE.bazel` is used to mark the root directory for a project. Before this change, when calling `unused_deps` from a project using Bazel 9, an error occurs in the `bazel query` issued by `unused_deps` because bazel doesn't realize the external repository that `unused_deps` is writing is actually a repository.

This change ensures that the external repository created by the tool is a valid external repo for Bazel 9 and earlier.