### PR TITLE
suppressing canonical-repository warning

### DIFF
--- a/buildifier/internal/factory.bzl
+++ b/buildifier/internal/factory.bzl
@@ -168,6 +168,7 @@ def buildifier_impl_factory(ctx, test_rule = False):
             fail("Cannot use 'no_sandbox' without a 'workspace'")
         workspace = ctx.file.workspace.path
 
+    # buildifier: disable=canonical-repository
     substitutions = {
         "@@ARGS@@": shell.array_literal(args),
         "@@BUILDIFIER_SHORT_PATH@@": shell.quote(ctx.executable.buildifier.short_path),


### PR DESCRIPTION
Buildifier overflags in this file, producing canonical-repository warning:
`String contains "@@" which indicates a canonical repository name reference that should be avoided.`

