### PR TITLE
Allow callers to explicitly provide types for set and add commands

### DIFF
--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -86,8 +86,9 @@ See `buildozer -help` for the full list.
 
 Buildozer supports the following commands(`'command args'`):
 
-  * `add <attr> <value(s)>`: Adds value(s) to a list attribute of a rule. If a
-    value is already present in the list, it is not added.
+  * `add <attr>[:type] <value(s)>`: Adds value(s) to a list attribute of a rule.
+    If a value is already present in the list, it is not added. See
+   [supported types](#supported-types) for the available types.
   * `new_load <path> <[to=]from(s)>`: Add a load statement for the given path,
     importing the symbols. Afterwards, consider running `buildozer 'fix unusedLoads'`.
   * `replace_load <path> <[to=]from(s)>`: Similar to `new_load`, but removes
@@ -130,10 +131,12 @@ Buildozer supports the following commands(`'command args'`):
     be a simple replacement string, but it may also expand numbered or named
     groups using `$0` or `$x`. Lists without strings that match `old_regexp`
     are not modified.
-  * `set <attr> <value(s)>`: Sets the value of an attribute. If the attribute
-    was already present, its old value is replaced.
-  * `set_if_absent <attr> <value(s)>`: Sets the value of an attribute. If the
-    attribute was already present, no action is taken.
+  * `set <attr>[:<type>] <value(s)>`: Sets the value of an attribute. If the
+   attribute was already present, its old value is replaced. See
+    [supported types](#supported-types) for the available types.
+  * `set_if_absent <attr>[:<type>] <value(s)>`: Sets the value of an attribute. If the
+    attribute was already present, no action is taken. See
+    [supported types](#supported-types) for the available types.
   * `set kind <value>`: Set the target type to value.
   * `set_select <attr> <key_1> <value_1> <key_n> <value_n>`
   * `copy <attr> <from_rule>`: Copies the value of `attr` between rules. If it
@@ -187,6 +190,21 @@ The following commands only apply to `MODULE.bazel` files (e.g. the target
     *not* imported via `use_repo`. If the `dev` argument is given, extension
     usages with `dev_dependency = True` will be considered instead. Extension
     usages with `isolated = True` are ignored.
+
+#### Supported types
+
+For the commands that support explicitly providing argument types, the following
+types are available:
+
+  * `expr`: arbitrary expression, won't be quoted as a string unless already
+    quoted.
+  * `int`: reserved for integer values, but currently is equivalent to `expr`.
+  * `label`: a string containing a Bazel label, will be quoted and shortened if
+    necessary.
+  * `string`: a string value which will be quoted if necessary, but not treated
+    as a label (won't be transformed).
+  * `expr_list`, `int_list`, `label_list`, `string_list`: a list containing
+    variables of the types listed above. 
 
 #### Examples
 

--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -86,9 +86,10 @@ See `buildozer -help` for the full list.
 
 Buildozer supports the following commands(`'command args'`):
 
-  * `add <attr>[:type] <value(s)>`: Adds value(s) to a list attribute of a rule.
-    If a value is already present in the list, it is not added. See
-   [supported types](#supported-types) for the available types.
+  * `add <attr>[:<type>] <value(s)>`: Adds value(s) to a list attribute of a rule.
+    If a value is already present in the list, it is not added. `type` specifies
+    the type of values being added. See [supported types](#supported-types) for
+    the available types.
   * `new_load <path> <[to=]from(s)>`: Add a load statement for the given path,
     importing the symbols. Afterwards, consider running `buildozer 'fix unusedLoads'`.
   * `replace_load <path> <[to=]from(s)>`: Similar to `new_load`, but removes
@@ -132,11 +133,13 @@ Buildozer supports the following commands(`'command args'`):
     groups using `$0` or `$x`. Lists without strings that match `old_regexp`
     are not modified.
   * `set <attr>[:<type>] <value(s)>`: Sets the value of an attribute. If the
-   attribute was already present, its old value is replaced. See
+   attribute was already present, its old value is replaced. `type` specifies
+   the type of values being added. See
     [supported types](#supported-types) for the available types.
-  * `set_if_absent <attr>[:<type>] <value(s)>`: Sets the value of an attribute. If the
-    attribute was already present, no action is taken. See
-    [supported types](#supported-types) for the available types.
+  * `set_if_absent <attr>[:<type>] <value(s)>`: Sets the value of an attribute.
+    If the attribute was already present, no action is taken. `type` specifies
+    the type of values being added. See [supported types](#supported-types) for
+  * the available types.
   * `set kind <value>`: Set the target type to value.
   * `set_select <attr> <key_1> <value_1> <key_n> <value_n>`
   * `copy <attr> <from_rule>`: Copies the value of `attr` between rules. If it

--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -201,13 +201,6 @@ types are available:
 
   * `expr`: arbitrary expression, won't be quoted as a string unless already
     quoted.
-  * `int`: reserved for integer values, but currently is equivalent to `expr`.
-  * `label`: a string containing a Bazel label, will be quoted and shortened if
-    necessary.
-  * `string`: a string value which will be quoted if necessary, but not treated
-    as a label (won't be transformed).
-  * `expr_list`, `int_list`, `label_list`, `string_list`: a list containing
-    variables of the types listed above. 
 
 #### Examples
 

--- a/buildozer/README.md
+++ b/buildozer/README.md
@@ -200,7 +200,8 @@ For the commands that support explicitly providing argument types, the following
 types are available:
 
   * `expr`: arbitrary expression, won't be quoted as a string unless already
-    quoted.
+    quoted. Buildozer doesn't check that the expression is syntactically
+    correct, however the subsequent formatting step will fail if it's not.
 
 #### Examples
 
@@ -261,6 +262,9 @@ buildozer 'set_if_absent allowv1syntax 1' //pkg:%soy_js
 # Add an attribute new_attr with value "def_val" to all cc_binary rules
 # Note that special characters will automatically be escaped in the string
 buildozer 'add new_attr def_val' //:%cc_binary
+
+# Specifying an argument type to prevent automatic quoting
+buildozer 'add tags:expr FOO' //pkg:rule  # adds tags = [FOO]
 ```
 
 ### Print commands

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -224,6 +224,50 @@ function test_add_duplicate_label2() {
 )'
 }
 
+function test_add_override_ident() {
+  in='go_library(
+    name = "edit",
+    deps = ["build"],
+)'
+  run "$in" 'add deps:ident build' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        build,
+        "build",
+    ],
+)'
+}
+
+function test_add_override_ident2() {
+  in='go_library(
+    name = "edit",
+    deps = ["build"],
+)'
+  run "$in" 'add deps:raw_list build test()' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        build,
+        test(),
+        "build",
+    ],
+)'
+}
+
+function test_add_override_unknown_type() {
+  in='go_library(
+    name = "edit",
+    deps = ["build"],
+)'
+  ERROR=2 run "$in" 'add deps:foo build' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = ["build"],
+)'
+}
+
+
 function test_remove_last_dep() {
   run "$one_dep" 'remove deps //buildifier:build' '//pkg:edit'
   assert_equals 'go_library(name = "edit")'
@@ -1085,6 +1129,16 @@ function test_set_if_absent_present() {
 )'
 }
 
+function test_set_if_absent_override_string() {
+  in='soy_js(name = "a")'
+
+  run "$in" 'set_if_absent allowv1syntax:string 1' '//pkg:a'
+  assert_equals 'soy_js(
+    name = "a",
+    allowv1syntax = "1",
+)'
+}
+
 function test_set_custom_code() {
   in='cc_test(name = "a")'
 
@@ -1096,6 +1150,46 @@ function test_set_custom_code() {
         b = 2,
     ),
 )'
+}
+
+function test_set_override_string() {
+  in='cc_library(name = "a")'
+
+  run "$in" 'set copts:string foo' '//pkg:a'
+  assert_equals 'cc_library(
+    name = "a",
+    copts = "foo",
+)'
+}
+
+function test_set_override_ident() {
+  in='cc_library(name = "a")'
+
+  run "$in" 'set copts:ident foo' '//pkg:a'
+  assert_equals 'cc_library(
+    name = "a",
+    copts = foo,
+)'
+}
+
+function test_set_override_list_of_strings() {
+  in='cc_library(name = "a")'
+
+  run "$in" 'set name:list_of_strings b c' '//pkg:a'
+  assert_equals 'cc_library(name = [
+    "b",
+    "c",
+])'
+}
+
+function test_set_override_list_of_idents() {
+  in='cc_library(name = "a")'
+
+  run "$in" 'set name:list b c' '//pkg:a'
+  assert_equals 'cc_library(name = [
+    b,
+    c,
+])'
 }
 
 function assert_output() {

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -257,6 +257,69 @@ function test_add_override_expr_list() {
 )'
 }
 
+function test_add_override_string() {
+  in='go_library(
+    name = "edit",
+    deps = ["old"],
+)'
+  run "$in" 'add deps:string //pkg:new' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        "old",
+        "//pkg:new",
+    ],
+)'
+}
+
+function test_add_override_string_list() {
+  in='go_library(
+    name = "edit",
+    deps = ["build"],
+)'
+  run "$in" 'add deps:string_list //pkg:build test()' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        [
+            "//pkg:build",
+            "test()",
+        ],
+        "build",
+    ],
+)'
+}
+
+function test_add_override_label() {
+  in='go_library(
+    name = "edit",
+    deps = [":old"],
+)'
+  run "$in" 'add deps:label //pkg:new' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        ":new",
+        ":old",
+    ],
+)'
+}
+
+function test_add_override_label_list() {
+  in='go_library(
+    name = "edit",
+    deps = ["build"],
+)'
+  run "$in" 'add deps:label_list //pkg:build' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        [":build"],
+        "build",
+    ],
+)'
+}
+
 function test_add_override_unknown_type() {
   in='go_library(
     name = "edit",
@@ -1141,6 +1204,16 @@ function test_set_if_absent_override_string() {
 )'
 }
 
+function test_set_if_absent_override_label() {
+  in='soy_js(name = "a")'
+
+  run "$in" 'set_if_absent allowv1syntax:label //pkg:c' '//pkg:a'
+  assert_equals 'soy_js(
+    name = "a",
+    allowv1syntax = ":c",
+)'
+}
+
 function test_set_custom_code() {
   in='cc_test(name = "a")'
 
@@ -1157,10 +1230,20 @@ function test_set_custom_code() {
 function test_set_override_string() {
   in='cc_library(name = "a")'
 
-  run "$in" 'set copts:string foo' '//pkg:a'
+  run "$in" 'set copts:string //pkg:foo' '//pkg:a'
   assert_equals 'cc_library(
     name = "a",
-    copts = "foo",
+    copts = "//pkg:foo",
+)'
+}
+
+function test_set_override_label() {
+  in='cc_library(name = "a")'
+
+  run "$in" 'set copts:label //pkg:foo' '//pkg:a'
+  assert_equals 'cc_library(
+    name = "a",
+    copts = ":foo",
 )'
 }
 
@@ -1177,10 +1260,20 @@ function test_set_override_expr() {
 function test_set_override_string_list() {
   in='cc_library(name = "a")'
 
-  run "$in" 'set name:string_list b c' '//pkg:a'
+  run "$in" 'set name:string_list b //pkg:c' '//pkg:a'
   assert_equals 'cc_library(name = [
     "b",
-    "c",
+    "//pkg:c",
+])'
+}
+
+function test_set_override_label_list() {
+  in='cc_library(name = "a")'
+
+  run "$in" 'set name:label_list b //pkg:c' '//pkg:a'
+  assert_equals 'cc_library(name = [
+    "b",
+    ":c",
 ])'
 }
 

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -224,12 +224,12 @@ function test_add_duplicate_label2() {
 )'
 }
 
-function test_add_override_ident() {
+function test_add_override_expr() {
   in='go_library(
     name = "edit",
     deps = ["build"],
 )'
-  run "$in" 'add deps:ident build' '//pkg:edit'
+  run "$in" 'add deps:expr build' '//pkg:edit'
   assert_equals 'go_library(
     name = "edit",
     deps = [
@@ -239,17 +239,19 @@ function test_add_override_ident() {
 )'
 }
 
-function test_add_override_ident2() {
+function test_add_override_expr_list() {
   in='go_library(
     name = "edit",
     deps = ["build"],
 )'
-  run "$in" 'add deps:raw_list build test()' '//pkg:edit'
+  run "$in" 'add deps:expr_list build test()' '//pkg:edit'
   assert_equals 'go_library(
     name = "edit",
     deps = [
-        build,
-        test(),
+        [
+            build,
+            test(),
+        ],
         "build",
     ],
 )'
@@ -1162,33 +1164,33 @@ function test_set_override_string() {
 )'
 }
 
-function test_set_override_ident() {
+function test_set_override_expr() {
   in='cc_library(name = "a")'
 
-  run "$in" 'set copts:ident foo' '//pkg:a'
+  run "$in" 'set copts:expr foo()' '//pkg:a'
   assert_equals 'cc_library(
     name = "a",
-    copts = foo,
+    copts = foo(),
 )'
 }
 
-function test_set_override_list_of_strings() {
+function test_set_override_string_list() {
   in='cc_library(name = "a")'
 
-  run "$in" 'set name:list_of_strings b c' '//pkg:a'
+  run "$in" 'set name:string_list b c' '//pkg:a'
   assert_equals 'cc_library(name = [
     "b",
     "c",
 ])'
 }
 
-function test_set_override_list_of_idents() {
+function test_set_override_expr_list() {
   in='cc_library(name = "a")'
 
-  run "$in" 'set name:list b c' '//pkg:a'
+  run "$in" 'set name:expr_list b c()' '//pkg:a'
   assert_equals 'cc_library(name = [
     b,
-    c,
+    c(),
 ])'
 }
 

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1247,6 +1247,16 @@ function test_set_override_label() {
 )'
 }
 
+function test_set_override_label_2() {
+  in='cc_library(name = "a")'
+
+  run "$in" 'set copts:label foo' '//pkg:a'
+  assert_equals 'cc_library(
+    name = "a",
+    copts = "foo",
+)'
+}
+
 function test_set_override_expr() {
   in='cc_library(name = "a")'
 

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -239,87 +239,6 @@ function test_add_override_expr() {
 )'
 }
 
-function test_add_override_expr_list() {
-  in='go_library(
-    name = "edit",
-    deps = ["build"],
-)'
-  run "$in" 'add deps:expr_list build test()' '//pkg:edit'
-  assert_equals 'go_library(
-    name = "edit",
-    deps = [
-        [
-            build,
-            test(),
-        ],
-        "build",
-    ],
-)'
-}
-
-function test_add_override_string() {
-  in='go_library(
-    name = "edit",
-    deps = ["old"],
-)'
-  run "$in" 'add deps:string //pkg:new' '//pkg:edit'
-  assert_equals 'go_library(
-    name = "edit",
-    deps = [
-        "old",
-        "//pkg:new",
-    ],
-)'
-}
-
-function test_add_override_string_list() {
-  in='go_library(
-    name = "edit",
-    deps = ["build"],
-)'
-  run "$in" 'add deps:string_list //pkg:build test()' '//pkg:edit'
-  assert_equals 'go_library(
-    name = "edit",
-    deps = [
-        [
-            "//pkg:build",
-            "test()",
-        ],
-        "build",
-    ],
-)'
-}
-
-function test_add_override_label() {
-  in='go_library(
-    name = "edit",
-    deps = [":old"],
-)'
-  run "$in" 'add deps:label //pkg:new' '//pkg:edit'
-  assert_equals 'go_library(
-    name = "edit",
-    deps = [
-        ":new",
-        ":old",
-    ],
-)'
-}
-
-function test_add_override_label_list() {
-  in='go_library(
-    name = "edit",
-    deps = ["build"],
-)'
-  run "$in" 'add deps:label_list //pkg:build' '//pkg:edit'
-  assert_equals 'go_library(
-    name = "edit",
-    deps = [
-        [":build"],
-        "build",
-    ],
-)'
-}
-
 function test_add_override_unknown_type() {
   in='go_library(
     name = "edit",
@@ -1194,23 +1113,13 @@ function test_set_if_absent_present() {
 )'
 }
 
-function test_set_if_absent_override_string() {
+function test_set_if_absent_override_expr() {
   in='soy_js(name = "a")'
 
-  run "$in" 'set_if_absent allowv1syntax:string 1' '//pkg:a'
+  run "$in" 'set_if_absent copts:expr foo()' '//pkg:a'
   assert_equals 'soy_js(
     name = "a",
-    allowv1syntax = "1",
-)'
-}
-
-function test_set_if_absent_override_label() {
-  in='soy_js(name = "a")'
-
-  run "$in" 'set_if_absent allowv1syntax:label //pkg:c' '//pkg:a'
-  assert_equals 'soy_js(
-    name = "a",
-    allowv1syntax = ":c",
+    copts = foo(),
 )'
 }
 
@@ -1227,36 +1136,6 @@ function test_set_custom_code() {
 )'
 }
 
-function test_set_override_string() {
-  in='cc_library(name = "a")'
-
-  run "$in" 'set copts:string //pkg:foo' '//pkg:a'
-  assert_equals 'cc_library(
-    name = "a",
-    copts = "//pkg:foo",
-)'
-}
-
-function test_set_override_label() {
-  in='cc_library(name = "a")'
-
-  run "$in" 'set copts:label //pkg:foo' '//pkg:a'
-  assert_equals 'cc_library(
-    name = "a",
-    copts = ":foo",
-)'
-}
-
-function test_set_override_label_2() {
-  in='cc_library(name = "a")'
-
-  run "$in" 'set copts:label foo' '//pkg:a'
-  assert_equals 'cc_library(
-    name = "a",
-    copts = "foo",
-)'
-}
-
 function test_set_override_expr() {
   in='cc_library(name = "a")'
 
@@ -1265,36 +1144,6 @@ function test_set_override_expr() {
     name = "a",
     copts = foo(),
 )'
-}
-
-function test_set_override_string_list() {
-  in='cc_library(name = "a")'
-
-  run "$in" 'set name:string_list b //pkg:c' '//pkg:a'
-  assert_equals 'cc_library(name = [
-    "b",
-    "//pkg:c",
-])'
-}
-
-function test_set_override_label_list() {
-  in='cc_library(name = "a")'
-
-  run "$in" 'set name:label_list b //pkg:c' '//pkg:a'
-  assert_equals 'cc_library(name = [
-    "b",
-    ":c",
-])'
-}
-
-function test_set_override_expr_list() {
-  in='cc_library(name = "a")'
-
-  run "$in" 'set name:expr_list b c()' '//pkg:a'
-  assert_equals 'cc_library(name = [
-    b,
-    c(),
-])'
 }
 
 function assert_output() {

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -93,12 +93,16 @@ const (
 	// rawAttr is a type for idents, ints or other types that buildozer should
 	// take as is, without quoting or wrapping
 	rawAttr
-	// stringAttr is a type for strings (or labels)
+	// stringAttr is a type for strings
 	stringAttr
+	// labelAttr is similar to stringAttr but is automatically shortened if necessary
+	labelAttr
 	// rawListAttr is a type for lists of raw objects (same as rawAttr above)
 	rawListAttr
-	// stringListAttr is a type for lists of strings (or labels)
+	// stringListAttr is a type for lists of strings
 	stringListAttr
+	// labelListAttr is a type for lists of labels
+	labelListAttr
 )
 
 // parseAttr parses the attr name and optional type, e.g. "foo" or "bar:string"
@@ -113,12 +117,16 @@ func parseAttr(attrName string) (attr string, attrType AttrType, err error) {
 	switch typeName {
 	case "expr", "int":
 		return attr, rawAttr, nil
-	case "string", "label":
+	case "string":
 		return attr, stringAttr, nil
+	case "label":
+		return attr, labelAttr, nil
 	case "expr_list", "int_list":
 		return attr, rawListAttr, nil
-	case "string_list", "label_list":
+	case "string_list":
 		return attr, stringListAttr, nil
+	case "label_list":
+		return attr, labelListAttr, nil
 	default:
 		return attr, notProvidedTypeAttr, fmt.Errorf("unknown attr type: %q", typeName)
 	}
@@ -134,14 +142,23 @@ func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	if attrType == rawListAttr {
 		AddValueToListAttribute(env.Rule, attr, env.Pkg, getListExpr(env.Args[1:]...), &env.Vars)
 	} else if attrType == stringListAttr {
-		AddValueToListAttribute(env.Rule, attr, env.Pkg, getStringsListExpr(env.Pkg, env.Args[1:]...), &env.Vars)
+		AddValueToListAttribute(env.Rule, attr, env.Pkg, getStringsListExpr(env.Args[1:]...), &env.Vars)
+	} else if attrType == labelListAttr {
+		AddValueToListAttribute(env.Rule, attr, env.Pkg, getLabelsListExpr(env.Pkg, env.Args[1:]...), &env.Vars)
 	} else {
 		for _, val := range env.Args[1:] {
 			if attrType == rawAttr || (attrType == notProvidedTypeAttr && IsIntList(attr)) {
 				AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
 				continue
 			}
-			strVal := getStringExpr(val, env.Pkg)
+			var strVal build.Expr
+			if attrType == stringAttr {
+				strVal = getStringExpr(val)
+			} else {
+				// Fall back to the legacy behavior for backwards compatibility,
+				// which is to treat all unknown attributes as labels.
+				strVal = getLabelStringExpr(val, env.Pkg)
+			}
 			AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)
 		}
 
@@ -603,7 +620,7 @@ func cmdSubstitute(opts *Options, env CmdEnvironment) (*build.File, error) {
 			continue
 		}
 		if newValue, ok := stringSubstitute(e.Value, oldRegexp, newTemplate); ok {
-			env.Rule.SetAttr(key, getStringExpr(newValue, env.Pkg))
+			env.Rule.SetAttr(key, getLabelStringExpr(newValue, env.Pkg))
 		}
 	}
 	return env.File, nil
@@ -656,10 +673,17 @@ func getAttrValueExpr(attr string, attrType AttrType, args []string, env CmdEnvi
 		}
 		return &build.ListExpr{List: list}
 	case attrType == stringListAttr || (attrType == notProvidedTypeAttr && IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob("))):
-		// list of strings/labels
+		// list of strings
 		var list []build.Expr
 		for _, arg := range args {
-			list = append(list, getStringExpr(arg, env.Pkg))
+			list = append(list, getStringExpr(arg))
+		}
+		return &build.ListExpr{List: list}
+	case attrType == labelListAttr || (attrType == notProvidedTypeAttr && IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob("))):
+		// list of labels
+		var list []build.Expr
+		for _, arg := range args {
+			list = append(list, getLabelStringExpr(arg, env.Pkg))
 		}
 		return &build.ListExpr{List: list}
 	case attrType == rawListAttr:
@@ -672,9 +696,12 @@ func getAttrValueExpr(attr string, attrType AttrType, args []string, env CmdEnvi
 	case len(args) == 0:
 		// Expected a non-list argument, nothing provided
 		return &build.Ident{Name: "None"}
-	case attrType == stringAttr || (attrType == notProvidedTypeAttr && IsString(attr)):
+	case attrType == labelAttr || (attrType == notProvidedTypeAttr && IsString(attr)):
+		// single label
+		return getLabelStringExpr(args[0], env.Pkg)
+	case attrType == stringAttr:
 		// single string
-		return getStringExpr(args[0], env.Pkg)
+		return getStringExpr(args[0])
 	default:
 		return &build.Ident{Name: args[0]}
 	}
@@ -688,9 +715,17 @@ func getStringValue(value string) string {
 	return value
 }
 
-// getStringExpr creates a StringExpr from an input argument, which can be either quoted or not,
+// getStringExpr creates a StringExpr from an input argument, which can be either quoted or not.necessary
+func getStringExpr(value string) build.Expr {
+	if unquoted, triple, err := build.Unquote(value); err == nil {
+		return &build.StringExpr{Value: unquoted, TripleQuote: triple}
+	}
+	return &build.StringExpr{Value: value}
+}
+
+// getStringExprLabel creates a StringExpr from an input argument, which can be either quoted or not,
 // and shortens the label value if possible.
-func getStringExpr(value, pkg string) build.Expr {
+func getLabelStringExpr(value, pkg string) build.Expr {
 	if unquoted, triple, err := build.Unquote(value); err == nil {
 		return &build.StringExpr{Value: ShortenLabel(unquoted, pkg), TripleQuote: triple}
 	}
@@ -708,10 +743,20 @@ func getListExpr(exprs ...string) *build.ListExpr {
 
 // getStringsListExpr creates a ListExpr from a list of input arguments, each of which is ensured
 // to be a string (the labels are shortened if necessary).
-func getStringsListExpr(pkg string, exprs ...string) *build.ListExpr {
+func getStringsListExpr(exprs ...string) *build.ListExpr {
 	listVal := &build.ListExpr{}
 	for _, expr := range exprs {
-		listVal.List = append(listVal.List, getStringExpr(expr, pkg))
+		listVal.List = append(listVal.List, getStringExpr(expr))
+	}
+	return listVal
+}
+
+// getLabelsListExpr creates a ListExpr from a list of input arguments, each of which is ensured
+// to be a string (the labels are shortened if necessary).
+func getLabelsListExpr(pkg string, exprs ...string) *build.ListExpr {
+	listVal := &build.ListExpr{}
+	for _, expr := range exprs {
+		listVal.List = append(listVal.List, getLabelStringExpr(expr, pkg))
 	}
 	return listVal
 }
@@ -751,7 +796,7 @@ func cmdDictAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 			return nil, fmt.Errorf("no colon in dict_add argument %q found", x)
 		}
 		kv = removeEscapes(kv, ':')
-		expr := getStringExpr(kv[1], env.Pkg)
+		expr := getLabelStringExpr(kv[1], env.Pkg)
 
 		prev := DictionaryGet(dict, kv[0])
 		if prev == nil {
@@ -781,10 +826,10 @@ func cmdSetSelect(opts *Options, env CmdEnvironment) (*build.File, error) {
 			if cur := DictionaryGet(dict, key); cur != nil {
 				list = cur.(*build.ListExpr)
 			}
-			AddValueToList(list, env.Pkg, getStringExpr(value, env.Pkg), !attributeMustNotBeSorted(env.Rule.Name(), attr))
+			AddValueToList(list, env.Pkg, getLabelStringExpr(value, env.Pkg), !attributeMustNotBeSorted(env.Rule.Name(), attr))
 			expr = list
 		} else {
-			expr = getStringExpr(value, env.Pkg)
+			expr = getLabelStringExpr(value, env.Pkg)
 		}
 		// Set overwrites previous values.
 		DictionarySet(dict, key, expr)
@@ -812,7 +857,7 @@ func cmdDictSet(opts *Options, env CmdEnvironment) (*build.File, error) {
 			return nil, fmt.Errorf("no colon in dict_set argument %q found", x)
 		}
 		kv = removeEscapes(kv, ':')
-		expr := getStringExpr(kv[1], env.Pkg)
+		expr := getLabelStringExpr(kv[1], env.Pkg)
 		// Set overwrites previous values.
 		DictionarySet(dict, kv[0], expr)
 	}
@@ -870,11 +915,11 @@ func cmdDictReplaceIfEqual(opts *Options, env CmdEnvironment) (*build.File, erro
 			// Key-Value Pair matches key.
 			if val, ok := kv.Value.(*build.StringExpr); ok {
 				if labels.Equal(val.Value, oldV, env.Pkg) {
-					kv.Value = getStringExpr(newV, env.Pkg)
+					kv.Value = getLabelStringExpr(newV, env.Pkg)
 				}
 			} else if val, ok := kv.Value.(*build.Ident); ok {
 				if val.Name == oldV {
-					kv.Value = getStringExpr(newV, env.Pkg)
+					kv.Value = getLabelStringExpr(newV, env.Pkg)
 				}
 			}
 		}
@@ -900,7 +945,7 @@ func cmdDictListAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	}
 
 	for _, val := range args {
-		expr := getStringExpr(val, env.Pkg)
+		expr := getLabelStringExpr(val, env.Pkg)
 		prev = AddValueToList(prev, env.Pkg, expr, true)
 	}
 

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -102,6 +102,8 @@ const (
 )
 
 // parseAttr parses the attr name and optional type, e.g. "foo" or "bar:string"
+// The type names are taken from https://bazel.build/rules/lib/toplevel/attr
+// when possible
 func parseAttr(attrName string) (attr string, attrType AttrType, err error) {
 	chunks := strings.SplitN(attrName, ":", 2)
 	if len(chunks) == 1 {
@@ -109,13 +111,13 @@ func parseAttr(attrName string) (attr string, attrType AttrType, err error) {
 	}
 	attr, typeName := chunks[0], chunks[1]
 	switch typeName {
-	case "int", "raw", "ident":
+	case "expr", "int":
 		return attr, rawAttr, nil
 	case "string", "label":
 		return attr, stringAttr, nil
-	case "list", "raw_list":
+	case "expr_list", "int_list":
 		return attr, rawListAttr, nil
-	case "list_of_strings", "list_of_labels":
+	case "string_list", "label_list":
 		return attr, stringListAttr, nil
 	default:
 		return attr, notProvidedTypeAttr, fmt.Errorf("unknown attr type: %q", typeName)
@@ -129,14 +131,22 @@ func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, val := range env.Args[1:] {
-		if attrType == rawAttr || attrType == rawListAttr || (attrType == notProvidedTypeAttr && IsIntList(attr)) {
-			AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
-			continue
+	if attrType == rawListAttr {
+		AddValueToListAttribute(env.Rule, attr, env.Pkg, getListExpr(env.Args[1:]...), &env.Vars)
+	} else if attrType == stringListAttr {
+		AddValueToListAttribute(env.Rule, attr, env.Pkg, getStringsListExpr(env.Pkg, env.Args[1:]...), &env.Vars)
+	} else {
+		for _, val := range env.Args[1:] {
+			if attrType == rawAttr || (attrType == notProvidedTypeAttr && IsIntList(attr)) {
+				AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
+				continue
+			}
+			strVal := getStringExpr(val, env.Pkg)
+			AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)
 		}
-		strVal := getStringExpr(val, env.Pkg)
-		AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)
+
 	}
+
 	ResolveAttr(env.Rule, attr, env.Pkg)
 	return env.File, nil
 }
@@ -685,6 +695,25 @@ func getStringExpr(value, pkg string) build.Expr {
 		return &build.StringExpr{Value: ShortenLabel(unquoted, pkg), TripleQuote: triple}
 	}
 	return &build.StringExpr{Value: ShortenLabel(value, pkg)}
+}
+
+// getListExpr creates a ListExpr from a list of input arguments
+func getListExpr(exprs ...string) *build.ListExpr {
+	listVal := &build.ListExpr{}
+	for _, expr := range exprs {
+		listVal.List = append(listVal.List, &build.Ident{Name: expr})
+	}
+	return listVal
+}
+
+// getStringsListExpr creates a ListExpr from a list of input arguments, each of which is ensured
+// to be a string (the labels are shortened if necessary).
+func getStringsListExpr(pkg string, exprs ...string) *build.ListExpr {
+	listVal := &build.ListExpr{}
+	for _, expr := range exprs {
+		listVal.List = append(listVal.List, getStringExpr(expr, pkg))
+	}
+	return listVal
 }
 
 func cmdCopy(opts *Options, env CmdEnvironment) (*build.File, error) {

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -93,16 +93,6 @@ const (
 	// rawAttr is a type for idents, ints or other types that buildozer should
 	// take as is, without quoting or wrapping
 	rawAttr
-	// stringAttr is a type for strings
-	stringAttr
-	// labelAttr is similar to stringAttr but is automatically shortened if necessary
-	labelAttr
-	// rawListAttr is a type for lists of raw objects (same as rawAttr above)
-	rawListAttr
-	// stringListAttr is a type for lists of strings
-	stringListAttr
-	// labelListAttr is a type for lists of labels
-	labelListAttr
 )
 
 // parseAttr parses the attr name and optional type, e.g. "foo" or "bar:string"
@@ -115,18 +105,8 @@ func parseAttr(attrName string) (attr string, attrType AttrType, err error) {
 	}
 	attr, typeName := chunks[0], chunks[1]
 	switch typeName {
-	case "expr", "int":
+	case "expr":
 		return attr, rawAttr, nil
-	case "string":
-		return attr, stringAttr, nil
-	case "label":
-		return attr, labelAttr, nil
-	case "expr_list", "int_list":
-		return attr, rawListAttr, nil
-	case "string_list":
-		return attr, stringListAttr, nil
-	case "label_list":
-		return attr, labelListAttr, nil
 	default:
 		return attr, notProvidedTypeAttr, fmt.Errorf("unknown attr type: %q", typeName)
 	}
@@ -139,29 +119,14 @@ func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	if attrType == rawListAttr {
-		AddValueToListAttribute(env.Rule, attr, env.Pkg, getListExpr(env.Args[1:]...), &env.Vars)
-	} else if attrType == stringListAttr {
-		AddValueToListAttribute(env.Rule, attr, env.Pkg, getStringsListExpr(env.Args[1:]...), &env.Vars)
-	} else if attrType == labelListAttr {
-		AddValueToListAttribute(env.Rule, attr, env.Pkg, getLabelsListExpr(env.Pkg, env.Args[1:]...), &env.Vars)
-	} else {
-		for _, val := range env.Args[1:] {
-			if attrType == rawAttr || (attrType == notProvidedTypeAttr && IsIntList(attr)) {
-				AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
-				continue
-			}
-			var strVal build.Expr
-			if attrType == stringAttr {
-				strVal = getStringExpr(val)
-			} else {
-				// Fall back to the legacy behavior for backwards compatibility,
-				// which is to treat all unknown attributes as labels.
-				strVal = getLabelStringExpr(val, env.Pkg)
-			}
-			AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)
+	for _, val := range env.Args[1:] {
+		if attrType == rawAttr || (attrType == notProvidedTypeAttr && IsIntList(attr)) {
+			AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
+			continue
 		}
-
+		var strVal build.Expr
+		strVal = getLabelStringExpr(val, env.Pkg)
+		AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)
 	}
 
 	ResolveAttr(env.Rule, attr, env.Pkg)
@@ -665,43 +630,26 @@ func getAttrValueExpr(attr string, attrType AttrType, args []string, env CmdEnvi
 		// formatted properly by the subsequent call of buildifier on the
 		//resulting file)
 		return &build.Ident{Name: args[0]}
-	case attrType == rawListAttr || (attrType == notProvidedTypeAttr && IsIntList(attr)):
+	case IsIntList(attr):
 		// list of raw objects (e.g. ints or idents)
 		var list []build.Expr
 		for _, i := range args {
 			list = append(list, &build.LiteralExpr{Token: i})
 		}
 		return &build.ListExpr{List: list}
-	case attrType == stringListAttr || (attrType == notProvidedTypeAttr && IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob("))):
-		// list of strings
-		var list []build.Expr
-		for _, arg := range args {
-			list = append(list, getStringExpr(arg))
-		}
-		return &build.ListExpr{List: list}
-	case attrType == labelListAttr || (attrType == notProvidedTypeAttr && IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob("))):
+	case IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")):
 		// list of labels
 		var list []build.Expr
 		for _, arg := range args {
 			list = append(list, getLabelStringExpr(arg, env.Pkg))
 		}
 		return &build.ListExpr{List: list}
-	case attrType == rawListAttr:
-		// list of arbitrary objects (idents, ints, already quoted strings, etc.)
-		var list []build.Expr
-		for _, arg := range args {
-			list = append(list, &build.Ident{Name: arg})
-		}
-		return &build.ListExpr{List: list}
 	case len(args) == 0:
 		// Expected a non-list argument, nothing provided
 		return &build.Ident{Name: "None"}
-	case attrType == labelAttr || (attrType == notProvidedTypeAttr && IsString(attr)):
+	case IsString(attr):
 		// single label
 		return getLabelStringExpr(args[0], env.Pkg)
-	case attrType == stringAttr:
-		// single string
-		return getStringExpr(args[0])
 	default:
 		return &build.Ident{Name: args[0]}
 	}
@@ -713,14 +661,6 @@ func getStringValue(value string) string {
 		return unquoted
 	}
 	return value
-}
-
-// getStringExpr creates a StringExpr from an input argument, which can be either quoted or not.necessary
-func getStringExpr(value string) build.Expr {
-	if unquoted, triple, err := build.Unquote(value); err == nil {
-		return &build.StringExpr{Value: unquoted, TripleQuote: triple}
-	}
-	return &build.StringExpr{Value: value}
 }
 
 // getStringExprLabel creates a StringExpr from an input argument, which can be either quoted or not,
@@ -737,26 +677,6 @@ func getListExpr(exprs ...string) *build.ListExpr {
 	listVal := &build.ListExpr{}
 	for _, expr := range exprs {
 		listVal.List = append(listVal.List, &build.Ident{Name: expr})
-	}
-	return listVal
-}
-
-// getStringsListExpr creates a ListExpr from a list of input arguments, each of which is ensured
-// to be a string (the labels are shortened if necessary).
-func getStringsListExpr(exprs ...string) *build.ListExpr {
-	listVal := &build.ListExpr{}
-	for _, expr := range exprs {
-		listVal.List = append(listVal.List, getStringExpr(expr))
-	}
-	return listVal
-}
-
-// getLabelsListExpr creates a ListExpr from a list of input arguments, each of which is ensured
-// to be a string (the labels are shortened if necessary).
-func getLabelsListExpr(pkg string, exprs ...string) *build.ListExpr {
-	listVal := &build.ListExpr{}
-	for _, expr := range exprs {
-		listVal.List = append(listVal.List, getLabelStringExpr(expr, pkg))
 	}
 	return listVal
 }

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -83,7 +83,8 @@ type CmdEnvironment struct {
 	output *apipb.Output_Record         // output proto, stores whatever a command wants to print
 }
 
-// AttrType is an enum representing a type of the attribute, e.g. int, string, list of strings, etc
+// AttrType is an enum representing a type of the attribute, e.g. expr or not
+// provided type
 type AttrType int
 
 const (
@@ -95,9 +96,8 @@ const (
 	rawAttr
 )
 
-// parseAttr parses the attr name and optional type, e.g. "foo" or "bar:string"
-// The type names are taken from https://bazel.build/rules/lib/toplevel/attr
-// when possible
+// parseAttr parses the attr name and optional type, e.g. "foo" or "bar:expr"
+// The only supported type now is `expr`
 func parseAttr(attrName string) (attr string, attrType AttrType, err error) {
 	chunks := strings.SplitN(attrName, ":", 2)
 	if len(chunks) == 1 {


### PR DESCRIPTION
Buildozer tries to guess the format of an attribute's value before adding it to the file, sometimes it does it incorrectly. This PR provides a way to explicitly set a type of the attribute. Currently it's only supported for the `set`, `set_if_absent` and `add` commands, but can be extended further for other commands as well (likely will also be required for `dict_set` and `dict_add`).

The syntax is backward-compatible with the old command usages:

    set name bar  # sets name = "bar"
    set name:expr FOO  # sets name = FOO

The only supported type for now is `expr` for arbitrary expressions.

Attribute names can't contain colons, hence no previosly existing calls should be affected by the change. It should also be straightforward for the callers because resembles the syntax for type hints in Python (and Starlark).