### PR TITLE
Catch more file patterns

### DIFF
--- a/buildifier/runner.bash.template
+++ b/buildifier/runner.bash.template
@@ -47,17 +47,14 @@ find . \
   @@EXCLUDE_PATTERNS@@ \
   \( -name '*.bzl' \
     -o -name '*.sky' \
-    -o -name BUILD.bazel \
+    -o -name '*.star' \
+    -o -name '*.bazel' \
     -o -name BUILD \
     -o -name '*.BUILD' \
-    -o -name 'BUILD.*.bazel' \
+    -o -name BUILD.oss \
     -o -name 'BUILD.*.oss' \
-    -o -name MODULE.bazel \
-    -o -name '*.MODULE.bazel' \
     -o -name WORKSPACE \
-    -o -name WORKSPACE.bazel \
     -o -name WORKSPACE.oss \
     -o -name WORKSPACE.bzlmod \
-    -o -name 'WORKSPACE.*.bazel' \
     -o -name 'WORKSPACE.*.oss' \
   \) -print | xargs "$buildifier_short_path" "${ARGS[@]}"

--- a/buildifier/runner.bat.template
+++ b/buildifier/runner.bat.template
@@ -14,17 +14,17 @@ for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" MANIFEST') do (set b
 powershell ^
 $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -File -ErrorAction SilentlyContinue ^|^
     Where-Object {^
-        $_.Name -eq 'BUILD.bazel' `^
-        -or $_.Name -eq 'BUILD' `^
+        $_.Name -eq 'BUILD' `^
         -or $_.Name -eq 'WORKSPACE' `^
-        -or $_.Name -eq 'WORKSPACE.bazel' `^
         -or $_.Name -eq 'WORKSPACE.oss' `^
-        -or $_.Name  -clike '*.bzl' `^
+        -or $_.Name -eq 'WORKSPACE.bzlmod' `^
+        -or $_.Name -eq 'BUILD.oss' `^
+        -or $_.Name -clike '*.bazel' `^
+        -or $_.Name -clike '*.bzl' `^
         -or $_.Name -clike '*.sky' `^
+        -or $_.Name -clike '*.star' `^
         -or $_.Name -clike '*.BUILD' `^
-        -or $_.Name -clike 'BUILD.*.bazel' `^
         -or $_.Name -clike 'BUILD.*.oss' `^
-        -or $_.Name -clike 'WORKSPACE.*.bazel' `^
         -or $_.Name -clike 'WORKSPACE.*.oss'^
     };^
  ^<# Process files in batches of 100- to avoid exceeding CreateProcess' maximum length of 32,767 characters #^> ^

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -30,18 +30,16 @@ import (
 func isStarlarkFile(name string) bool {
 	ext := filepath.Ext(name)
 	switch ext {
-	case ".bzl", ".sky", ".star":
+	case ".bazel", ".BUILD", ".bzl", ".sky", ".star":
 		return true
 	}
 
 	switch ext {
-	case ".bazel", ".oss":
-		// BUILD.bazel or BUILD.foo.bazel should be treated as Starlark files, same for WORSKSPACE and MODULE
-		// MODULE files flip the order: [prefix.]MODULE.bazel
-		return strings.HasPrefix(name, "BUILD.") || strings.HasPrefix(name, "WORKSPACE.") || strings.HasSuffix(name, "MODULE.bazel")
+	case ".oss":
+		return strings.HasPrefix(name, "BUILD.") || strings.HasPrefix(name, "WORKSPACE.")
 	}
 
-	return name == "BUILD" || name == "WORKSPACE"
+	return name == "BUILD" || name == "WORKSPACE" || name == "WORKSPACE.bzlmod"
 }
 
 func skip(info os.FileInfo) bool {

--- a/buildifier/utils/utils_test.go
+++ b/buildifier/utils/utils_test.go
@@ -47,7 +47,15 @@ func TestIsStarlarkFile(t *testing.T) {
 		},
 		{
 			filename: "build.foo.bazel",
-			ok:       false,
+			ok:       true,
+		},
+		{
+			filename: "foo.BUILD.bazel",
+			ok:       true,
+		},
+		{
+			filename: "foo.BUILD",
+			ok:       true,
 		},
 		{
 			filename: "build.foo.oss",
@@ -79,7 +87,7 @@ func TestIsStarlarkFile(t *testing.T) {
 		},
 		{
 			filename: "workspace.foo.bazel",
-			ok:       false,
+			ok:       true,
 		},
 		{
 			filename: "workspace.foo.oss",
@@ -140,6 +148,14 @@ func TestIsStarlarkFile(t *testing.T) {
 		{
 			filename: "MODULE.bazel.other",
 			ok:       false,
+		},
+		{
+			filename: "foo.bazel",
+			ok:       true,
+		},
+		{
+			filename: "REPO.bazel",
+			ok:       true,
 		},
 	}
 


### PR DESCRIPTION
Previously `buildifier -r .` would not pick up `foo.BUILD.bazel` files
or `foo.BUILD` files even though the `runner.bash.template` would. This
attempts to unify these.
