### PR TITLE
Fix spelling of 'Github' to 'GitHub' in PR template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ frustration later on.
 
 ### Code reviews
 All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
+use GitHub pull requests for this purpose.
 
 ### The small print
 Contributions made by corporations are covered by a different agreement than


### PR DESCRIPTION
## Buildtools PR checklist

- [ ] The code in this PR is covered by unit/integration tests.
- [ ] I have tested these changes and provide testing instructions below.
- [ ] I have either responded to, or resolved all Gemini comments on the PR.
- [x] I have read Google Eng Practices on [Small Changes](https://google.github.io/eng-practices/review/developer/small-cls.html), this PR either follows these guidelines or the description provides reasoning for why they can not be followed.

## Description

That's all; just fixing the "Github" typo in the PR template doc.