### PR TITLE
Allow to disable multiple warnings on one line

### DIFF
--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -127,6 +127,20 @@ if debug:
     print("Debug information:", foo)  # buildifier: disable=print
 ```
 
+To disable multiple warnings, you can specify them as a comma-separated list on
+a single line:
+
+```python
+# buildifier: disable=warning1,warning2
+```
+
+Or place them on separate lines:
+
+```python
+# buildifier: disable=warning1
+# buildifier: disable=warning2
+```
+
 --------------------------------------------------------------------------------
 
 ## <a name="allowed-symbol-load-locations"></a>Symbol must be loaded from a specific location

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -113,6 +113,19 @@ All warnings can be disabled / suppressed / ignored by adding a special comment 
 the expression that causes the warning. Historically comments with `buildozer` instead of
 `buildifier` are also supported, they are equivalent.
 
+To disable multiple warnings, you can specify them as a comma-separated list on a single line:
+
+```python
+# buildifier: disable=warning1,warning2
+```
+
+Or place them on separate lines:
+
+```python
+# buildifier: disable=warning1
+# buildifier: disable=warning2
+```
+
 #### Examples
 
 ```python
@@ -125,20 +138,6 @@ Docstrings don't trigger the warning if they are first statements of a file or a
 
 if debug:
     print("Debug information:", foo)  # buildifier: disable=print
-```
-
-To disable multiple warnings, you can specify them as a comma-separated list on
-a single line:
-
-```python
-# buildifier: disable=warning1,warning2
-```
-
-Or place them on separate lines:
-
-```python
-# buildifier: disable=warning1
-# buildifier: disable=warning2
 ```
 
 --------------------------------------------------------------------------------

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -557,7 +557,7 @@ func ContainsComments(expr build.Expr, str string) bool {
 
 // ContainsDisableComment checks whether the expr has a comment that disables
 // a warning, including when multiple warnings are disabled on the same line.
-func ContainsDisableComments(expr build.Expr, warning string) bool {
+func ContainsDisableComment(expr build.Expr, warning string) bool {
 	warning = strings.ToLower(warning)
 	com := expr.Comment()
 	comments := append(com.Before, com.Suffix...)
@@ -569,7 +569,7 @@ func ContainsDisableComments(expr build.Expr, warning string) bool {
 				return true
 			}
 		}
-    }
+	}
 	return false
 }
 

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -524,6 +524,23 @@ func hasComments(literal *build.StringExpr) bool {
 	return len(literal.Before) > 0 || len(literal.Suffix) > 0
 }
 
+// commentDisables checks whether token contains prefix + ": disable=" followed by,
+// at some positition, target.
+func commentDisables(token string, prefix string, target string) bool {
+	search := prefix + ": disable="
+	for {
+		idx := strings.Index(token, search)
+		if idx < 0 {
+			return false
+		}
+		rest := token[idx+len(search):]
+		if strings.Contains(rest, target) {
+			return true
+		}
+		token = rest
+	}
+}
+
 // ContainsComments returns whether the expr has a comment that includes str.
 func ContainsComments(expr build.Expr, str string) bool {
 	str = strings.ToLower(str)
@@ -532,6 +549,23 @@ func ContainsComments(expr build.Expr, str string) bool {
 	comments = append(comments, com.After...)
 	for _, c := range comments {
 		if strings.Contains(strings.ToLower(c.Token), str) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsDisableComment checks whether the expr has a comment that disables warning
+// under the given tool prefix (such as "buildifier" or "buildozer"),
+// including when multiple warnings are disabled on the same line.
+func ContainsDisableComment(expr build.Expr, tool string, warning string) bool {
+	tool = strings.ToLower(tool)
+	warning = strings.ToLower(warning)
+	com := expr.Comment()
+	comments := append(com.Before, com.Suffix...)
+	comments = append(comments, com.After...)
+	for _, c := range comments {
+		if commentDisables(strings.ToLower(c.Token), tool, warning) {
 			return true
 		}
 	}

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -555,20 +555,21 @@ func ContainsComments(expr build.Expr, str string) bool {
 	return false
 }
 
-// ContainsDisableComment checks whether the expr has a comment that disables warning
-// under the given tool prefix (such as "buildifier" or "buildozer"),
-// including when multiple warnings are disabled on the same line.
-func ContainsDisableComment(expr build.Expr, tool string, warning string) bool {
-	tool = strings.ToLower(tool)
+// ContainsDisableComment checks whether the expr has a comment that disables
+// a warning, including when multiple warnings are disabled on the same line.
+func ContainsDisableComments(expr build.Expr, warning string) bool {
 	warning = strings.ToLower(warning)
 	com := expr.Comment()
 	comments := append(com.Before, com.Suffix...)
 	comments = append(comments, com.After...)
-	for _, c := range comments {
-		if commentDisables(strings.ToLower(c.Token), tool, warning) {
-			return true
+	tools := []string{"buildifier", "buildozer"}
+	for _, tool := range tools {
+		for _, c := range comments {
+			if commentDisables(strings.ToLower(c.Token), tool, warning) {
+				return true
+			}
 		}
-	}
+    }
 	return false
 }
 

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -865,3 +865,35 @@ a = my_macro(
 		})
 	}
 }
+
+func TestContainsDisableComment(t *testing.T) {
+	testCases := []struct {
+		comment string
+		prefix  string
+		warning string
+		want    bool
+	}{
+		{"# buildifier: disable=warning1", "buildifier", "warning1", true},
+		{"# buildifier: disable=warning1", "buildifier", "warning2", false},
+		{"# buildifier: disable=warning1,warning2", "buildifier", "warning1", true},
+		{"# buildifier: disable=warning1,warning2", "buildifier", "warning2", true},
+		{"# buildifier: disable=warning1,warning2", "buildifier", "warning3", false},
+		{"# buildifier: disable=warning1, warning2", "buildifier", "warning2", true},
+		{"# buildifier: disable=warning1,warning2 (explanation)", "buildifier", "warning1", true},
+		{"# buildifier: disable=warn", "buildifier", "warning1", false},
+		{"# buildifier: disable=warning1", "buildifier", "warn", true},
+		{"# buildozer: disable=warning1,warning2", "buildozer", "warning2", true},
+		{"# buildozer: disable=warning1,warning2", "buildifier", "warning2", false},
+	}
+
+	for i, tc := range testCases {
+		expr := &build.Ident{
+			Comments: build.Comments{
+				Before: []build.Comment{{Token: tc.comment}},
+			},
+		}
+		if got := ContainsDisableComment(expr, tc.prefix, tc.warning); got != tc.want {
+			t.Errorf("case %d: ContainsDisableComment(%q, %q, %q) = %v, want %v", i, tc.comment, tc.prefix, tc.warning, got, tc.want)
+		}
+	}
+}

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -882,6 +882,7 @@ func TestContainsDisableComment(t *testing.T) {
 		{"# buildifier: disable=warning1,warning2 (explanation)", "buildifier", "warning1", true},
 		{"# buildifier: disable=warn", "buildifier", "warning1", false},
 		{"# buildifier: disable=warning1", "buildifier", "warn", true},
+		{"# buildifier: disable=warning1,warning2 (warning3)", "buildifier", "warning3", true},
 		{"# buildozer: disable=warning1,warning2", "buildozer", "warning2", true},
 		{"# buildozer: disable=warning1,warning2", "buildifier", "warning2", false},
 	}

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -869,22 +869,21 @@ a = my_macro(
 func TestContainsDisableComment(t *testing.T) {
 	testCases := []struct {
 		comment string
-		prefix  string
 		warning string
 		want    bool
 	}{
-		{"# buildifier: disable=warning1", "buildifier", "warning1", true},
-		{"# buildifier: disable=warning1", "buildifier", "warning2", false},
-		{"# buildifier: disable=warning1,warning2", "buildifier", "warning1", true},
-		{"# buildifier: disable=warning1,warning2", "buildifier", "warning2", true},
-		{"# buildifier: disable=warning1,warning2", "buildifier", "warning3", false},
-		{"# buildifier: disable=warning1, warning2", "buildifier", "warning2", true},
-		{"# buildifier: disable=warning1,warning2 (explanation)", "buildifier", "warning1", true},
-		{"# buildifier: disable=warn", "buildifier", "warning1", false},
-		{"# buildifier: disable=warning1", "buildifier", "warn", true},
-		{"# buildifier: disable=warning1,warning2 (warning3)", "buildifier", "warning3", true},
-		{"# buildozer: disable=warning1,warning2", "buildozer", "warning2", true},
-		{"# buildozer: disable=warning1,warning2", "buildifier", "warning2", false},
+		{"# buildifier: disable=warning1", "warning1", true},
+		{"# buildifier: disable=warning1", "warning2", false},
+		{"# buildifier: disable=warning1,warning2", "warning1", true},
+		{"# buildifier: disable=warning1,warning2", "warning2", true},
+		{"# buildifier: disable=warning1,warning2", "warning3", false},
+		{"# buildifier: disable=warning1, warning2", "warning2", true},
+		{"# buildifier: disable=warning1,warning2 (explanation)", "warning1", true},
+		{"# buildifier: disable=warn", "warning1", false},
+		{"# buildifier: disable=warning1", "warn", true},
+		{"# buildifier: disable=warning1,warning2 (warning3)", "warning3", true},
+		{"# buildozer: disable=warning1,warning2", "warning2", true},
+		{"# othertool: disable=warning1,warning2", "warning2", false},
 	}
 
 	for i, tc := range testCases {
@@ -893,8 +892,8 @@ func TestContainsDisableComment(t *testing.T) {
 				Before: []build.Comment{{Token: tc.comment}},
 			},
 		}
-		if got := ContainsDisableComment(expr, tc.prefix, tc.warning); got != tc.want {
-			t.Errorf("case %d: ContainsDisableComment(%q, %q, %q) = %v, want %v", i, tc.comment, tc.prefix, tc.warning, got, tc.want)
+		if got := ContainsDisableComment(expr, tc.warning); got != tc.want {
+			t.Errorf("case %d: ContainsDisableComment(%q, %q) = %v, want %v", i, tc.comment, tc.warning, got, tc.want)
 		}
 	}
 }

--- a/warn/docs/docs.go
+++ b/warn/docs/docs.go
@@ -91,6 +91,19 @@ All warnings can be disabled / suppressed / ignored by adding a special comment 
 the expression that causes the warning. Historically comments with ` + "`" + `buildozer` + "`" + ` instead of
 ` + "`" + `buildifier` + "`" + ` are also supported, they are equivalent.
 
+To disable multiple warnings, you can specify them as a comma-separated list on a single line:
+
+` + "```" + `python
+# buildifier: disable=warning1,warning2
+` + "```" + `
+
+Or place them on separate lines:
+
+` + "```" + `python
+# buildifier: disable=warning1
+# buildifier: disable=warning2
+` + "```" + `
+
 #### Examples
 
 ` + "```" + `python

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -312,8 +312,7 @@ func runWarningsFunction(category string, f *build.File, fct func(f *build.File,
 
 // HasDisablingComment checks if a node has a comment that disables a certain warning
 func HasDisablingComment(expr build.Expr, warning string) bool {
-	return edit.ContainsDisableComment(expr, "buildifier", warning) ||
-		edit.ContainsDisableComment(expr, "buildozer", warning)
+	return edit.ContainsDisableComment(expr, warning)
 }
 
 // DisabledWarning checks if the warning was disabled by a comment.

--- a/warn/warn.go
+++ b/warn/warn.go
@@ -312,8 +312,8 @@ func runWarningsFunction(category string, f *build.File, fct func(f *build.File,
 
 // HasDisablingComment checks if a node has a comment that disables a certain warning
 func HasDisablingComment(expr build.Expr, warning string) bool {
-	return edit.ContainsComments(expr, "buildifier: disable="+warning) ||
-		edit.ContainsComments(expr, "buildozer: disable="+warning)
+	return edit.ContainsDisableComment(expr, "buildifier", warning) ||
+		edit.ContainsDisableComment(expr, "buildozer", warning)
 }
 
 // DisabledWarning checks if the warning was disabled by a comment.

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -420,3 +420,59 @@ cc_library(
 		}
 	}
 }
+
+func TestDisabledWarningMultiple(t *testing.T) {
+	contents := `foo()
+
+# buildifier: disable=depset-iteration,print
+for x in depset([1, 2, 3]):
+    print(x)
+
+# buildozer: disable=string-iteration, no-effect (with explanation)
+for y in "foobar":
+    y
+`
+	f, err := build.ParseBzl("file.bzl", []byte(contents))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	tests := []struct {
+		start    int
+		end      int
+		category string
+	}{
+		{
+			start:    3,
+			end:      5,
+			category: "depset-iteration",
+		},
+		{
+			start:    3,
+			end:      5,
+			category: "print",
+		},
+		{
+			start:    7,
+			end:      9,
+			category: "string-iteration",
+		},
+		{
+			start:    7,
+			end:      9,
+			category: "no-effect",
+		},
+	}
+
+	linesCount := strings.Count(contents, "\n")
+
+	for _, tc := range tests {
+		for line := 1; line <= linesCount; line++ {
+			disabled := DisabledWarning(f, line, tc.category)
+			shouldBeDisabled := line >= tc.start && line <= tc.end
+			if disabled != shouldBeDisabled {
+				t.Errorf("Wrong disabled status for category %q at line %d: want %t, got %t", tc.category, line, shouldBeDisabled, disabled)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This allows to disable more than one warning per "disable" comment. So, instead of writing

```python
# buildifier: disable=warning1
# buildifier: disable=warning2
```

you can now write

```python
# buildifier: disable=warning1,warning2
```